### PR TITLE
Adjust the paketo example to use the base builder

### DIFF
--- a/reference/configuration.html.md
+++ b/reference/configuration.html.md
@@ -53,7 +53,7 @@ The optional build section contains key/values concerned with how the applicatio
 
 ```toml
 [build]
-  builder = "paketobuildpacks/builder:tiny"
+  builder = "paketobuildpacks/builder:base"
   buildpacks = ["gcr.io/paketo-buildpacks/nodejs"]
 ```
 


### PR DESCRIPTION
It appears that the example in the docs using the Paketo tiny builder results in an error, as the node buildpack lists itself as incompatible with the tiny stack.

To that end, adjusted the docs to use the base builder instead, which throws no such error.