### PR TITLE
Fix 404ing link

### DIFF
--- a/rails/the-basics/sidekiq.html.md
+++ b/rails/the-basics/sidekiq.html.md
@@ -23,7 +23,7 @@ If you don't see `REDIS_URL` in the command above, Sidekiq won't be able to conn
 
 ## Run multiple processes
 
-Most production Rails applications run background workers in a seperate process. There's a few ways of accomplishing that on Fly that are [outlined in the multiple-proccesses](/docs/app-guides/multiple-processes.html.md) docs.
+Most production Rails applications run background workers in a seperate process. There's a few ways of accomplishing that on Fly that are [outlined in the multiple-proccesses](/docs/app-guides/multiple-processes) docs.
 
 The quickest way to run multiple processes in one region is via the `processes` directive in the `fly.toml` file.
 


### PR DESCRIPTION
On https://fly.io/docs/rails/the-basics/sidekiq/, the "outlined in the multiple-proccesses" link returns a Nginx 404 page when you click it. It needs to be https://fly.io/docs/app-guides/multiple-processes not https://fly.io/docs/app-guides/multiple-processes.html.md.