### PR TITLE
Remove erroneously added comment tag on pricing page

### DIFF
--- a/about/pricing.html.md.erb
+++ b/about/pricing.html.md.erb
@@ -5,7 +5,7 @@ sitemap: true
 nav: firecracker
 ---
 
-Our pricing is designed to let you run small applications for free, and scale costs affordably as your needs grow. With this in mind, Fly.io application services are billed individually, based on usage, with a free allowance of resources to get you started. 
+Our pricing is designed to let you run small applications for free, and scale costs affordably as your needs grow. With this in mind, Fly.io application services are billed individually, based on usage, with a free allowance of resources to get you started.
 
 Billing is per user or organization. If you want to run more free apps, just make another organization and invite your friends.
 
@@ -122,7 +122,7 @@ The price of a postgres cluster is `(vm_price + persistent_volume_price + additi
         <td class="text-right">~$1,266/mo</td>
       </tr>
     </tbody>
-  <%# </table> %>
+  </table>
 </div>
 
 ### Outbound data transfer
@@ -136,4 +136,3 @@ We bill for outbound data transfer, inbound transfer is free.
 [Community support](https://community.fly.io) is included for all customers, regardless of usage level.
 
 We offer volume discounts and paid support plans with SLA guarantees as well.
-


### PR DESCRIPTION
5130133 erroneously added an erb comment tag to the pricing page, messing up formatting. This PR removes the tag and fixes the table.