### PR TITLE
Add information about Dockerfile limitations

### DIFF
--- a/getting-started/dockerfile.html.md.erb
+++ b/getting-started/dockerfile.html.md.erb
@@ -91,5 +91,6 @@ You're off and running!
 
 Lots of applications deployed in a container have some state that they want to keep. Here are a couple resources to check out for ways to do that.
 
+- **[Builders:](https://fly.io/docs/reference/builders/)** Learn more about the different [build options](https://fly.io/docs/reference/builders/) on Fly.
 - **[Persistent Volumes:](https://fly.io/docs/reference/volumes/)** You can create [persistent volumes](https://fly.io/docs/reference/volumes/) that you can mount into your container for reading and writing data that changes but isn't blown away when you deploy again.
 - **[Postgres Database:](https://fly.io/docs/reference/postgres/#about-postgres-on-fly)** Deploy a [Fly Postgres Database](https://fly.io/docs/reference/postgres/#about-postgres-on-fly). It automatically creates a `DATABASE_URL` ENV` when you attach it to your app.

--- a/reference/builders.html.md
+++ b/reference/builders.html.md
@@ -13,6 +13,12 @@ The dockerfile builder is the default builder, invoked when there is a `Dockerfi
 
 This is the most flexible of the options, but with that flexibility comes the need to write Dockerfiles and the associated quirks of the Docker build system. Which is why we have further build options on Fly that simplify the process.
 
+### Local and remote builders
+
+In case you do not have access to a local Docker daemon, we will still be able to build your image on deployment using a remote builder. This is one of our servers acting as a build server for your image. This is a service we offer free of charge, so you don't need to worry about anything!
+
+In case you want to avoid having your image built locally, you can pass the `--local-only` build flag to `flyctl`. Building locally might not always work with alternative runtimes.
+
 ## Buildpacks
 
 Platforms like Heroku use the idea of a buildpack, a building process that's run entirely in its own container, to construct their deployable images. These buildpacks are then bundled into a "builder" stack with an operating system and can be called upon to build an app. The buildpack idea has been standardized with [Cloud Native Buildpacks](https://buildpacks.io/). Buildpacks use several tests to detect if they can build the application and if they can, then proceed to run the scripts needed to create an image.

--- a/reference/builders.html.md
+++ b/reference/builders.html.md
@@ -17,7 +17,7 @@ This is the most flexible of the options, but with that flexibility comes the ne
 
 Platforms like Heroku use the idea of a buildpack, a building process that's run entirely in its own container, to construct their deployable images. These buildpacks are then bundled into a "builder" stack with an operating system and can be called upon to build an app. The buildpack idea has been standardized with [Cloud Native Buildpacks](https://buildpacks.io/). Buildpacks use several tests to detect if they can build the application and if they can, then proceed to run the scripts needed to create an image.
 
-A library of standardized buildpacks are available from [Paketo Buildpacks](https://paketo.io/) and it's from this library, Heroku's Heroku18 buildpack, and Fly's own buildpack (for Deno), that you can select from in Flyctl. If you want to use an unlisted buildpack, you can specify it by name using the 
+A library of standardized buildpacks are available from [Paketo Buildpacks](https://paketo.io/) and it's from this library, Heroku's Heroku18 buildpack, and Fly's own buildpack (for Deno), that you can select from in Flyctl. If you want to use an unlisted buildpack, you can specify it by name using the
 `buildpacks` setting in `fly.toml`.
 
 The deploy process works the same way with buildpacks.
@@ -25,3 +25,4 @@ The deploy process works the same way with buildpacks.
 ## Image
 
 Finally, if you already have a Docker image in a repository and just want to deploy that, you can skip the building process and go straight to the deploy with the image build option.
+Please note that our platform is running on `amd64` hosts and images need to be built for this architecture. If you are building on a machine that has a different architecture, such as `aarch64`, you can change the target platform using the `--platform linux/amd64` build flag for `docker build`.


### PR DESCRIPTION
This PR adds extra information about Docker image target platforms, and also adds a little note about builders since I ran into issues deploying to Fly using [Colima](https://github.com/abiosoft/colima) instead of Docker Desktop on macOS.