### PR TITLE
Update Postgres Clusters total pricing accuracy

### DIFF
--- a/about/pricing.html.md.erb
+++ b/about/pricing.html.md.erb
@@ -97,7 +97,7 @@ The `fly pg create` command will install a PostgreSQL cluster in your organizati
         <td class="text-right">2GB RAM</td>
         <td class="text-right">2&nbsp;x&nbsp;~$10.70/mo</td>
         <td class="text-right">2&nbsp;x&nbsp;~$6/mo</td>
-        <td class="text-right">~$27.40/mo</td>
+        <td class="text-right">~$33.40/mo</td>
       </tr>
       <tr>
         <td>dedicated-cpu-2x</td><td>100GB volumes</td>


### PR DESCRIPTION
All other 2x2 VM+Volume configurations have accurate pricing, however the 2x $10.70 + 2x $6 was listed as a total of $27.40. Original author only calculated 2x $10.70 and 1x $6.