### PR TITLE
Update the Set API key section

### DIFF
--- a/app-guides/terraform-iac-getting-started.html.md.erb
+++ b/app-guides/terraform-iac-getting-started.html.md.erb
@@ -21,7 +21,7 @@ Go ahead and [download](https://learn.hashicorp.com/tutorials/terraform/install-
 
 ## Set API key
 
-`export FLY_API_TOKEN=$(fly auth token)`
+First make sure you're logged in by running `flyctl auth login`, after which you can run `export FLY_API_TOKEN=$(flyctl auth token)` to obtain a token.
 
 ## Open wireguard tunnel
 


### PR DESCRIPTION
I'm not aware of a `fly` command, but `flyctl` provides the same `auth token` sub-commands. So I am assuming it should be `flyctl` instead of `fly`? Also, clarify that you _need_ to be logged in before you can request a token.