### PR TITLE
add MacPorts as alternative to Homebrew; add missing Homebrew links

### DIFF
--- a/app-guides/run-a-private-dns-over-https-service.html.md.erb
+++ b/app-guides/run-a-private-dns-over-https-service.html.md.erb
@@ -22,10 +22,16 @@ It's useful to be able to run private services for protocols like DoH. If you pi
 
 ### Install Fly CLI
 
-If you're on a Mac, you can install the CLI with Homebrew:
+If you're on a Mac, you can install the CLI with [Homebrew](https://brew.sh):
 
 ```cmd
 brew install flyctl
+```
+
+If you're on a Mac, you can install the CLI with [MacPorts](https://www.macports.org):
+
+```cmd
+[sudo] port install flyctl
 ```
 
 For other systems, download and run the install script:

--- a/app-guides/speed-up-a-heroku-app.html.md.erb
+++ b/app-guides/speed-up-a-heroku-app.html.md.erb
@@ -35,13 +35,19 @@ Your three step journey starts at [https://fly.io/heroku](https://fly.io/heroku)
 
 You'll need flyctl to interact with Fly. It's a command-line application which is quick to install.
 
-If you are on a Mac and have Homebrew installed, run:
+If you are on a Mac and have the [Homebrew](https://brew.sh) package manager installed, run:
 
 ```cmd
 brew install flyctl
 ```
 
-If you are on Linux or on a Mac without Homebrew, run
+If you are on a Mac and have the [MacPorts](https://www.macports.org) package manager installed, run:
+
+```cmd
+[sudo] port install flyctl
+```
+
+If you are on Linux or on a Mac without Homebrew or MacPorts, run
 
 ```cmd
 curl -L https://fly.io/install.sh | sh

--- a/flyctl/installing.html.md
+++ b/flyctl/installing.html.md
@@ -22,6 +22,12 @@ If you have the [Homebrew](https://brew.sh) package manager installed, flyctl ca
 brew install flyctl
 ```
 
+If you have the [MacPorts](https://www.macports.org) package manager installed, flyctl can be installed by running:
+
+```cmd
+[sudo] port install flyctl
+```
+
 If not, you can run the install script:
 
 ```cmd

--- a/flyctlhelp.html.md
+++ b/flyctlhelp.html.md
@@ -15,6 +15,12 @@ If you are on a Mac with the [Homebrew](https://brew.sh) package manager install
 brew install flyctl
 ```
 
+If you are on a Mac with the [MacPorts](https://www.macports.org) package manager installed, flyctl can be installed by running:
+
+```cmd
+[sudo] port install flyctl
+```
+
 If not, you can run the install script:
 
 ```cmd

--- a/getting-started/installing-flyctl.html.md
+++ b/getting-started/installing-flyctl.html.md
@@ -22,6 +22,12 @@ If you have the [Homebrew](https://brew.sh) package manager installed, flyctl ca
 brew install flyctl
 ```
 
+If you have the [MacPorts](https://www.macports.org) package manager installed, flyctl can be installed by running:
+
+```cmd
+[sudo] port install flyctl
+```
+
 If not, you can run the install script:
 
 ```cmd

--- a/hands-on/installing.html.md
+++ b/hands-on/installing.html.md
@@ -22,6 +22,12 @@ If you have the [Homebrew](https://brew.sh) package manager installed, flyctl ca
 brew install flyctl
 ```
 
+If you have the [MacPorts](https://www.macports.org) package manager installed, flyctl can be installed by running:
+
+```cmd
+[sudo] port install flyctl
+```
+
 If not, you can run the install script:
 
 ```cmd


### PR DESCRIPTION
I was going through the guide to using Fly and the documentation only mentions Homebrew when there are two package managers for macOS: Homebrew, and MacPorts. I think it's important people at least know MacPorts is an option here.

MacPorts does package and keep flyctl up to date.