### PR TITLE
Remove single quotes when migrating Heroku config

### DIFF
--- a/rails/getting-started/migrate-from-heroku.html.md
+++ b/rails/getting-started/migrate-from-heroku.html.md
@@ -75,7 +75,7 @@ There's still work to be done to move more Heroku stuff over, so don't worry if 
 To see all of your Heroku env vars and secrets, run:
 
 ```cmd
-heroku config -s | grep -v -e "DATABASE_URL" -e "REDIS_URL" -e "REDIS_TLS_URL" | fly secrets import
+heroku config -s | grep -v -e "DATABASE_URL" -e "REDIS_URL" -e "REDIS_TLS_URL" | sed -e "s/='//" -e "s/'$//" | fly secrets import
 ```
 
 This command exports the Heroku secrets, excludes `DATABASE_URL` and `REDIS_URL`, and imports them into Fly.

--- a/rails/getting-started/migrate-from-heroku.html.md
+++ b/rails/getting-started/migrate-from-heroku.html.md
@@ -75,7 +75,7 @@ There's still work to be done to move more Heroku stuff over, so don't worry if 
 To see all of your Heroku env vars and secrets, run:
 
 ```cmd
-heroku config -s | grep -v -e "DATABASE_URL" -e "REDIS_URL" -e "REDIS_TLS_URL" | sed -e "s/='//" -e "s/'$//" | fly secrets import
+heroku config -s | grep -v -e "DATABASE_URL" -e "REDIS_URL" -e "REDIS_TLS_URL" | sed -e "s/='/=/" -e "s/'$//" | fly secrets import
 ```
 
 This command exports the Heroku secrets, excludes `DATABASE_URL` and `REDIS_URL`, and imports them into Fly.


### PR DESCRIPTION
Heroku will wrap some configuration values with single quotes; this uses `sed` to remove those quotes.