### PR TITLE
Small typo in postgres user role docs

### DIFF
--- a/reference/postgres.html.md
+++ b/reference/postgres.html.md
@@ -189,7 +189,7 @@ A Postgres cluster is configured with three users when created:
 
 - `postgres` - a role with superuser and login privileges that was created for you along with the cluster. Since the `postgres` role has superuser rights, it's recommended that you only use it for admin tasks and create new users with access restricted to the minimum necessary for applications
 - `flypgadmin` - this role is used internally by fly to configure and query the postgres cluster
-- `repluser` - this is the user replica servers us for replication from the leader
+- `repluser` - this is the user replica servers use for replication from the leader
 
 You can view a list of users using `flyctl`
 


### PR DESCRIPTION
There was a small typo in the user role docs where is started `us` rather than `use` ... see commit for context!