### PR TITLE
Remove obselete references to flyctl init

### DIFF
--- a/flyctl/cmd/flyctl.md
+++ b/flyctl/cmd/flyctl.md
@@ -10,7 +10,6 @@ It allows users to manage authentication, application initialization,
 deployment, network configuration, logging and more with just the 
 one command.
 
-Initialize an app with the init command
 Deploy an app with the deploy command
 View a deployed web application with the open command
 Check the status of an application with the status command

--- a/partials/_flyctl_nav.html.slim
+++ b/partials/_flyctl_nav.html.slim
@@ -55,9 +55,6 @@ dl
     = nav_link "/docs/flyctl/info/", class: "flex ai:baseline jc:between text:inherit sm:text:persist sm:m:8p pt:7p" do
       | View App information
       span class="text:code leading:xs ml:8p pt:2p pb:3p" info
-    = nav_link "/docs/flyctl/init/", class: "flex ai:baseline jc:between text:inherit sm:text:persist sm:m:8p pt:7p" do
-      | Initialize a new App
-      span class="text:code leading:xs ml:8p pt:2p pb:3p" init      
     = nav_link "/docs/flyctl/ips/", class: "flex ai:baseline jc:between text:inherit sm:text:persist sm:m:8p pt:7p" do
       | Managing IP addresses
       span class="text:code leading:xs ml:8p pt:2p pb:3p" ips


### PR DESCRIPTION
11b9d5e removed the flyctl init command from the docs, but there are some stray references to it in the docs, one of which creates a dead link.