### PR TITLE
Move the getting started guide intros into a shared partial

### DIFF
--- a/getting-started/deno.html.md.erb
+++ b/getting-started/deno.html.md.erb
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-Getting an application running on Fly essentially involves working out how to package it as a deployable image. Once packaged it can be deployed to the Fly infrastructure to run on the global application platform. For this _Getting Started_ article, we'll look at building a [Deno](https://deno.land) application from scratch.
+<%= partial "partials/intro", locals: { runtime: "[Deno](https://deno.land)" } %>
 
 ## _The Hellodeno Application_
 
@@ -49,13 +49,13 @@ There's nothing else to run. Deno will manage getting packages for itself.
 Run `deno run --allow-net main.ts` to start the application:
 
 ```cmd
-deno run --allow-net main.ts      
+deno run --allow-net main.ts
 ```
 ```output
 listening on http://0.0.0.0:8080/
 ```
 
-And connect to localhost:8080 to confirm that you have a working Deno application by receiving a greeting. Now to package it up for Fly. There are a number of ways to do this. You can use flyctl's own simple builder, 
+And connect to localhost:8080 to confirm that you have a working Deno application by receiving a greeting. Now to package it up for Fly. There are a number of ways to do this. You can use flyctl's own simple builder,
 
 ## _Install Flyctl and Login_
 
@@ -66,7 +66,7 @@ We are ready to start working with Fly and that means we need `flyctl`, our CLI 
 Each Fly application needs a `fly.toml` file to tell the system how we'd like to deploy it. That file can be automatically generated with the command `flyctl init` command. To build this simmple deno app, we'll use the builtin deno builder.
 
 ```cmd
-flyctl init 
+flyctl init
 ```
 ```output
 
@@ -131,7 +131,7 @@ The `flyctl` command will always refer to this file in the current directory if 
 
 Next is then the `build` section which records which builder we would like to use to build and deploy this app. Here we are using the builtin builder for deno.
 
-The rest of the file contains settings to be applied to the application when it deploys. 
+The rest of the file contains settings to be applied to the application when it deploys.
 
 We'll have more details about these properties as we progress, but for now, it's enough to say that they mostly configure which ports the application will be visible on. The assumption the builder makes is that your application is talking on port 8080.
 
@@ -143,7 +143,7 @@ We are now ready to deploy our containerized app to the Fly platform. At the com
 flyctl deploy
 ```
 
-This will lookup our `fly.toml` file and get the app name `hellodeno` from there. Flyctl will then call on the builtin builder to build the application image, complete with the deno runtime. 
+This will lookup our `fly.toml` file and get the app name `hellodeno` from there. Flyctl will then call on the builtin builder to build the application image, complete with the deno runtime.
 
 Then `flyctl` will start the process of deploying our application to the Fly platform. Flyctl will return you to the command line when it's done.
 

--- a/getting-started/elixir.html.md.erb
+++ b/getting-started/elixir.html.md.erb
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-Getting an application running on Fly is essentially working out how to package it as a deployable image and attach it to a database. Once packaged it can be deployed to the Fly infrastructure to run on the global application platform. For this _Getting Started_ article, we'll look at building an Elixir Phoenix application from scratch and connecting it to a PostgreSQL database.
+<%= partial "partials/intro", locals: { runtime: "Elixir Phoenix", database: true } %>
 
 ## _The HelloElixir Application_
 

--- a/getting-started/golang.html.md.erb
+++ b/getting-started/golang.html.md.erb
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-In this _Getting Started_ article, we look at how to deploy a Go application on Fly. 
+<%= partial "partials/intro", locals: { runtime: "Go" } %>
 
 ## _The Example Application_
 
@@ -48,7 +48,7 @@ func main() {
 }
 ```
 
-The `main` function starts a server that responds with a html page showing the fly region that served the request. The template lives in `./templates/` and is embedded into the binary using the [`embed`](https://golang.org/pkg/embed/) package in go 1.16+. 
+The `main` function starts a server that responds with a html page showing the fly region that served the request. The template lives in `./templates/` and is embedded into the binary using the [`embed`](https://golang.org/pkg/embed/) package in go 1.16+.
 
 The template itself, `index.html.tmpl`, is very simple too:
 
@@ -138,7 +138,7 @@ app = "hellofly"
     timeout = 2000
 ```
 
