### PR TITLE
Fix link to next section in Rails > Getting Started

### DIFF
--- a/rails/getting-started/index.html.md
+++ b/rails/getting-started/index.html.md
@@ -426,4 +426,4 @@ Now that you have seen it up and running, a few things are worth noting:
   * `fly ssh console` can be used to ssh into your VM. `fly ssh console -C "/app/bin/rails console"` can be used to open a rails console.
 
 Now that you have seen how to deploy a trivial application, it is time
-to move on to [The Basics](../../the-basics/).
+to move on to [The Basics](../the-basics/).


### PR DESCRIPTION
Currently the link in this page [available here](https://fly.io/docs/rails/getting-started/) points to https://fly.io/docs/the-basics/ which 404's. I think this is the intended link.