### PR TITLE
Consider credentials as sensitive data

### DIFF
--- a/rails/the-basics/configuration.html.md
+++ b/rails/the-basics/configuration.html.md
@@ -22,11 +22,11 @@ fly secret set SUPER_SECRET_KEY=password1234
 
 ### Non-sensitive variables
 
-Variables that don't have sensitive data, like credentials, can be set in the `fly.toml` file under the `[env]` directive. An example file might look like:
+Variables that don't have sensitive data can be set in the `fly.toml` file under the `[env]` directive. An example file might look like:
 
 ```toml
 [env]
-  LOCALE=en
+  RAILS_LOG_TO_STDOUT = x
 ```
 
 ### View the variables


### PR DESCRIPTION
Credentials often include sensitive data, so it would be better to not suggest putting them in `fly.toml`.

This commit also changes the `fly.toml` example variable from `LOCALE` to `RAILS_LOG_TO_STDOUT`, to avoid implying that `LOCALE` has any effect by default, such as setting `I18n.default_locale`.  (Note that `RAILS_LOG_TO_STDOUT` only [has to be a nonblank string][1], so the example value used here is `x`, to avoid a boolean connotation.)

[1]: https://github.com/rails/rails/blob/v7.0.3/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L97