### PR TITLE
Remove Puma `-C config/puma.rb` option

### DIFF
--- a/rails/the-basics/sidekiq.html.md
+++ b/rails/the-basics/sidekiq.html.md
@@ -36,7 +36,7 @@ Add the following to the `fly.toml`:
 
 ```toml
 [processes]
-web = "bundle exec puma -C config/puma.rb"
+web = "bundle exec puma"
 worker = "bundle exec sidekiq"
 ```
 


### PR DESCRIPTION
Since Puma v2.8.0 (puma/puma@7d7a1fbebe4dde2edf045ada80730ce4f41c4cd5), Puma will automatically use `config/puma.rb` if it is present, so specifying `-C config/puma.rb` is not necessary.  (See the [Configuration File section][1] of the Puma README for more information.)

[1]: https://github.com/puma/puma/blob/v5.6.4/README.md#configuration-file