### PR TITLE
Senyo/typos

### DIFF
--- a/about/open-source.html.md.erb
+++ b/about/open-source.html.md.erb
@@ -18,7 +18,7 @@ There's a tradition of giving equity grants to startup advisors who help growing
 
 ## Recurring donations
 
-We sponsor the developers behind our favorite open source projects. Some we use heavily, like the <a href="https://github.com/hyperium/hyper/">Hyper HTTP client for Rust</a>. Some are just cool, like the <a href="https://www.notion.so/fly/Open-Source-Sponsorships-7be4b19ce2a7489ea4d559bf403e08fa#7e63057a6a6d433f9ae8f9657b92b2f8" target="_blank" rel="nofollow noopener">Crystal Language</a>.
+We sponsor the developers behind our favorite open source projects. Some we use heavily, like the <a href="https://github.com/hyperium/hyper/">Hyper HTTP client for Rust</a>. Some are just cool, like the <a href="https://gleam.run" target="_blank" rel="nofollow noopener">Gleam language</a>.
 
 ## Revenue share
 

--- a/reference/configuration.html.md
+++ b/reference/configuration.html.md
@@ -9,7 +9,7 @@ All Fly applications have a `fly.toml` file which describes how the application 
 
 The file is in TOML format ([github reference](https://github.com/toml-lang/toml)). If you are unfamiliar with TOML, here's a [useful introduction](https://npf.io/2014/08/intro-to-toml/). It is made up of lines with either key/value settings or sections (noted by values surrounded by one or more pairs of square brackets).
 
-You don't need to create a `fly.toml` file by hand. Runnning [flyctl launch](/docs/flyctl/launch/) will create a `fly.toml` file for you. You can also save one from an existing app by running [flyctl config save](/docs/flyctl/config-save/)
+You don't need to create a `fly.toml` file by hand. Running [flyctl launch](/docs/flyctl/launch/) will create a `fly.toml` file for you. You can also save one from an existing app by running [flyctl config save](/docs/flyctl/config-save/)
 
 ## _Fly.toml - line by line_
 

--- a/reference/monorepo.html.md
+++ b/reference/monorepo.html.md
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-By default, `flyctl deploy` builds and deploys a `fly.toml` file, a `Dockerfile`, and sourcecode from the current working directory. This is sufficient for deploying a single app, but you can also configure `flyctl` to build and deploy multiple apps from a monorepo or deploy an app to multiple targets.
+By default, `flyctl deploy` builds and deploys a `fly.toml` file, a `Dockerfile`, and source code from the current working directory. This is sufficient for deploying a single app, but you can also configure `flyctl` to build and deploy multiple apps from a monorepo or deploy an app to multiple targets.
 
 ## _Paths_
 

--- a/reference/postgres.html.md
+++ b/reference/postgres.html.md
@@ -141,7 +141,7 @@ In general, your clients should connect to port 5432.
 
 A Postgres cluster is configured with three users when created: 
 
-- `postgres` - a role with superuser and login privilages that was created for you along with the cluster. Since the `postgres` role has superuser rights, it's recommended that you only use it for admin tasks and create new users with access restricted to the minimum necessary for applications
+- `postgres` - a role with superuser and login privileges that was created for you along with the cluster. Since the `postgres` role has superuser rights, it's recommended that you only use it for admin tasks and create new users with access restricted to the minimum necessary for applications
 - `flypgadmin` - this role is used internally by fly to configure and query the postgres cluster
 - `repluser` - this is the user replica servers us for replication from the leader
 

--- a/reference/scaling.html.md
+++ b/reference/scaling.html.md
@@ -70,7 +70,7 @@ flyctl scale show
           Count: 4
 ```
 
-This application uses the shared-cpu-1x (one shared CPU) VM size, with 512MB of RAM for each instance and there should be four instances created of it created.
+This application uses the shared-cpu-1x (one shared CPU) VM size, with 512MB of RAM for each instance and there should be four instances of it created.
 
 ## Anchor Scaling
 


### PR DESCRIPTION
just corrections on a few typos. i also changed us mentioning in our about page about sponsoring Crystal language to sponsoring Gleam language because:
1. the link was broken
2. i'm not sure if we are still sponsoring them (not visible in our github sponsors page, though it could be through another channel)