### PR TITLE
minor: discrepancy in hellofly demo

### DIFF
--- a/hands-on/connecting-to-an-app.html.md
+++ b/hands-on/connecting-to-an-app.html.md
@@ -9,7 +9,7 @@ toc: false
 The quickest way to connect to your deployed app is with the `flyctl open` command. This will open a browser on the http version of the site. That will automatically be upgraded to a https secured connection (when using the fly.dev domain) to connect to it securely. Add `/name` to `flyctl open` and it'll be appended to the apps path and you'll get an extra greeting from the hellofly application.
 
 ```cmd
-flyctl open /to/fred
+flyctl open /fred
 ```
 ```out
 Opening http://hellofly.fly.dev/fred


### PR DESCRIPTION
I was going through the hands-on demo and noticed that `flyctl open /to/fred` actually opened my browser to a 404 page instead of what's shown in the screen shot.  The issue seems to be that the demo container doesn't actually support the `/to/:token` route, only `/:token` seems to work.  

Note that in addition my change below the screen shot also needs to be updated as well (I have a bunch of pinned tabs in my Safari so can't reproduce the image without closing them all), it seems like the app deployed at `hellofly` also expects just `/:token`.