### PR TITLE
Fix broken link to "The Basics"

### DIFF
--- a/rails/getting-started/index.html.md
+++ b/rails/getting-started/index.html.md
@@ -426,4 +426,4 @@ Now that you have seen it up and running, a few things are worth noting:
   * `fly ssh console` can be used to ssh into your VM. `fly ssh console -C "/app/bin/rails console"` can be used to open a rails console.
 
 Now that you have seen how to deploy a trivial application, it is time
-to move on to [The Basics](../../the-basics/).
+to move on to [The Basics](../../rails/the-basics/).


### PR DESCRIPTION
The last sentence on this page says `it is time to move on to [The Basics](https://fly.io/docs/the-basics/).` but that link 404's.

However on the rendered page just below it there's a list of "Additional Resources" which includes a link to `[The Basics](https://fly.io/docs/rails/the-basics/)` which works -- so this PR makes the broken link match the working link.