### PR TITLE
Laravel docs: Customize Deploys

### DIFF
--- a/laravel/index.html.md.erb
+++ b/laravel/index.html.md.erb
@@ -84,7 +84,7 @@ The `fly launch` adds some files to your code base.
 1. `Dockerfile` - Used to build a container image that is run in fly
 2. `.dockerignore` - Used to ensure certain files don't make its way into your repository
 3. `fly.toml` - Configuration specific to hosting on Fly
-4. `docker` - A directory containing configuration files for running Nginx/PHP in a container
+4. `.fly` (formerly `docker`) - A directory containing configuration files for running Nginx/PHP in a container
 
 Running `fly launch` (and later `fly deploy`) uses the `Dockerfile` to build a container image, copying your application files into the resulting image.
 

--- a/laravel/the-basics/cron-and-queues.html.md
+++ b/laravel/the-basics/cron-and-queues.html.md
@@ -2,7 +2,7 @@
 title: Cron and Queues
 layout: framework_docs
 objective: Run queue workers and Laravel's scheduler via cron
-order: 5
+order: 6
 ---
 
 You may need to run Laravel's scheduler (via cron) or queue workers.

--- a/laravel/the-basics/cron-and-queues.html.md
+++ b/laravel/the-basics/cron-and-queues.html.md
@@ -29,6 +29,8 @@ The line `app = ""` is needed (with an empty string!) to keep a process group fo
 
 We created an additional process group `cron = "cron -f"`. This tells the VM to run the cron daemon rather than start the web server.
 
+Edit your `Dockerfile` to add additional cron definitions to `/etc/cron.d` if you need. The `cron -f` command will load any cron definitions found in any files in that location.
+
 ## Queue Worker
 
 We can start an instance of our queue worker by adding another process. In this example, we'll add a `worker` process group in addition to `app` and `cron` processes.

