### PR TITLE
Fixes typo in Ruby guide

### DIFF
--- a/getting-started/ruby.html.md.erb
+++ b/getting-started/ruby.html.md.erb
@@ -100,7 +100,7 @@ app = "helloruby"
 
 [build]
   builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/ruby]
+  buildpacks = ["gcr.io/paketo-buildpacks/ruby"]
 
 [[services]]
   internal_port = 8080


### PR DESCRIPTION
The Ruby guide contained an example `fly.toml` in which the `build.buildpacks` key contained a string which was missing the closing `¨`.
This change adds this quotation mark.