### PR TITLE
Remove `--postgres-app` Flag From Documentation Related to `fly attach`

### DIFF
--- a/flyctl/cmd/flyctl_postgres_detach.md
+++ b/flyctl/cmd/flyctl_postgres_detach.md
@@ -12,7 +12,6 @@ flyctl postgres detach [POSTGRES APP] [flags]
   -a, --app string            Application name
   -c, --config string         Path to application configuration file
   -h, --help                  help for detach
-      --postgres-app string   Name of the postgres app to detach
 ~~~
 
 ## Global Options

--- a/getting-started/edgedb.html.md
+++ b/getting-started/edgedb.html.md
@@ -72,7 +72,7 @@ Let's discuss what's going on with all these secrets.
 Let's attach `mypostgres` to `myedgedb`.
 
 ```cmd
-flyctl postgres attach --postgres-app mypostgres --app myedgedb
+flyctl postgres attach mypostgres --app myedgedb
 ```
 
 This sets the value of `DATABASE_URL` in the `myedgedb` app and creates a new role called `myedgedb` in our Postgres database. By default, this role doesn't have the full set of permissions EdgeDB needs to run. To change that, open a connection to your Postgres instance.

--- a/getting-started/legacy_elixir.html.md.erb
+++ b/getting-started/legacy_elixir.html.md.erb
@@ -285,7 +285,7 @@ We can take the defaults which select the lowest values for CPU, size, etc. This
 We use `flyctl` to attach our app to the database which also sets our needed `DATABASE_URL` ENV value.
 
 ```cmd
-fly postgres attach --postgres-app hello-elixir-db
+fly postgres attach hello-elixir-db
 ```
 ```output
 Postgres cluster hello-elixir-db is now attached to fly-elixir

--- a/getting-started/multi-region-databases.html.md
+++ b/getting-started/multi-region-databases.html.md
@@ -65,7 +65,7 @@ d8e8a317       app     2       syd    run     running (replica)       3 total, 3
 To hook your app up to your cluster, run the `attach` command from your application directory:
 
 ```cmd
-fly pg attach --postgres-app chaos-postgres
+fly pg attach chaos-postgres
 ```
 
 This installs a `DATABASE_URL` secret in your application, which is available to your app processes as an environment variable. The command also prints the connection string to the console.

--- a/rails/the-basics/backup-and-restoring-data.html.md
+++ b/rails/the-basics/backup-and-restoring-data.html.md
@@ -113,13 +113,13 @@ This provisions and launches a new Fly database server with the snapshot you spe
 Detach the Rails application from the current Postgres cluster:
 
 ```cmd
-fly postgres detach --postgres-app my-rails-app-db
+fly postgres detach my-rails-app-db
 ```
 
 Then attach it to the new cluster:
 
 ```cmd
-fly postgres attach --postgres-app my-rails-app-db-restored
+fly postgres attach my-rails-app-db-restored
 ```
 
 Now your application is pointing at the restored database.

--- a/reference/postgres.html.md
+++ b/reference/postgres.html.md
@@ -153,7 +153,7 @@ psql postgres://postgres:secret123@appname.internal:5432
 Using the superuser credentials, you can create databases, users, and whatever else you need for your apps. But we also have the `flyctl postgres attach` shortcut:
 
 ```
-flyctl postgres attach --app <app-name> --postgres-app <postgres-app-name>
+flyctl postgres attach --app <app-name> <postgres-app-name>
 ```
 
 When you attach an app to Postgres, a number of things happen:
@@ -168,7 +168,7 @@ When the Attached app starts it will find an environment variable `DATABASE_URL`
 Use `flyctl postgres detach` to remove postgres from the app.
 
 ```
-flyctl postgres detach --app <app-name> --postgres-app <postgres-app-name>
+flyctl postgres detach --app <app-name> <postgres-app-name>
 ```
 
 This will revoke access to the attachment's role, remove the role, and remove the `DATABASE_URL` secret. The database will not be removed.


### PR DESCRIPTION
# Overview

There is a reference to a `--postgres-app` flag in several examples and guides, however based on version `v0.0.377` this flag no longer exists. This flag was also removed from the docs recently in pr https://github.com/superfly/docs/pull/237 .

This pr just removes the `--postgres-app` flag from each example. And, for reference here is a session screenshot from attempting to use this flag with `fly attach` and `fly detach`.

<img width="775" alt="Screen Shot 2022-08-21 at 4 29 18 PM" src="https://user-images.githubusercontent.com/1526888/185815697-09bc9599-e072-44c2-9245-9c1c2b57479c.png">