-The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name value at the start. That name will be used to identify the application to the Fly service. The rest of the file contains settings to be applied to the application when it deploys. 
+The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name value at the start. That name will be used to identify the application to the Fly service. The rest of the file contains settings to be applied to the application when it deploys.
 
 You can see in the `[build]` section the builder image and the list of buildpacks that will be used to build the app for deployment. You can also add build arguments to configure the build process using the `[build.args]` section.
 
@@ -182,11 +182,11 @@ ID       VERSION REGION DESIRED STATUS  HEALTH CHECKS      RESTARTS CREATED
 $
 ```
 
-As you can see, the application has been with a DNS hostname of hellofly.fly.dev, and an instance is running in Frankfurt. Your deployment's name will, of course, be different. 
+As you can see, the application has been with a DNS hostname of hellofly.fly.dev, and an instance is running in Frankfurt. Your deployment's name will, of course, be different.
 
 ## _Connecting to the App_
 
-The quickest way to connect to your deployed app is with the `flyctl open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain). 
+The quickest way to connect to your deployed app is with the `flyctl open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain).
 
 
  to connect to it securely. Add `/name` to `flyctl open` and it'll be appended to the URL as the path and you'll get an extra greeting from the hellofly application.

--- a/getting-started/node.html.md.erb
+++ b/getting-started/node.html.md.erb
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-Getting an application running on Fly is essentially working out how to package it as a deployable image. Once packaged it can be deployed to the Fly infrastructure to run on the global application platform. For this _Getting Started_ article, we'll look at building a Node application from scratch.
+<%= partial "partials/intro", locals: { runtime: "Node" } %>
 
 ## _The Hellonode Application_
 
@@ -31,14 +31,14 @@ app.get(["/", "/:name"], (req, res) => {
 app.listen(port, () => console.log(`HelloNode app listening on port ${port}!`));
 ```
 
-We'll call this file `server.js` and run `npm init` and `npm install express --save` so we've got the basic node setup. 
+We'll call this file `server.js` and run `npm init` and `npm install express --save` so we've got the basic node setup.
 
 ## _Running The Application_
 
 Run `node server.js` to start the application
 
 ```cmd
-node server.js          
+node server.js
 ```
 ```output
 HelloNode app listening on port 3000!
@@ -77,9 +77,9 @@ First, this command scans your source code to determine how to build a deploymen
 
 After your source code is scanned and the results are printed, you'll be prompted for an organization. Organizations are a way of sharing applications and resources between Fly users. Every fly account has a personal organization, called `personal`, which is only visible to your account. Let's select that for this guide.
 
-Next, you'll be prompted to select a region to deploy in. The closest region to you is selected by default. You can use this or change to another region. 
+Next, you'll be prompted to select a region to deploy in. The closest region to you is selected by default. You can use this or change to another region.
 
-At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. You'll then be prompted to build and deploy your app. Once complete, your app will be running on fly. 
+At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. You'll then be prompted to build and deploy your app. Once complete, your app will be running on fly.
 
 ## _Inside `fly.toml`_
 
@@ -113,7 +113,7 @@ app = "hellonode"
     timeout = 2000
 ```
 
-The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name/value at the start. That name will be used to identify the application to the Fly platform. The rest of the file contains settings to be applied to the application when it deploys. 
+The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name/value at the start. That name will be used to identify the application to the Fly platform. The rest of the file contains settings to be applied to the application when it deploys.
 
 We'll have more details about these properties as we progress, but for now, it's enough to say that they mostly configure which ports the application will be visible on.
 

--- a/getting-started/partials/_intro.html.md.erb
+++ b/getting-started/partials/_intro.html.md.erb
@@ -1,0 +1,6 @@
+Getting an application running on Fly is essentially working out how to package it as a deployable image<%- if defined?(database) %> and attach it to a database<%- end %>.
+Once packaged it can be deployed to the Fly infrastructure to run on the global application platform.
+
+For this _Getting Started_ article, we'll look at deploying <%= "#{runtime.downcase.start_with?(/[aeiou]/) ? "an" : "a"} #{runtime}" %>
+<%= defined?(type) ? type : "application" %>
+on Fly<%- if defined?(database) %> and connecting it to a PostgreSQL database<%- end %>.

--- a/getting-started/python.html.md.erb
+++ b/getting-started/python.html.md.erb
@@ -4,9 +4,8 @@ layout: docs
 sitemap: false
 nav: firecracker
 ---
