### PR TITLE
Change the case of 'IP' in `Fly-Client-Ip`

### DIFF
--- a/reference/runtime-environment.html.md
+++ b/reference/runtime-environment.html.md
@@ -26,7 +26,7 @@ Request headers carry information that is specific to the incoming request and i
 
 ## _Request Headers_
 
-### `Fly-Client-IP`
+### `Fly-Client-Ip`
 **Client IP Address**: The IP address Fly accepted a connection from. This will be the client making the initial request and as such, will also appear at the start of the `X-Forwarded-For` addresses. 
 
 ### `Fly-Forwarded-Port`


### PR DESCRIPTION
The `Fly-Client-IP` header is spelled as `Fly-Client-Ip` by the runtime environment.

`Fly-Client-Ip:[92.xxx.xxx.xx]`