### PR TITLE
Use correct capitalization of GitHub

### DIFF
--- a/app-guides/run-a-global-image-service.html.md.erb
+++ b/app-guides/run-a-global-image-service.html.md.erb
@@ -27,7 +27,7 @@ With Fly you can eliminate all that administrative load by letting Fly deploy a 
 
 Let's start with [h2non/Imaginary](https://github.com/h2non/imaginary), a fantastically useful image processing application written in Go. Once configured, it lets you process images. The images can be posted to it or you can ask it to get an image from a remote server and all of this is controlled through a URL request to the Imaginary server.
 
-You can find all the source in the Github repository, but for this guide, we don't need to worry about that. We're going to use the developer-supplied Docker image to deploy it.
+You can find all the source in the GitHub repository, but for this guide, we don't need to worry about that. We're going to use the developer-supplied Docker image to deploy it.
 
 ## _Deploying Docker Images to Fly_
 
@@ -86,7 +86,7 @@ In another terminal session, run:
 curl -O "http://localhost:8080/crop?width=500&height=400&url=https://raw.githubusercontent.com/h2non/imaginary/master/testdata/large.jpg"
 ```
 
-This will ask Imaginary to crop, to 100x100, an image stored in the Imaginary Github repository. This should result in a file, `large.jpg` being written to disc which you can display using your preferred image viewer. MacOS users can simply `open large.jpg` at the command line.
+This will ask Imaginary to crop, to 100x100, an image stored in the Imaginary GitHub repository. This should result in a file, `large.jpg` being written to disc which you can display using your preferred image viewer. MacOS users can simply `open large.jpg` at the command line.
 
 Open the cropped image. Take a moment to play with the width and height values in the URL we're querying and you will get different sized cropped images. Once you are happy the local build is working, you can return to the session where you started the docker image and ctrl-C to stop it.
 
@@ -116,7 +116,7 @@ This will take you to the sign-up page where you can either:
 
 * **Sign up with Email**: Enter your name, email and password.
 
-* **Sign up with Github**: If you have a Github account, you can use that to sign up. Look out for the confirmatory email we will send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
+* **Sign up with GitHub**: If you have a GitHub account, you can use that to sign up. Look out for the confirmatory email we will send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
 
 
 ##### Returning User
@@ -127,7 +127,7 @@ Run:
 flyctl auth login
 ```
 
-Your browser will open up with the Fly sign-in screen. Enter your user name and password to sign in. If you signed up with Github, use the `Sign in with Github` button to sign in.
+Your browser will open up with the Fly sign-in screen. Enter your user name and password to sign in. If you signed up with GitHub, use the `Sign in with GitHub` button to sign in.
 
 
 Whichever route you take you will be signed-up, signed-in and returned to your command line, ready to Fly.

--- a/app-guides/run-a-private-dns-over-https-service.html.md.erb
+++ b/app-guides/run-a-private-dns-over-https-service.html.md.erb
@@ -50,7 +50,7 @@ This will take you to the sign-up page where you can either:
 
 * **Sign up With Email**: Enter your name, email and password.
 
-* **Sign up With Github**: If you have a Github account, you can use that to sign up. Look out for the confirmatory email we will send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
+* **Sign up With GitHub**: If you have a GitHub account, you can use that to sign up. Look out for the confirmatory email we will send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
 
 
 #### Returning User