-# Python-hellofly-flask
 
-In our Hands-On section, we show how to deploy a deployable image file using Flyctl. Now we are going to deploy an application from source. In this _Getting Started_ article, we look at how to deploy a Python application on Fly. 
+<%= partial "partials/intro", locals: { runtime: "Python" } %>
 
 ## _The Hellofly-python Application_
 
@@ -154,7 +153,7 @@ kill_timeout = 5
     timeout = 2000
 ```
 
-The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name/value at the start. That name will be used to identify the application to the Fly service. The rest of the file contains settings to be applied to the application when it deploys. 
+The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name/value at the start. That name will be used to identify the application to the Fly service. The rest of the file contains settings to be applied to the application when it deploys.
 
 We'll have more details about these properties as we progress, but for now, it's enough to say that they mostly configure which ports the application will be visible on.
 
@@ -195,11 +194,11 @@ ID       VERSION REGION DESIRED STATUS  HEALTH CHECKS      RESTARTS CREATED
 0530d622 0       lhr    run     running 1 total, 1 passing 0        40s ago
 ```
 
-As you can see, the application has been with a DNS hostname of `hellofly-python.fly.dev`, and an instance is running in London. Your deployment's name will, of course, be different. 
+As you can see, the application has been with a DNS hostname of `hellofly-python.fly.dev`, and an instance is running in London. Your deployment's name will, of course, be different.
 
 ## _Connecting to the App_
 
-The quickest way to connect to your deployed app is with the `flyctl open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain). 
+The quickest way to connect to your deployed app is with the `flyctl open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain).
 
 
  to connect to it securely. Add `/name` to `flyctl open` and it'll be appended to the URL as the path and you'll get an extra greeting from the hellofly-python application.

--- a/getting-started/ruby.html.md.erb
+++ b/getting-started/ruby.html.md.erb
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-Getting an application running on Fly is essentially working out how to package it as a deployable image. Once packaged it can be deployed to the Fly infrastructure to run on the global application platform. For this _Getting Started_ article, we'll look at building a Ruby application from scratch.
+<%= partial "partials/intro", locals: { runtime: "Ruby" } %>
 
 ## _The Helloruby Application_
 
@@ -87,9 +87,9 @@ First, this command scans your source code to determine how to build a deploymen
 
 After your source code is scanned and the results are printed, you'll be prompted for an organization. Organizations are a way of sharing application and resources between Fly users. Every fly account has a personal organization, called `personal`, which is only visible to your account. Let's select that for this guide.
 
-Next, you'll be prompted to select a region to deploy in. The closest region to you is selected by default. You can use this or change to another region. 
+Next, you'll be prompted to select a region to deploy in. The closest region to you is selected by default. You can use this or change to another region.
 
-At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. You'll then be prompted to build and deploy your app. Once complete, your app will be running on fly. 
+At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. You'll then be prompted to build and deploy your app. Once complete, your app will be running on fly.
 
 ## _Inside `fly.toml`_
 
@@ -123,7 +123,7 @@ app = "helloruby"
     timeout = 2000
 ```
 
-The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name/value at the start. That name will be used to identify the application to the Fly platform. The rest of the file contains settings to be applied to the application when it deploys. 
+The `flyctl` command will always refer to this file in the current directory if it exists, specifically for the `app` name/value at the start. That name will be used to identify the application to the Fly platform. The rest of the file contains settings to be applied to the application when it deploys.
 
 We'll have more details about these properties as we progress, but for now, it's enough to say that they mostly configure which ports the application will be visible on.
 

--- a/getting-started/static.html.md.erb
+++ b/getting-started/static.html.md.erb
@@ -5,9 +5,8 @@ sitemap: false
 nav: firecracker
 ---
 
-Getting something running on Fly is basically working out how to package it as a deployable executable image. Once that is done it can be deployed to the Fly infrastructure and run on the global application platform. 
+<%= partial "partials/intro", locals: { runtime: "static", type: "site" } %>
 
-For this _Getting Started_ article, we'll look at creating a static web site from scratch, including the web server, and deploying it on Fly.
 
 ## _The HelloStatic Site_
 


### PR DESCRIPTION
This PR unifies the slightly different language across the Getting Started guides. The partial logic may be overengineered but works as a starting point.