### PR TITLE
Move copying of config later to avoid full dependency and asset recom…

### DIFF
--- a/getting-started/elixir.html.md
+++ b/getting-started/elixir.html.md
@@ -244,7 +244,6 @@ ENV SECRET_KEY_BASE=nokey
 # Copy over the mix.exs and mix.lock files to load the dependencies. If those
 # files don't change, then we don't keep re-fetching and rebuilding the deps.
 COPY mix.exs mix.lock ./
-COPY config config
 
 RUN mix deps.get --only prod && \
     mix deps.compile
@@ -269,6 +268,7 @@ RUN mix phx.digest
 COPY lib lib
 
 # compile and build release
+COPY config config
 COPY rel rel
 RUN mix do compile, release
 


### PR DESCRIPTION
…pilation

Following the current example, I noticed that every time I update runtime.exs or any other files in the config directory it leads to full recompilation of all dependencies. On a large project, it's a long step. So I recommend moving it down a bit so that we only use it when we do the actual compilation.