@@ -61,7 +61,7 @@ Run:
 flyctl auth login
 ```
 
-Your browser will open up with the Fly sign-in screen. Enter your user name and password to sign in. If you signed up with Github, use the `Sign in with Github` button to sign in.
+Your browser will open up with the Fly sign-in screen. Enter your user name and password to sign in. If you signed up with GitHub, use the `Sign in with GitHub` button to sign in.
 
 
 Whichever route you take you will be signed-up, signed-in and returned to your command line, ready to Fly.

--- a/app-guides/udp-and-tcp.html.md.erb
+++ b/app-guides/udp-and-tcp.html.md.erb
@@ -16,10 +16,10 @@ Our UDP support can be a little tricky, and can catch you out, especially if you
 
 ## The Basic Idea
 
-Let's build a simple echo service. You can play the home version at [this Github repository](https://github.com/fly-apps/udp-echo-). We'll listen on port 5000, UDP and TCP, and just bat back whatever clients send us.
+Let's build a simple echo service. You can play the home version at [this GitHub repository](https://github.com/fly-apps/udp-echo-). We'll listen on port 5000, UDP and TCP, and just bat back whatever clients send us.
 
 Use `flyctl launch` to create a `fly.toml` file. Use it to wire up the ports.
-  
+
 ```toml
 [[services]]
   internal_port = 5000
@@ -47,7 +47,7 @@ We're going to build this silly app in Go (don't worry, it's trivial, you'll be 
 ## Let's See Some Code
 
 You light up UDP and TCP with standard socket code. Usually, the only fussy bit will be the `fly-global-services` bind for UDP. Here's what that looks like in Go:
