### PR TITLE
doc: correct migration from heroku postgres to assure data is created incorrect db

### DIFF
--- a/rails/getting-started/migrate-from-heroku.html.md
+++ b/rails/getting-started/migrate-from-heroku.html.md
@@ -108,10 +108,10 @@ Set the `HEROKU_DATABASE_URL` variable in your Fly environment.
 fly secrets set HEROKU_DATABASE_URL=$(heroku config:get DATABASE_URL)
 ```
 
-Alright, lets start the transfer.
+Alright, lets start the transfer. Run this inside your fly environment:
 
 ```cmd
-pg_dump --no-owner -C -d $HEROKU_DATABASE_URL | psql -d $DATABASE_URL
+pg_dump --no-owner --clean -d $HEROKU_DATABASE_URL | psql -d $DATABASE_URL
 ```
 
 After the database transfers unset the `HEROKU_DATABASE_URL` variable.


### PR DESCRIPTION
Note: `-C` (`--create`) is _not_ `-c` (`--clean`). The former leads to the creation of a db with the name of the db in heroku, but we need to copy the data into the db of the given `$DATABASE_URL`.