### PR TITLE
Update [env] code snippet to match correct format

### DIFF
--- a/languages-and-frameworks/dockerfile.html.md.erb
+++ b/languages-and-frameworks/dockerfile.html.md.erb
@@ -33,8 +33,8 @@ Most Dockerfiles expect some configuration settings through `ENV`. The generated
 
 ```toml
 [env]
-  MY_SPECIAL_ENV=some_value
-  MAX_PLAYER_COUNT=15
+  MY_SPECIAL_ENV = "some_value"
+  MAX_PLAYER_COUNT = "15"
 ```
 
 Add whatever values your Dockerfile or container requires.


### PR DESCRIPTION
I was following [Deploy via Dockerfile](https://fly.io/docs/languages-and-frameworks/dockerfile/) guide an encountered errors when defining my environment variables in `fly.toml`. After consulting the [fly.toml env vars docs](https://fly.io/docs/reference/configuration/#the-env-variables-section) and following that format everything worked fine.

This PR updates the `fly.toml` code snippet to the correct format.

