### PR TITLE
Update flag for rails console command

### DIFF
--- a/rails/the-basics/run-tasks-and-consoles.html.md
+++ b/rails/the-basics/run-tasks-and-consoles.html.md
@@ -39,7 +39,7 @@ fly ssh console -C "bin/rails help"
 To access an interactive Rails console, run:
 
 ```cmd
-fly ssh console -c "bin/rails console"
+fly ssh console -C "bin/rails console"
 ```
 ```output
 irb>


### PR DESCRIPTION
I spent a few minutes trying to connect with -c when I really needed -C instead for the Rails console.

--

I'm unsure if this is worthy of an issue / doc fix... but I also had to prefix my commands with the WORKDIR from my Dockerfile that was generated by `fly launch` (app/) to make the commands work... so `bin/rails console` (doesn't work) -> `app/bin/rails console` (works)