### PR TITLE
`fly platform vm-sizes` does not show pricing

### DIFF
--- a/reference/scaling.html.md
+++ b/reference/scaling.html.md
@@ -94,7 +94,7 @@ It shows the size (`shared-cpu-1x`), number of CPUs, and memory (in GB or MB).
 
 ### Viewing Available VM Sizes
 
-The `fly platform vm-sizes` command will display the various sizes with cores and memory and current pricing:
+The `fly platform vm-sizes` command will display the various sizes with cores and memory:
 
 ```cmd
 fly platform vm-sizes


### PR DESCRIPTION
the command `fly platform vm-sizes` does not show the current pricing for each vm