### PR TITLE
Add multi-region docs to Run a Crystal App guide

### DIFF
--- a/getting-started/crystal.html.md.erb
+++ b/getting-started/crystal.html.md.erb
@@ -164,6 +164,17 @@ Deployment Status
 Instances
 ID              PROCESS VERSION REGION  DESIRED STATUS  HEALTH CHECKS           RESTARTS        CREATED
 235f9667        app     0       ord     run     running 1 total, 1 passing      0               1m2s ago
+
+* If you want to know what IP addresses the app is using, try `flyctl ips list`:
+
+```cmd
+flyctl ips list
+```
+```out
+TYPE ADDRESS             REGION CREATED AT
+v4   66.51.123.94        global 3m20s ago
+v6   2a09:8280:1::3:23f4 global 3m20s ago
+```
 ```
 
 ## _Connecting to the App_
@@ -181,16 +192,54 @@ Your browser will be sent to the displayed URL. Fly will auto-upgrade this URL t
 
 ## _Bonus Points_
 
-* If you want to know what IP addresses the app is using, try `flyctl ips list`:
+Fly also supports multi-region deployments.
 
-```cmd
-flyctl ips list
-```
-```out
-TYPE ADDRESS             REGION CREATED AT
-v4   66.51.123.94        global 3m20s ago
-v6   2a09:8280:1::3:23f4 global 3m20s ago
-```
+To deploy to multiple regions, first [Create a PostgreSQL Cluster](https://fly.io/docs/getting-started/multi-region-databases/), then follow these steps:
+
+1. Configure your primary region by setting the env `PRIMARY_REGION` in your fly.toml
+  ```toml
+  [env]
+    PRIMARY_REGION = "ord"
+  ```
+
+1. Add the [superfly/fly.cr shard](https://github.com/superfly/fly.cr) shard to your project
+  ```yaml
+  dependencies:
+  fly:
+    github: superfly/fly.cr
+    version: ~> 0.1
+  ```
+
+1. Require `fly/pg/error_handler` and `fly/avram` _after_ `avram`
+  ```crystal
+  # src/shards.cr
+  # ...
+  require "avram"
+  # ...
+  require "fly/pg/error_handler"
+  require "fly/avram"
+  # ...
+  ```
+
+1. Add the `Fly::PG::ErrorHandler` middleware to your list of middlewares, _after_ the `Lucky::ErrorHandler`
+  ```crystal
+  # src/app_server.cr
+  # ...
+    def middleware : Array(HTTP::Handler)
+      [
+        # ...
+        Lucky::ErrorHandler.new(action: Errors::Show),
+        Raven::Lucky::ErrorHandler.new,
+        Fly::PG::ErrorHandler.new,
+        # ..,.
+      ]of HTTP::Handler
+    end
+  # ...
+  ```
+
+1. Deploy with `fly deploy`
+
+1. You can see replays in the `fly log`
 
 ## _Arrived at Destination_
 


### PR DESCRIPTION
I don’t know what flavor of markdown the main site is working, but the code blocks inside of the ol ’s will likely need to be redone if this isn’t github flavored markdown