### PR TITLE
Small changes to the getting-started docs

### DIFF
--- a/flyctl/installing.html.md
+++ b/flyctl/installing.html.md
@@ -27,7 +27,7 @@ If not, you can run the install script:
 ```cmd
 curl -L https://fly.io/install.sh | sh
 ```
-After that, you should add the flyctl directory to your shell rc file. Check the output of the install script for the exact command. Copy, paste and run it and the `flyctl` keyword will be available everywhere. Or for maximum efficiency, you can use the `fly` keyword! 
+After that, you should add the flyctl directory to your shell rc file. Check the output of the install script for the exact command. Copy, paste and run it and the `flyctl` command will be available everywhere. Or for maximum efficiency, you can use the `fly` command! 
 
 <h2 id="linux" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
   <a href="#linux" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>

--- a/flyctl/installing.html.md
+++ b/flyctl/installing.html.md
@@ -27,6 +27,7 @@ If not, you can run the install script:
 ```cmd
 curl -L https://fly.io/install.sh | sh
 ```
+After that, you should add the flyctl directory to your shell rc file. Check the output of the install script for the exact command. Copy, paste and run it and the `flyctl` keyword will be available everywhere. Or for maximum efficiency, you can use the `fly` keyword! 
 
 <h2 id="linux" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
   <a href="#linux" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>

--- a/hands-on/partials/_launch-app.html.md
+++ b/hands-on/partials/_launch-app.html.md
@@ -8,7 +8,7 @@ flyctl launch --image flyio/hellofly:latest
 ```output 
 ? App Name (leave blank to use an auto-generated name):
 ```
-Here you can enter the name of the app.
+Here you can enter the name of the app. Please note that you can only use numbers, lowercase letters and dashes.
 ```output 
 ? Select organization: Personal (personal)
 ```

--- a/hands-on/partials/_launch-app.html.md
+++ b/hands-on/partials/_launch-app.html.md
@@ -1,14 +1,22 @@
 Fly.io allows you to deploy any kind of app as long as it is packaged in a **Docker image**. That also means you can just deploy a Docker image and as it happens we have one ready to go in `flyio/hellofly:latest`. 
 
-Each Fly.io application needs a `fly.toml` file to tell the system how we'd like to deploy it. That file can be automatically generated with the `flyctl launch` command. 
+Each Fly.io application needs a `fly.toml` file to tell the system how we'd like to deploy it. That file can be automatically generated with the `flyctl launch` command, which will ask a few questions to set everything up. Let's run through it now: 
 
 ```cmd
 flyctl launch --image flyio/hellofly:latest
 ```
 ```output 
+? App Name (leave blank to use an auto-generated name):
+```
+Here you can enter the name of the app.
+```output 
 ? Select organization: Personal (personal)
 ```
 **Organizations**: Organizations are a way of sharing applications and resources between Fly.io users. Every Fly.io account has a personal organization, called `personal`, which is only visible to your account. Let's select that for this guide.
+
+<div class="callout">
+    If you did not add another organization to your account, the `personal` organization will be selected automatically.  
+</div>
 
 ```output
 ? Select region: ord (Chicago, Illinois (US))
@@ -21,6 +29,11 @@ Next, you'll be prompted to select a region to deploy in. The closest region to 
 You will also be prompted for credit card payment information, required for charges outside the free allowances on Fly.io. See [Pricing](/docs/about/pricing) for more details.
 
 </div>
+
+```output
+? Would you like to set up a Postgresql database now? (y/N)
+```
+Lastly, the CLI will ask if you need a Postgresql database. You can reply no for now.
 
 At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. The `fly.toml` file now contains a default configuration for deploying your app.
 

--- a/hands-on/partials/_next.html.md
+++ b/hands-on/partials/_next.html.md
@@ -7,7 +7,8 @@ If you're all about the code, then these guides will get you deploying from your
 * [Learn how to build and deploy the hellofly application from Go source](/docs/getting-started/golang/)
 * [Deploying a Node application with Fly.io](/docs/getting-started/node/)
 * [Deploying a Deno application with Fly.io](/docs/getting-started/deno/)
-* [Deploying a Laravel application with Fly.io](/docs/getting-started/laravel/)
+* [Deploying a Laravel application with Fly.io](/docs/laravel/)
+* [Deploying a Rails application with Fly.io](/docs/rails/)
 
 And if you want to automate your deployments (who doesn't), check out:
 

--- a/hands-on/partials/_next.html.md
+++ b/hands-on/partials/_next.html.md
@@ -7,6 +7,7 @@ If you're all about the code, then these guides will get you deploying from your
 * [Learn how to build and deploy the hellofly application from Go source](/docs/getting-started/golang/)
 * [Deploying a Node application with Fly.io](/docs/getting-started/node/)
 * [Deploying a Deno application with Fly.io](/docs/getting-started/deno/)
+* [Deploying a Laravel application with Fly.io](/docs/getting-started/laravel/)
 
 And if you want to automate your deployments (who doesn't), check out:
 


### PR DESCRIPTION
- described all CLI prompts from the fly launch command
- mentioned that the flyctl directory should be added to the rc file
- add a link to getting started with laravel on fly.io