### PR TITLE
Update overmind CMD to use Exec form

### DIFF
--- a/app-guides/multiple-processes.html.md
+++ b/app-guides/multiple-processes.html.md
@@ -152,7 +152,7 @@ RUN apt-get update && \
 
 RUN GO111MODULE=on go get -u github.com/DarthSim/overmind/v2
 ADD Procfile /app/
-CMD overmind start
+CMD ["overmind", "start"]
 ```
 
 `overmind` has a bunch of interesting features, most notable among them that it wraps `tmux`, so you can get a terminal window on any of your running programs. Deploy, and then you can:


### PR DESCRIPTION
overmind captures SIGTERM and cleans itself up by deleting `.overmind.sock`, but in order for this to work correctly it needs to run in Exec form, which is the recommended by docker (https://docs.docker.com/engine/reference/builder/#cmd)