--- a/laravel/the-basics/customizing-deployments.html.md
+++ b/laravel/the-basics/customizing-deployments.html.md
@@ -1,0 +1,35 @@
+---
+title: Customizing Deployments
+layout: framework_docs
+objective: Customize how Fly deploys your Laravel application.
+order: 6
+---
+
+The `fly launch` command sets you up with a useful starting point, but you can customize just about everything to meet your needs. Here's a few things that might be useful to know.
+
+## User Scripts
+
+The `fly launch` command generated a `.fly/scripts` directory. Any file in here ending in `.sh` will run anytime your application is started (via `bash`).
+
+These scripts are checked for in the `ENTRYPOINT` script before anything else is ran.
+
+By default, `fly launch` generates the script `.fly/scripts/caches.sh`, which runs various artisan cache commands such as `config:cache`, `route:cache`, and `view:cache`.
+
+You can enable or disable those as you see fit, as well as add your own `.sh` scripts!
+
+## Release Command
+
+You may want to use the [`release_command`](/docs/reference/configuration/#the-deploy-section) to perform database migrations or other tasks. 
+
+These types of tasks could be a `.sh` user-script, or `release_command` defined in your `fly.toml` file - it's up to you and your use case.
+
+If you need a script to do something (or NOT do something) during a release command, your scripts can detect the presence of the `RELEASE_COMMAND` environment variable.
+
+```bash
+if [ -z "$RELEASE_COMMAND" ]; then
+    # We are NOT in a temporary VM, run as normal...
+else
+    # We are in the temporary VM created
+    # for release commands...
+fi
+```

--- a/laravel/the-basics/customizing-deployments.html.md
+++ b/laravel/the-basics/customizing-deployments.html.md
@@ -7,23 +7,23 @@ order: 2
 
 The `fly launch` command sets you up with a useful starting point, but you can customize just about everything to meet your needs. Here's a few things that might be useful to know.
 
-## User Scripts
+## Startup Scripts
 
 The `fly launch` command generated a `.fly/scripts` directory. Any file in here ending in `.sh` will run (via `bash`) anytime your application is started.
 
-User scripts are run from the `ENTRYPOINT` script before anything else is ran.
+These scripts are called from the Docker `ENTRYPOINT` script (`.fly/entrypoint.sh`) before anything else is ran.
 
-By default, `fly launch` generates the script `.fly/scripts/caches.sh`, which runs various artisan cache commands such as `config:cache`, `route:cache`, and `view:cache`.
+By default, `fly launch` generates a startup script `.fly/scripts/caches.sh`, which runs various artisan cache commands such as `config:cache`, `route:cache`, and `view:cache`.
 
 You can enable or disable those as you see fit, as well as add your own `.sh` scripts!
 
 ## Release Command
 
-You may want to use the [`release_command`](/docs/reference/configuration/#the-deploy-section) to perform database migrations or other tasks. 
+You may want to use the [`release_command`](/docs/reference/configuration/#the-deploy-section) to perform database migrations or other tasks. The release command is run in a temporary VM that is created just before your application is deployed and released. This potentially helps with zero-downtime deploys.
 
-These types of tasks could be a `.sh` user script, or `release_command` defined in your `fly.toml` file - it's up to you and your use case.
+Note, however, that any Startup Script in `.fly/scripts` will also be run when a `release_command` is used.
 
-If you need a script to do something (or NOT do something) during a release command, your scripts can detect the presence of the `RELEASE_COMMAND` environment variable.
+If you need a startup script to do something (or NOT do something) during a release command, your scripts can detect the presence of the `RELEASE_COMMAND` environment variable.
 
 ```bash
 if [ -z "$RELEASE_COMMAND" ]; then
@@ -33,3 +33,5 @@ else
     # for release commands...
 fi
 ```
+
+Note that [release commands](/docs/reference/configuration/#the-deploy-section) run in a temporary VM. Any file-based changes done in the release command (such as `artisan view:cache`) will be lost when the release command is completed. The subsequently deployed application is a totally different VM.

--- a/laravel/the-basics/customizing-deployments.html.md
+++ b/laravel/the-basics/customizing-deployments.html.md
@@ -9,9 +9,9 @@ The `fly launch` command sets you up with a useful starting point, but you can c
 
 ## User Scripts
 
-The `fly launch` command generated a `.fly/scripts` directory. Any file in here ending in `.sh` will run anytime your application is started (via `bash`).
+The `fly launch` command generated a `.fly/scripts` directory. Any file in here ending in `.sh` will run (via `bash`) anytime your application is started.
 
-These scripts are checked for in the `ENTRYPOINT` script before anything else is ran.
+User scripts are run from the `ENTRYPOINT` script before anything else is ran.
 
 By default, `fly launch` generates the script `.fly/scripts/caches.sh`, which runs various artisan cache commands such as `config:cache`, `route:cache`, and `view:cache`.
 
@@ -21,7 +21,7 @@ You can enable or disable those as you see fit, as well as add your own `.sh` sc
 
 You may want to use the [`release_command`](/docs/reference/configuration/#the-deploy-section) to perform database migrations or other tasks. 
 
-These types of tasks could be a `.sh` user-script, or `release_command` defined in your `fly.toml` file - it's up to you and your use case.
+These types of tasks could be a `.sh` user script, or `release_command` defined in your `fly.toml` file - it's up to you and your use case.
 
 If you need a script to do something (or NOT do something) during a release command, your scripts can detect the presence of the `RELEASE_COMMAND` environment variable.
 

--- a/laravel/the-basics/customizing-deployments.html.md
+++ b/laravel/the-basics/customizing-deployments.html.md
@@ -2,7 +2,7 @@
 title: Customizing Deployments
 layout: framework_docs
 objective: Customize how Fly deploys your Laravel application.
-order: 6
+order: 2
 ---
 
 The `fly launch` command sets you up with a useful starting point, but you can customize just about everything to meet your needs. Here's a few things that might be useful to know.

--- a/laravel/the-basics/customizing-deployments.html.md
+++ b/laravel/the-basics/customizing-deployments.html.md
@@ -34,4 +34,4 @@ else
 fi
 ```
 
-Note that [release commands](/docs/reference/configuration/#the-deploy-section) run in a temporary VM. Any file-based changes done in the release command (such as `artisan view:cache`) will be lost when the release command is completed. The subsequently deployed application is a totally different VM.
+Note that [release commands](/docs/reference/configuration/#the-deploy-section) run in a temporary VM. Any file-based changes done in the release command (such as `artisan view:cache`) will be lost when the release command is completed. The subsequently deployed application is a totally different VM. Commands that result in file-based changes (such as `artisan view:cache`) is best run as a Startup Script.

--- a/laravel/the-basics/databases.html.md
+++ b/laravel/the-basics/databases.html.md
@@ -2,7 +2,7 @@
 title: Databases
 layout: framework_docs
 objective: Notes and configurations on connecting with Databases
-order: 4
+order: 5
 ---
 No application is complete without a data store!
 

--- a/laravel/the-basics/logging-stack-traces.html.md
+++ b/laravel/the-basics/logging-stack-traces.html.md
@@ -2,7 +2,7 @@
 title: Logging Stack Traces
 layout: framework_docs
 objective: Adjust Laravel's logging configuration to get a full stack trace.
-order: 3
+order: 4
 ---
 
 By default, we set the Logging output to use a `JsonFormatter`. This makes the log output a bit cleaner, but has the trade-off of not showing you a full stack trace. You just get the exception messages.

--- a/laravel/the-basics/post-deployment.html.md
+++ b/laravel/the-basics/post-deployment.html.md
@@ -2,7 +2,7 @@
 title: Post Deployment
 layout: framework_docs
 objective: Interact with a deployed Laravel application.
-order: 2
+order: 3
 ---
 
 Once you have your Laravel application up and running in Fly.io, it helps to know how to execute commands on it and review events happening in your application.

--- a/reference/configuration.html.md
+++ b/reference/configuration.html.md
@@ -120,13 +120,15 @@ This section configures deployment-related settings such as the release command 
   release_command = "bundle exec rails db:migrate"
 ```
 
-This command runs in a temporary VM - using the successfully built release - *before* that release is deployed. This is useful for running Postgres database migrations.
+This command runs in a temporary VM - using the successfully built release - *before* that release is deployed. This is useful for running database migrations.
 
 The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes.  Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` or `ENTRYPOINT` in your Dockerfile.
 
 A non-zero exit status from this command will stop the deployment. `fly deploy` will display logs from the command. Logs are available via `fly logs` as well.
 
 To ensure the command runs in a specific region - say `dfw` - set `PRIMARY_REGION = 'dfw'` on in your application environment in `fly.toml` or with `fly deploy -e PRIMARY_REGION=dfw`. Setting `PRIMARY_REGION` is important if when running [database replicas in multiple regions](/docs/getting-started/multi-region-databases).
+
+The environment variable `RELEASE_COMMAND=1` is set for you within the temporary release VM. This might be useful if you need to customize your Dockerfile `ENTRYPOINT` to behave differently within a release VM.
 
 #### Picking a deployment strategy
 


### PR DESCRIPTION
1. Added a mention in the `release_commands` docs about new env var `RELEASE_COMMAND=1` that is set in the temporary VM created to run release commands
2. Added a new section to the Laravel Docs "Customizing Deployments" to mention a new feature in the Laravel launcher - user-scripts, that are run whenever an app VM is started (via `ENTRYPOINT`).
    - this section will be useful for future customization notes as well