### PR TITLE
Add language attribute to single-line shell blocks

### DIFF
--- a/app-guides/planetscale.html.md
+++ b/app-guides/planetscale.html.md
@@ -141,7 +141,7 @@ It will ask if you want a PostgreSQL database. Type _N_ (no) as you are using Pl
 
 Finally you are asked if you want to deploy. Type _N_ (no). Why not deploy now? This sample application expects a `DATABASE_URL` connection string to be available as a secret environment variable. Now that your app is staged on Fly we can set that. So run this command (setting its value as a comma-separated list of _all_ of the connection strings you have from PlanetScale). The sample app expects the **first one** to be the connection string for your **primary database** (the region you created the PlanetScale database in). Any _subsequent_ ones are the connection strings for any read-only regions. The resulting command you need to run will look something like this. Note the comma _between_ the connection strings:
 
-```
+```cmd
 fly secrets set DATABASE_URL='mysql://your-primary-region-one,mysql://optional-for-read-region,mysql://optional-for-another-read-region'
 ```
 
@@ -149,7 +149,7 @@ You should see `Secrets are staged for the first deployment`.
 
 Now you can go ahead and deploy the app:
 
-```
+```cmd
 fly deploy
 ```
 
@@ -206,7 +206,7 @@ So far the app has _only_ used the primary database. Since there is only _one_ v
 
 Now we'll test the read-only regions. Start by permitting the app to run in more regions. You can see which regions the app can run in using:
 
-```
+```cmd
 fly regions list
 ```
 
@@ -220,13 +220,13 @@ Backup Region:
 
 Adjust that to permit more regions. For our test database, we made a primary in `eu-west-1` (Ireland), and two read-only regions in `us-west-2` (US) and `ap-southeast-2` (Australia). Suitably distributed to test the latency. And so we'll adjust the regions our sample Fly app can run in to use roughly matching Fly regions:
 
-```
+```cmd
 fly regions set lhr sea syd
 ```
 
 Now we need to scale the app to put a vm in each of those regions:
 
-```
+```cmd
 fly scale count 3 --max-per-region=1
 ```
 

--- a/getting-started/edgedb.html.md
+++ b/getting-started/edgedb.html.md
@@ -108,7 +108,7 @@ flyctl status
 
 Now we need to persist the auto-generated TLS certificate to make sure it survives EdgeDB app restarts. (If you’ve provided your own certificate, skip this step).
 
-```
+```cmd
 flyctl ssh console \
   -C "edgedb-show-secrets.sh --format=toml EDGEDB_SERVER_TLS_KEY EDGEDB_SERVER_TLS_CERT" \
   | tr -d '\r' | flyctl secrets import
@@ -122,7 +122,7 @@ Your EdgeDB instance should be available from any other app in the same organiza
 
 To connect to this database from another app, create a secret called `EDGEDB_DSN` containing this value. EdgeDB's client libraries read this environment variable and will connect to your instance automatically.
 
-```
+```cmd
 flyctl secrets set \
   EDGEDB_DSN=edgedb://edgedb:mysecretpassword@myedgedb.internal:8080 \
   --app my-other-app

--- a/getting-started/multi-region-databases.html.md
+++ b/getting-started/multi-region-databases.html.md
@@ -22,7 +22,7 @@ This guide is all about PostgreSQL, but the deployment topology will work with M
 
 If you don't already have a PostgreSQL cluster running, you can create one with the `fly` CLI:
 
-```
+```cmd
 fly pg create --name chaos-postgres --region scl
 ```
 
@@ -43,7 +43,7 @@ If you already have a Postgres cluster called `chaos-postgres` running, you can 
 
 Then, add one new VM for each new volume:
 
-```
+```cmd
 fly scale count 6 -a chaos-postgres
 ```
 
@@ -64,7 +64,7 @@ d8e8a317       app     2       syd    run     running (replica)       3 total, 3
 ### Attach database to application
 To hook your app up to your cluster, run the `attach` command from your application directory:
 
-```
+```cmd
 fly pg attach --postgres-app chaos-postgres
 ```
 
@@ -132,7 +132,7 @@ You can allocate an IPv4 address by running the following:
 fly ips allocate-v4
 ```
 If your network supports IPv6:
-```
+```cmd
 fly ips allocate-v6
 ```
 

--- a/reference/metrics.html.md
+++ b/reference/metrics.html.md
@@ -37,15 +37,15 @@ Querying works like any Prometheus server. The only gotcha is you'll need to aut
 
 **Find your Organization slug**
 
-```
+```cmd
 flyctl orgs list
 ```
 
- will show you all your organization memberships with their names and slugs.
+will show you all your organization memberships with their names and slugs.
 
 **Get an access token**
 
-```
+```cmd
 flyctl auth token
 ```
 
@@ -258,4 +258,3 @@ All series pulled into our Prometheus cluster will include the following labels:
 - `instance`: your app instance ID
 
 If your app exposes metric labels with the same names, they will be overwritten.
-

--- a/reference/monorepo.html.md
+++ b/reference/monorepo.html.md
@@ -15,15 +15,15 @@ The first argument to `flyctl deploy` is the path to the working directory for y
 
 You can override this by providing a path:
 
-```
-$ flyctl deploy ./path/to/app
+```cmd
+flyctl deploy ./path/to/app
 ```
 
 ### `fly.toml` path   
 
 By default, `flyctl deploy` will look for a `fly.toml` in the working directory. You can override this using the `--config` flag. 
 
-```
+```cmd
 flyctl deploy --config ./path/to/fly.toml
 ```
 
@@ -31,7 +31,7 @@ flyctl deploy --config ./path/to/fly.toml
 
 By default, `flyctl deploy` will look for a `Dockerfile` in the working directory. You can override this using the `--dockerfile` flag. 
 
-```
+```cmd
 flyctl deploy --dockerfile ./path/to/Dockerfile
 ```
 
@@ -63,12 +63,12 @@ flyctl deploy --dockerfile ./Dockerfile.staging
 
 **Deploy a subdirectory**
 
-```
+```cmd
 flyctl deploy ./apps/api
 ```
 
 **Share a multi-stage Dockerfile with several fly apps**
 
-```
+```cmd
 flyctl deploy --config fly.api.toml --build-target api
 ```


### PR DESCRIPTION
- Guides and Examples / Use a PlanetScale Database
- Quickstart Guides / Multi-region PostgreSQL
- Quickstart Guides / Run EdgeDB on Fly
- Fly Reference / Metrics
- Fly Reference / Monorepo Apps