### PR TITLE
Avoid using `rake` for `rails` subcommand

### DIFF
--- a/rails/the-basics/run-tasks-and-consoles.html.md
+++ b/rails/the-basics/run-tasks-and-consoles.html.md
@@ -11,7 +11,7 @@ Running one-off tasks on fly can be accomplished via `fly console`.
 To execute rake on fly, run:
 
 ```cmd
-fly ssh console -C "bin/rake db:migrate"
+fly ssh console -C "bin/rake my_rake_task"
 ```
 
 To list all the available tasks, run:


### PR DESCRIPTION
`bin/rails` is the preferred way to run the `db:migrate` subcommand (and all other Rails subcommands).  Therefore, it would be better to suggest an arbitrary task for the `bin/rake` example.