### PR TITLE
Fix busted codefences in Crystal quickstart

### DIFF
--- a/getting-started/crystal.html.md.erb
+++ b/getting-started/crystal.html.md.erb
@@ -164,8 +164,9 @@ Deployment Status
 Instances
 ID              PROCESS VERSION REGION  DESIRED STATUS  HEALTH CHECKS           RESTARTS        CREATED
 235f9667        app     0       ord     run     running 1 total, 1 passing      0               1m2s ago
+```
 
-* If you want to know what IP addresses the app is using, try `flyctl ips list`:
+If you want to know what IP addresses the app is using, try `flyctl ips list`:
 
 ```cmd
 flyctl ips list
@@ -174,7 +175,6 @@ flyctl ips list
 TYPE ADDRESS             REGION CREATED AT
 v4   66.51.123.94        global 3m20s ago
 v6   2a09:8280:1::3:23f4 global 3m20s ago
-```
 ```
 
 ## _Connecting to the App_


### PR DESCRIPTION
Looks like a copy/paste missed some triple-ticks, this should restore the intended formatting.