-  
+
 ```golang
 func main() {
   // in other programming languages, this might look like:
@@ -63,7 +63,7 @@ func main() {
 	//    s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
 	//    s.bind("0.0.0.0", port)
 	//    s.listen()
-  
+
 	tcp, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		log.Fatalf("can't listen on %d/tcp: %s", port, err)
@@ -145,9 +145,9 @@ echo hello world | nc udp-echo-sample.fly.dev 5000
 ```output
 hello world
 ```
-     
+
 ## More On Those Three Gotchas
-  
+
 ### The `fly-global-services` Address
 
 For the most part, UDP "just works" on Fly.io, the way you'd expect it to.
@@ -167,7 +167,7 @@ You usually need to **explicitly bind your UDP service to `fly-global-services`.
 You can't bind your TCP service to `fly-global-services`; the TCP side of your app should probably bind to `*`.
 
 This is super annoying. You probably want to use the same configuration value for both UDP and TCP ports, but you have to be fussy about it on Fly.io. We're working on it!
-     
+
 ### UDP Won't Work Over IPv6
 
 Another thing that won't impact your code that you'll need to know about is that we don't currently support UDP over IPv6. The kernel forwarding code we run to make UDP work isn't IPv6 aware. This is not OK, and we're working on it, but it's a limitation you'll run into today.

--- a/flyctlhelp.html.md
+++ b/flyctlhelp.html.md
@@ -40,6 +40,6 @@ iwr https://fly.io/install.ps1 -useb | iex
 
 ## _Other options_
 
-All the executable versions of flyctl for all platforms are available from the [Github repository](https://github.com/superfly/flyctl). Browse to the [latest release view](https://github.com/superfly/flyctl/releases/latest) to view all available files.
+All the executable versions of flyctl for all platforms are available from the [GitHub repository](https://github.com/superfly/flyctl). Browse to the [latest release view](https://github.com/superfly/flyctl/releases/latest) to view all available files.
 
 Standalone executable files and archive/compressed files are available. If in doubt as to which one to use, use the install scripts above.

--- a/getting-started/crystal.html.md.erb
+++ b/getting-started/crystal.html.md.erb
@@ -137,7 +137,7 @@ flyctl deploy
 
 This will lookup our `fly.toml` file, and get the app name `hello-lucky` from there. Then `flyctl` will start the process of deploying our application to the Fly platform. Flyctl will return you to the command line when it's done.
 
-Alternatively, you can use [Github Actions to deploy your app to Fly](/docs/app-guides/continuous-deployment-with-github-actions/)
+Alternatively, you can use [GitHub Actions to deploy your app to Fly](/docs/app-guides/continuous-deployment-with-github-actions/)
 
 ## _Viewing the Deployed App_
 

--- a/getting-started/deno.html.md.erb
+++ b/getting-started/deno.html.md.erb
@@ -11,7 +11,7 @@ nav: firecracker
 
 Our example will be a basic "hello world" example using Deno and [Dinatra](https://github.com/syumai/dinatra).
 
-You can get the code for the example from [the hellodeno Github repository](https://github.com/fly-apps/hellodeno). Just `git clone https://github.com/fly-apps/hellodeno` to get a local copy. Here's all the code:
+You can get the code for the example from [the hellodeno GitHub repository](https://github.com/fly-apps/hellodeno). Just `git clone https://github.com/fly-apps/hellodeno` to get a local copy. Here's all the code:
 
 ```typescript
 import {

--- a/getting-started/golang.html.md.erb
+++ b/getting-started/golang.html.md.erb
@@ -9,7 +9,7 @@ nav: firecracker
 
 ## _The Example Application_
 
-You can get the code for the example from [the Github repository](https://github.com/fly-apps/go-example). Just `git clone https://github.com/fly-apps/go-example` to get a local copy.
+You can get the code for the example from [the GitHub repository](https://github.com/fly-apps/go-example). Just `git clone https://github.com/fly-apps/go-example` to get a local copy.
 
 The `go-example` application is, as you'd expect for an example, small. It's a Go application that uses the http server and templates from the standard library. Here's all the code from `main.go`:
 

--- a/getting-started/log-in-to-fly.html.md
+++ b/getting-started/log-in-to-fly.html.md
@@ -16,7 +16,7 @@ If you already have a Fly account, you can log in with Flyctl by running:
 flyctl auth login
 ```
 
-Your browser will open up with the Fly sign-in screen, enter your user name and password to sign-in. If you signed up with Github, use the `Sign-in with Github` button to sign in.
+Your browser will open up with the Fly sign-in screen, enter your user name and password to sign-in. If you signed up with GitHub, use the `Sign-in with GitHub` button to sign in.
 
 Now proceed to globally deploying Docker Images, Go Applications, Node Applications and more.
 
@@ -31,7 +31,7 @@ flyctl auth signup
 This will open your browser on the sign-up page where you can either:
 
 * **Sign-up With Email**: Enter your name, email and password.
-* **Sign-up With Github**: If you have a Github account, you can use that to sign-up. Look out for the confirmatory email we'll send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
+* **Sign-up With GitHub**: If you have a GitHub account, you can use that to sign-up. Look out for the confirmatory email we'll send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
 
 You will also be prompted for credit card payment information, required for charges outside the free plan on Fly. See [Pricing](/docs/about/pricing) for more details on that. If you do not enter a details here, you will be unable to create a new application on Fly until you add a credit card to your account.
 

--- a/getting-started/node.html.md.erb
+++ b/getting-started/node.html.md.erb
@@ -11,7 +11,7 @@ nav: firecracker
 
 Our example will be a basic "hello world" example using Node and Express.
 
-You can get the code for the example from [the hellonode Github repository](https://github.com/fly-apps/hellonode-builtin). Just `git clone https://github.com/fly-apps/hellonode-builtin` to get a local copy. Here's all the code:
+You can get the code for the example from [the hellonode GitHub repository](https://github.com/fly-apps/hellonode-builtin). Just `git clone https://github.com/fly-apps/hellonode-builtin` to get a local copy. Here's all the code:
 
 ```javascript
 const express = require("express");

--- a/getting-started/python.html.md.erb
+++ b/getting-started/python.html.md.erb
@@ -9,7 +9,7 @@ nav: firecracker
 
 ## _The Hellofly-python Application_
 
-You can get the code for the example from [the Fly-Examples Github repository](https://github.com/fly-apps/python-hellofly-flask). Just `git clone https://github.com/fly-apps/python-hellofly-flask` to get a local copy.
+You can get the code for the example from [the Fly-Examples GitHub repository](https://github.com/fly-apps/python-hellofly-flask). Just `git clone https://github.com/fly-apps/python-hellofly-flask` to get a local copy.
 
 The Python hellofly application is, as you'd expect for an example, small. It's a Python application that uses the [Flask](https://flask.palletsprojects.com/) web framework. Here's all the code form `hellofly.py`:
 

--- a/getting-started/rails.html.md.erb
+++ b/getting-started/rails.html.md.erb
@@ -8,7 +8,7 @@ nav: firecracker
 <%= partial "partials/intro", locals: { runtime: "Rails" } %>
 
 We'll take a look at the short versions first, deploying with a preconfigured example Rails app.
-You can get the code for the example from [the Fly-Examples Github repository](https://github.com/fly-apps/hello-rails).
+You can get the code for the example from [the Fly-Examples GitHub repository](https://github.com/fly-apps/hello-rails).
 Just `git clone https://github.com/fly-apps/hello-rails` to get a local copy.
 
 <%= partial "partials/install_flyctl_login" %>

--- a/getting-started/ruby.html.md.erb
+++ b/getting-started/ruby.html.md.erb
@@ -11,7 +11,7 @@ nav: firecracker
 
 Our example will be a basic "hello world" example using Sinatra. We'll assume that you already have Ruby and Bundler installed.
 
-You can get the code for the example from [the helloruby Github repository](https://github.com/fly-apps/helloruby-builtin). Just `git clone https://github.com/fly-apps/helloruby-builtin` to get a local copy. Here's all the code for our `app.rb`:
+You can get the code for the example from [the helloruby GitHub repository](https://github.com/fly-apps/helloruby-builtin). Just `git clone https://github.com/fly-apps/helloruby-builtin` to get a local copy. Here's all the code for our `app.rb`:
 
 ```ruby
 #!/usr/bin/env ruby

--- a/getting-started/static.html.md.erb
+++ b/getting-started/static.html.md.erb
@@ -11,7 +11,7 @@ To be fair, a static site isn't an app. So we're really talking about **deployin
 
 In this demonstration, we'll use [goStatic](https://github.com/PierreZ/goStatic), a tiny web server written in Go that lets us serve static files with very little configuration. We'll provide a Dockerfile and our content for Fly to transmogrify into a web server running in a VM.
 
-You can clone all the files needed for this example from [the hello-static Github repository](https://github.com/fly-apps/hello-static) to a local directory:
+You can clone all the files needed for this example from [the hello-static GitHub repository](https://github.com/fly-apps/hello-static) to a local directory:
 
 ```cmd
 git clone https://github.com/fly-apps/hello-static
@@ -37,13 +37,13 @@ cd hello-static
 
 ### _The Site_
 
-Our example will be a simple static site. That can be as trivial as a single `index.html` file. Let's make it only slightly more complicated by writing two html files and having them link to each other. 
+Our example will be a simple static site. That can be as trivial as a single `index.html` file. Let's make it only slightly more complicated by writing two html files and having them link to each other.
 
 Put these html files into a subdirectory of their own, called `public`. Files in this directory are the ones our goStatic server will serve. Create the `hello-static/public` directory if needed.
 
 Here's `index.html`, which is the landing page:
 
-```html 
+```html
 <html>
   <head>
     <title>
@@ -75,11 +75,11 @@ Here's `goodbye.html`.
 
 ### _The Dockerfile_
 
-goStatic is designed to run in a container, and the [image](https://hub.docker.com/r/pierrezemb/gostatic) is available at Docker Hub. This is super convenient for us, because Fly apps need container images too! 
+goStatic is designed to run in a container, and the [image](https://hub.docker.com/r/pierrezemb/gostatic) is available at Docker Hub. This is super convenient for us, because Fly apps need container images too!
 
 We can use the goStatic image as a base image. We just have to copy our site's files to `/srv/http/` in the image.
 
-Here's our Dockerfile to do that: 
+Here's our Dockerfile to do that:
 
 ```docker
 FROM pierrezemb/gostatic
@@ -91,14 +91,14 @@ The Dockerfile should be placed in the working directory (here, `hello-static`).
 ### _Configuring the App for Fly.io_
 
 We set the initial configuration for the app by running `flyctl launch`. This takes care of setting the app name, the Fly.io organization it belongs to, and a region to deploy to. It also generates a `fly.toml` file
-with more configuration settings. 
+with more configuration settings.
 
 The `hello-static` repository contains a `fly.toml` that will be detected by `flyctl launch`; you can use it to configure your app. Otherwise, a new `fly.toml` will be generated with `flyctl launch`, and we can edit it.
 
 ```cmd
 flyctl launch
 ```
-```output           
+```output
 Creating app in /Users/chris/trystatic/hello-static
 Scanning source code
 Detected a Dockerfile app
@@ -125,13 +125,13 @@ Before deploying, we need to do one more thing. goStatic listens on port 8043 by
   script_checks = []
   ```
 
-Now we're ready to deploy: 
+Now we're ready to deploy:
 
 ```cmd
 flyctl deploy
 ```
 
-The output should end something like this, if everything has gone well: 
+The output should end something like this, if everything has gone well:
 
 ```
 ==> Monitoring deployment

--- a/hands-on/sign-in.html.md
+++ b/hands-on/sign-in.html.md
@@ -12,7 +12,7 @@ If you already have a Fly account, all you need to do is sign in with Flyctl. Si
 flyctl auth login
 ```
 
-Your browser will open up with the Fly sign-in screen, enter your user name and password to sign in. If you signed up with Github, use the `Sign in with Github` button to sign in.
+Your browser will open up with the Fly sign-in screen, enter your user name and password to sign in. If you signed up with GitHub, use the `Sign in with GitHub` button to sign in.
 
 Whichever route you take you will be returned to your command line, ready to use Fly.
 

--- a/hands-on/sign-up.html.md
+++ b/hands-on/sign-up.html.md
@@ -14,9 +14,9 @@ flyctl auth signup
 
 This will take you to the sign-up page where you can either:
 
-* **Sign-up with email**: Enter your name, email and password. 
+* **Sign-up with email**: Enter your name, email and password.
 
-* **Sign-up with github**: If you have a Github account, you can use that to sign up. Look out for the confirmatory email we'll send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
+* **Sign-up with github**: If you have a GitHub account, you can use that to sign up. Look out for the confirmatory email we'll send you which will give you a link to set a password; you'll need a password set so we can actively verify that it is you for some Fly operations.
 
 You will also be prompted for credit card payment information, required for charges outside the free tier on Fly. See [Pricing](/docs/about/pricing) for more details on what is included in the free tier.. If you do not enter a details here, you will be unable to create a new application on Fly until you add a credit card to your account.
 

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -41,7 +41,7 @@
   </dt>
   <dd class="mb-8 border-l border-gray-100">
     <%= nav_link "Custom Domains for SaaS", href="/docs/app-guides/custom-domains-with-fly/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
-    <%= nav_link "Deploy with Github Actions", href="/docs/app-guides/continuous-deployment-with-github-actions/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
+    <%= nav_link "Deploy with GitHub Actions", href="/docs/app-guides/continuous-deployment-with-github-actions/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run Multiple Processes", href="/docs/app-guides/multiple-processes/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Run UDP Services", href="/docs/app-guides/udp-and-tcp/", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>
     <%= nav_link "Elixir Guides", href="/docs/guides/#elixir", class: "flex hover:text-violet-600 transition-colors py-1 border-l-[3px] pl-4 -ml-0.5 border-transparent hover:border-violet-500" %>


### PR DESCRIPTION
👋 Hey folks! I noticed that the docs had multiple places where it referenced `Github` instead of `GitHub`, which is the correct capitalization. I went through and corrected these.

VS Code also removed some trailing whitespace on some lines too it seems, sorry about that noise in the diff.

It looks like your website also has some places with the lowercase `h`, if you don't mind passing that along to the folks who can fix that as well 😅:

<img width="435" alt="Screen Shot 2022-04-05 at 1 12 23 AM" src="https://user-images.githubusercontent.com/858504/161709319-d4e3c067-8779-4b0b-bd3e-b3706c267588.png">


