### PR TITLE
Install Guide: add Scoop

### DIFF
--- a/flyctl/installing.html.md
+++ b/flyctl/installing.html.md
@@ -50,7 +50,13 @@ curl -L https://fly.io/install.sh | sh
   Windows
 </h2>
 
-Run the Powershell install script:
+If you are on a Windows with the [Scoop](https://scoop.sh/) package manager installed, flyctl can be installed by running:
+
+```cmd
+scoop install flyctl
+```
+
+If not, you can run the Powershell install script:
 
 ```cmd
 iwr https://fly.io/install.ps1 -useb | iex

--- a/flyctlhelp.html.md
+++ b/flyctlhelp.html.md
@@ -32,7 +32,13 @@ curl -L https://fly.io/install.sh | sh
 
 ## _Windows_
 
-Run the Powershell install script:
+If you are on a Windows with the [Scoop](https://scoop.sh/) package manager installed, flyctl can be installed by running:
+
+```cmd
+scoop install flyctl
+```
+
+If not, you can run the Powershell install script:
 
 ```cmd
 iwr https://fly.io/install.ps1 -useb | iex

--- a/getting-started/installing-flyctl.html.md
+++ b/getting-started/installing-flyctl.html.md
@@ -50,7 +50,13 @@ curl -L https://fly.io/install.sh | sh
   Windows
 </h2>
 
-Run the Powershell install script:
+If you are on a Windows with the [Scoop](https://scoop.sh/) package manager installed, flyctl can be installed by running:
+
+```cmd
+scoop install flyctl
+```
+
+If not, you can run the Powershell install script:
 
 ```cmd
 iwr https://fly.io/install.ps1 -useb | iex

--- a/hands-on/installing.html.md
+++ b/hands-on/installing.html.md
@@ -50,7 +50,13 @@ curl -L https://fly.io/install.sh | sh
   Windows
 </h2>
 
-Run the Powershell install script:
+If you are on a Windows with the [Scoop](https://scoop.sh/) package manager installed, flyctl can be installed by running:
+
+```cmd
+scoop install flyctl
+```
+
+If not, you can run the Powershell install script:
 
 ```cmd
 iwr https://fly.io/install.ps1 -useb | iex


### PR DESCRIPTION
`flyctl` was moved from Extras bucket to Main bucket [5 days ago](https://github.com/ScoopInstaller/Main/commit/34791996725dc6f1d7332806ecd420ed32327b62), personally I like it more than using iwr, and It is kinda nice to have this on Installation guide pages