### PR TITLE
adding spaces to litefs.yml consul section

### DIFF
--- a/laravel/advanced-guides/global-sqlite-litefs.html.md.erb
+++ b/laravel/advanced-guides/global-sqlite-litefs.html.md.erb
@@ -173,8 +173,8 @@ exec: "/init"
 # These environment variables will be available in your Fly.io application.
 # You must specify "experiement.enable_consul" for FLY_CONSUL_URL to be available.
 consul:
-  url: "${FLY_CONSUL_URL}"
-  advertise-url: "http://${HOSTNAME}.vm.${FLY_APP_NAME}.internal:20202"
+    url: "${FLY_CONSUL_URL}"
+    advertise-url: "http://${HOSTNAME}.vm.${FLY_APP_NAME}.internal:20202"
 ```
 
 ### _Update Dockerfile with LiteFS configuration_

--- a/laravel/advanced-guides/global-sqlite-litefs.html.md.erb
+++ b/laravel/advanced-guides/global-sqlite-litefs.html.md.erb
@@ -173,8 +173,11 @@ exec: "/init"
 # These environment variables will be available in your Fly.io application.
 # You must specify "experiement.enable_consul" for FLY_CONSUL_URL to be available.
 consul:
-    url: "${FLY_CONSUL_URL}"
-    advertise-url: "http://${HOSTNAME}.vm.${FLY_APP_NAME}.internal:20202"
+  # Required. The base URL of the Consul server.
+  url: "${FLY_CONSUL_URL}"
+
+  # Required. The URL that litefs is accessible on.
+  advertise-url: "http://${HOSTNAME}.vm.${FLY_APP_NAME}.internal:20202"   
 ```
 
 ### _Update Dockerfile with LiteFS configuration_


### PR DESCRIPTION
The current docs show the items at the same level as `consul` and when they are copied they are copied as is, so its `yml` and spaces are important if we really want the configuration to work

this is how the old page looks like

![image](https://user-images.githubusercontent.com/27624/196680129-624f6d17-623d-4c05-a6dd-6c81bc5ff2ac.png)

and this is how it should look like

![image](https://user-images.githubusercontent.com/27624/196680379-b04a263b-de7a-4bce-b092-a2748af1d0d2.png)
