### PR TITLE
Change`nginxproxy` to `my-nginx-proxy` to reduce confusion

### DIFF
--- a/app-guides/custom-domains-with-fly.html.md
+++ b/app-guides/custom-domains-with-fly.html.md
@@ -29,11 +29,11 @@ There's a question to ask and answer. Do you want to start accepting traffic imm
 
 ### Accepting traffic immediately for the custom domain
 
-In this scenario, we want the custom domain to point to the `nginxproxy` server which will allow unencrypted IPv4 and IPv6 connections. Again, there are two ways to do this. Using DNS's CNAME capability or setting the A and AAAA records.
+In this scenario, we want the custom domain to point to a fly app called `my-nginx-proxy` which will allow unencrypted IPv4 and IPv6 connections. Again, there are two ways to do this. Using DNS's CNAME capability or setting the A and AAAA records.
 
 #### Option I: CNAME records
 
-CNAME records in DNS act like a pointer. If we add a CNAME record to our custom domain that points to our proxy name `nginxproxy.fly.dev` then requests for the custom domain's IP address would return the proxy's address and clients would then lookup the IP addresses for the proxy. 
+CNAME records in DNS act like a pointer. If we add a CNAME record to our custom domain that points to our nginx proxy app `my-nginx-proxy.fly.dev` then requests for the custom domain's IP address would return the proxy's address and clients would then lookup the IP addresses for the proxy. 
 
 It's the quickest way to get set up, but there are catches. First, it is ever so slightly slower with that second look up. Second, it limits what you can do with the domain, especially if it's an "Apex domain" - CNAMEs are, according to DNS standards, meant to be the only record in a host's DNS records and so you can't add MX and other essential records to the DNS entry. If you aren't setting up an Apex domain, the CNAME is the quickest way to get going.
 


### PR DESCRIPTION
I was confusing by the original wording, as to me it suggested that fly runs some kind of global nginx proxy. I think changing this to my-nginx-proxy makes it clearer.
BTW: I think the whole page could probably be restructured for clarity and maybe could do a quick start guide for people who already understand the difference between CNAME and A records. 