### PR TITLE
fix typo `Deplying` > `Deploying`

### DIFF
--- a/getting-started/node.html.md.erb
+++ b/getting-started/node.html.md.erb
@@ -68,7 +68,7 @@ Using the following build configuration
 ? Select region: ord (Chicago, Illinois (US))
 ? Would you like to deploy now? Yes
 
-Deplying hellonode
+Deploying hellonode
 ...
 ```
 


### PR DESCRIPTION
fix typo `Deplying` > `Deploying`