### PR TITLE
Add initial Rails guide

### DIFF
--- a/getting-started/partials/_launch.html.md.erb
+++ b/getting-started/partials/_launch.html.md.erb
@@ -22,11 +22,3 @@ Remote builder fly-builder-little-glitter-8329 ready
 1 desired, 1 placed, 1 healthy, 0 unhealthy [health checks: 2 total, 2 passing]
 --> v0 deployed successfully
 ```
-
-That's it! Run `fly open` to see your deployed app in action.
-
-Try a few other commands:
-
-* `fly logs` - Tail your application logs
-* `fly status` - App deployment details
-* `fly deploy` - Deploy the application after making changes

--- a/getting-started/partials/_launched.html.md.erb
+++ b/getting-started/partials/_launched.html.md.erb
@@ -1,0 +1,7 @@
+That's it! Run `fly open` to see your deployed app in action.
+
+Try a few other commands:
+
+* `fly logs` - Tail your application logs
+* `fly status` - App deployment details
+* `fly deploy` - Deploy the application after making changes

--- a/getting-started/rails.html.md.erb
+++ b/getting-started/rails.html.md.erb
@@ -1,0 +1,71 @@
+---
+title: "Build, Deploy and Run a Rails Application"
+layout: docs
+sitemap: false
+nav: firecracker
+---
+
+<%= partial "partials/intro", locals: { runtime: "Rails" } %>
+
+We'll take a look at the short versions first, deploying with a preconfigured example Rails app.
+You can get the code for the example from [the Fly-Examples Github repository](https://github.com/fly-apps/hello-rails).
+Just `git clone https://github.com/fly-apps/hello-rails` to get a local copy.
+
+<%= partial "partials/install_flyctl_login" %>
+
+## _Launching the app_
+
+To configure and launch the app, you can use `flyctl launch` and follow the simple wizard:
+
+```cmd
+flyctl launch
+```
+```output
+An existing fly.toml file was found for app hello-rails
+? Would you like to copy its configuration to the new app? (y/N)
+```
+
+You can set a name for the app, choose a default region, and choose to launch and attach a Postgresql database.
+Finally `flyctl` will ask if you want to deploy. Say yes!
+
+Once it's done, you can use `flyctl status` to check the app's status and deployment, and you should see something like this:
+
+```cmd
+flyctl status
+```
+```output
+App
+  Name     = hello-rails
+  Owner    = personal
+  Version  = 0
+  Status   = running
+  Hostname = hello-rails.fly.dev
+
+Deployment Status
+  ID          = c3ca80bf-4034-837a-ce92-682e6528c5c7
+  Version     = v0
+  Status      = successful
+  Description = Deployment completed successfully
+  Instances   = 1 desired, 1 placed, 1 healthy, 0 unhealthy
+
+Instances
+ID      	PROCESS	VERSION	REGION	DESIRED	STATUS 	HEALTH CHECKS     	RESTARTS	CREATED
+748868bc	app    	0      	lhr   	run    	running	1 total, 1 passing	0       	20s ago
+```
+
+<%= partial "partials/launched" %>
+
+## _Configuring an existing Rails application_
+
+If you've got an existing Rails app and you want to set it up for Fly, the process is pretty similar;
+`flyctl launch` will take you through the setup steps, but there's a couple of things to look at first.
+
+If you're using Postgres, your database settings will be passed to your app via a `DATABASE_URL` environment
+variable (which Rails picks up automatically). That means you can drop a lot of the production configuration from `config/database.yml`.
+
+If you've got your app's secrets stored in `config/credentials.yml.enc`, you'll need to provide the master
+key to the app by setting it as an secret via the CLI, which you can do with:
+
+```cmd
+flyctl secrets set RAILS_MASTER_KEY=putyourkeyhere
+```

--- a/getting-started/remix.html.md.erb
+++ b/getting-started/remix.html.md.erb
@@ -39,3 +39,5 @@ R E M I X
 ...
 ```
 <%= partial "partials/launch", locals: { detected: "Remix", app_name: app_name } %>
+
+<%= partial "partials/launched" %>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -26,6 +26,7 @@
     <%= nav_link "Run a Go App", href="/docs/getting-started/golang/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run a Node App", href="/docs/getting-started/node/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run a Python App", href="/docs/getting-started/python/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
+    <%= nav_link "Run a Rails App", href="/docs/getting-started/rails/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run a Remix App", href="/docs/getting-started/remix/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run a Ruby App", href="/docs/getting-started/ruby/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run from your Dockerfile", href="/docs/getting-started/dockerfile/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>


### PR DESCRIPTION
Closes https://github.com/fly-apps/rails-nix/issues/19

Adds a basic documentation page for launching Rails apps. 

Not covered yet (up next):
- Multiprocess apps, launching with Sidekiq and Redis.
- More detail on the `fly.toml` file
- Deployment options; Buildpacks, Docker.
