### PR TITLE
incorrect command in docs : flyctl postgres databases list

### DIFF
--- a/reference/postgres.html.md
+++ b/reference/postgres.html.md
@@ -139,7 +139,7 @@ One Postgres cluster can host multiple databases
 You can view a list of databases with from `flyctl`:
 
 ```bash
-flyctl postgres databases list 
+flyctl postgres list 
 ```
 
 ## Connection Examples


### PR DESCRIPTION
Updated to `flyctl postgres list` which seems to be the command (this is what I needed in any case).

Perhaps `flyctl postgres db list` is what some people are looking for though.