### PR TITLE
Add back multiple secrets on command line example.

### DIFF
--- a/partials/_set_secrets.html.erb
+++ b/partials/_set_secrets.html.erb
@@ -1,4 +1,4 @@
 ```cmd
-flyctl secrets set DATABASE_URL=postgres://example.com/mydb <%= defined?(show_multiple) && "MY_SECRET=romance" %> <%= defined?(app_name) && "-a #{app_name}" %>
+flyctl secrets set DATABASE_URL=postgres://example.com/mydb<%= defined?(show_multiple) && " MY_SECRET=romance" %><%= defined?(app_name) && " -a #{app_name}" %>
 ```
 

--- a/partials/_set_secrets.html.erb
+++ b/partials/_set_secrets.html.erb
@@ -1,4 +1,4 @@
 ```cmd
-flyctl secrets set DATABASE_URL=postgres://example.com/mydb <%= defined?(app_name) && "-a #{app_name}" %>
+flyctl secrets set DATABASE_URL=postgres://example.com/mydb <%= defined?(show_multiple) && "MY_SECRET=romance" %> <%= defined?(app_name) && "-a #{app_name}" %>
 ```
 

--- a/reference/secrets.html.md.erb
+++ b/reference/secrets.html.md.erb
@@ -23,7 +23,7 @@ The `flyctl secrets set` command will set one or more application secrets then p
 
 <%= partial "../partials/set_secrets", locals: { show_multiple: true } %>
 
-These will be set as `$MY_SECRET` and `$DATABASE_URL` environment variables within your application processes.
+These will be set as `$DATABASE_URL` and `$MY_SECRET` environment variables within your application processes.
 
 **Note:** if a secret you set causes your app to crash within 30s, the release will fail and your app will continue to run with previous secrets.
 

--- a/reference/secrets.html.md.erb
+++ b/reference/secrets.html.md.erb
@@ -21,7 +21,7 @@ When we launch a VM for your application, we issue the host it runs on a tempora
 
 The `flyctl secrets set` command will set one or more application secrets then perform a release.
 
-<%= partial "../partials/set_secrets" %>
+<%= partial "../partials/set_secrets", locals: { show_multiple: true } %>
 
 These will be set as `$MY_SECRET` and `$DATABASE_URL` environment variables within your application processes.
 


### PR DESCRIPTION
# What

This adds back a second secret to the CLI example for adding secrets on [secrets documentation](https://fly.io/docs/reference/secrets/).

# Why

When the secrets documentation was updated to use a partial, it only shows one secret now. MY_SECRET is referenced in the rest of the documentation but isn't actually created anywhere. This remedies that.

# How

I added a second variable to the partial so that it doesn't affect the other place it's being used. I don't write Ruby, so feel free to adjust if there's a better way to do this.