### PR TITLE
Support tweaks

### DIFF
--- a/flyctl/cmd/flyctl_orgs_delete.md
+++ b/flyctl/cmd/flyctl_orgs_delete.md
@@ -1,4 +1,5 @@
-Delete an existing organization.
+Delete an existing organization. 
+Succeeds when all services and additional admins have been removed.
 
 
 ## Usage

--- a/flyctl/cmd/flyctl_ssh_issue.md
+++ b/flyctl/cmd/flyctl_ssh_issue.md
@@ -2,9 +2,6 @@ Issue a new SSH credential. With -agent, populate credential
 into SSH agent. With -hour, set the number of hours (1-72) for credential
 validity.
 
-Root certificates are issued to organizations either after `fly ssh issue` or `fly ssh console`. 
-
-
 
 ## Usage
 ~~~

--- a/flyctl/cmd/flyctl_ssh_issue.md
+++ b/flyctl/cmd/flyctl_ssh_issue.md
@@ -2,6 +2,10 @@ Issue a new SSH credential. With -agent, populate credential
 into SSH agent. With -hour, set the number of hours (1-72) for credential
 validity.
 
+Root certificates are issued to organizations either after `fly ssh issue` or `fly ssh console`. 
+
+
+
 ## Usage
 ~~~
 flyctl ssh issue [org] [email] [path] [flags]
@@ -30,4 +34,4 @@ flyctl ssh issue [org] [email] [path] [flags]
 ## See Also
 
 * [flyctl ssh](/docs/flyctl/ssh/)	 - Use SSH to login to or run commands on VMs
-
+* [flyctl ssh log](/docs/flyctl/ssh/)

--- a/flyctl/cmd/flyctl_ssh_log.md
+++ b/flyctl/cmd/flyctl_ssh_log.md
@@ -1,4 +1,5 @@
-Log of all issued SSH certs. Each organization has its own root certificate.
+Log of all issued SSH certs. Each organization has a different root certificate.
+This is used for members of the organization and its apps' instances. 
 
 ## Usage
 ~~~

--- a/flyctl/cmd/flyctl_ssh_log.md
+++ b/flyctl/cmd/flyctl_ssh_log.md
@@ -1,4 +1,4 @@
-Log of all issued SSH certs
+Log of all issued SSH certs. Each organization has its own root certificate.
 
 ## Usage
 ~~~
@@ -23,4 +23,4 @@ flyctl ssh log [flags]
 ## See Also
 
 * [flyctl ssh](/docs/flyctl/ssh/)	 - Use SSH to login to or run commands on VMs
-
+* [flyctl ssh issue](/docs/flyctl/ssh-issue/)	 - Issue new SSH credential


### PR DESCRIPTION
provided a bit more detail for how ssh root certs work. 
also made an unrelated change to `fly orgs delete` to prevent common mistakes