### PR TITLE
Hands-on link wrong

### DIFF
--- a/signup-welcome.html.md
+++ b/signup-welcome.html.md
@@ -15,7 +15,7 @@ Welcome to Fly! You've just successfully signed up and you're ready to get going
 
 * If you are new here, the [Introduction](/docs/introduction/) will give you some background. 
 * If you know your way around Docker and similar tools, you can dive into the [Speedrun](/docs/speedrun/) - essential instructions to get you on Fly. 
-* If you want a more step-based approach to learning check out our [Hands-on](/docs/hands-on/).
+* If you want a more step-based approach to learning check out our [Hands-on](/docs/hands-on/start/).
 
 ## _More Fly_
 


### PR DESCRIPTION
Also mentioned here: https://community.fly.io/t/http-404-forbidden-error-from-signup-welcome-page/2881