### PR TITLE
add obsolete message for old guides

### DIFF
--- a/app-guides/6pndemochat.html.erb
+++ b/app-guides/6pndemochat.html.erb
@@ -11,4 +11,6 @@ categories:
   - 6pn
 date: 2021-01-12
 ---
+
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/6pn-demo-chat/main/README.md") %>

--- a/app-guides/git-gogs-server.html.erb
+++ b/app-guides/git-gogs-server.html.erb
@@ -12,4 +12,5 @@ categories:
   - volumes
 date: 2020-8-20
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/appkata-gogs/main/README.md") %>

--- a/app-guides/global-nginx-proxy.html.md
+++ b/app-guides/global-nginx-proxy.html.md
@@ -11,6 +11,7 @@ categories:
 date: 2020-09-20
 ---
 
+<%= partial "/docs/partials/obsolete_doc" %>
 
 Everything starts with a Fly app on Fly. If you already have an application running somewhere else, and want to get some of the benefits of running it close to users, you can launch a proxy app on Fly. This will forward requests to your _origin_ application for processing.
 

--- a/app-guides/graphql-edge-caching-apollo.html.erb
+++ b/app-guides/graphql-edge-caching-apollo.html.erb
@@ -13,4 +13,6 @@ categories:
 image: https://fly.io/ui/images/continuous-deployment.jpg
 date: 2020-06-21
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
+
 <%= github_render("fly-examples/edge-apollo-cache/master/README.md") %>

--- a/app-guides/graphql-on-fly-with-hasura.html.md
+++ b/app-guides/graphql-on-fly-with-hasura.html.md
@@ -11,6 +11,8 @@ categories:
 date: 2020-09-21
 ---
 
+<%= partial "/docs/partials/obsolete_doc" %>
+
 So you have a PostgreSQL database somewhere in the cloud and you want to modernize how you access it. GraphQL is likely on your list of things you want to implement, but tools like Hasura - which take care of the backend complexity - need to be installed on a server somewhere. Fly can help by putting that server where it needs to be and making API requests faster than ever.
 
 Let's assume you have a Postgres database somewhere...

--- a/app-guides/grpc-and-grpc-web-services.html.erb
+++ b/app-guides/grpc-and-grpc-web-services.html.erb
@@ -10,4 +10,6 @@ categories:
   - lowlevel
 date: 2020-10-22
 ---
+
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/grpc-service/master/README.md") %>

--- a/app-guides/kong-api-gateway.html.erb
+++ b/app-guides/kong-api-gateway.html.erb
@@ -11,5 +11,6 @@ categories:
   - json
 date: 2020-04-23
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
 
 <%= github_render("fly-examples/kong-api-gateway/main/README.md") %>

--- a/app-guides/mqtt.html.erb
+++ b/app-guides/mqtt.html.erb
@@ -12,4 +12,6 @@ categories:
   - volumes
 date: 2020-11-02
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
+
 <%= github_render("fly-examples/appkata-mqtt/main/README.md") %>

--- a/app-guides/nginx-at-the-edge.html.md.erb
+++ b/app-guides/nginx-at-the-edge.html.md.erb
@@ -6,6 +6,8 @@ nav: firecracker
 date: 2020-01-10
 ---
 
+<%= partial "/docs/partials/obsolete_doc" %>
+
 Nginx is a lightweight and powerful proxy server. It runs exceptionally well close to end users, and devs can do a lot with it: everything from manage global redirect rules to full blown apps with OpenResty.
 
 ## _Build an Nginx app_

--- a/app-guides/node-red.html.erb
+++ b/app-guides/node-red.html.erb
@@ -10,6 +10,7 @@ categories:
   - javascript
   - flow
 date: 2020-11-03
-
 ---
+
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/appkata-node-red/main/README.md") %>

--- a/app-guides/openresty-nginx-plus-lua.html.erb
+++ b/app-guides/openresty-nginx-plus-lua.html.erb
@@ -13,4 +13,6 @@ categories:
 date: 2020-07-10
 
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
+
 <%= github_render("fly-examples/openresty-basic/main/README.md") %>

--- a/app-guides/postgres.html.erb
+++ b/app-guides/postgres.html.erb
@@ -11,4 +11,5 @@ categories:
   - development
 date: 2020-11-05
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/postgres/main/README.md") %>

--- a/app-guides/puppeteer-js-renderer.html.erb
+++ b/app-guides/puppeteer-js-renderer.html.erb
@@ -10,5 +10,5 @@ categories:
   - puppeteer
 date: 2020-07-20
 ---
-
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/puppeteer-js-renderer/master/README.md") %>

--- a/app-guides/redis.html.erb
+++ b/app-guides/redis.html.erb
@@ -12,4 +12,5 @@ categories:
   - volumes
 date: 2020-11-07
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/redis/main/README.md") %>

--- a/app-guides/redistls.html.erb
+++ b/app-guides/redistls.html.erb
@@ -13,4 +13,6 @@ categories:
   - certs
 date: 2020-11-10
 ---
+
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/appkata-redistls/main/README.md") %>

--- a/app-guides/run-a-global-image-service.html.md.erb
+++ b/app-guides/run-a-global-image-service.html.md.erb
@@ -17,6 +17,8 @@ date: 2020-05-10
   <img src="/public/images/image-service.jpg" alt="A hand holding scissors and cutting out paper for a scrapbook" class="w:full h:full fit:cover">
 </figure>
 
+<%= partial "/docs/partials/obsolete_doc" %>
+
 For many web applications, the ability to scale, crop and otherwise manipulate images is essential. One way of providing this capability is with a URL-request-driven image service which can retrieve images, process them and deliver them wherever needed.
 
 But that also means provisioning the service globally to keep latency times low which can be its own administrative headache.

--- a/app-guides/smokescreen.html.erb
+++ b/app-guides/smokescreen.html.erb
@@ -10,4 +10,5 @@ categories:
   - security
 date: 2020-12-01
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/smokescreen-example/master/README.md") %>

--- a/app-guides/speed-up-a-heroku-app.html.md.erb
+++ b/app-guides/speed-up-a-heroku-app.html.md.erb
@@ -11,6 +11,8 @@ image: https://fly.io/ui/images/turbo.jpg
 date: 2020-03-10
 ---
 
+<%= partial "/docs/partials/obsolete_doc" %>
+
 <figure class="flex ai:center jc:center w:full r:lg overflow:off mb:4">
   <img src="/public/images/turbo.jpg" alt="A smartphone flying through the air with an app on its screen" class="w:full h:full fit:cover">
 </figure>

--- a/app-guides/vscode-remote.html.erb
+++ b/app-guides/vscode-remote.html.erb
@@ -12,4 +12,5 @@ categories:
   - volumes
 date: 2020-11-20
 ---
+<%= partial "/docs/partials/obsolete_doc" %>
 <%= github_render("fly-examples/vscode-remote/main/README.md") %>

--- a/partials/_obsolete_doc.html.erb
+++ b/partials/_obsolete_doc.html.erb
@@ -1,0 +1,1 @@
+<div class="callout"><strong>Warning: This document is old! It is likely wrong in some important way.</strong></div>


### PR DESCRIPTION
Many old (2020-era) guides are still reachable, even though we took them out of the menus. Some are linked from blog posts, others from fly-apps repos. 

Added an obsolete warning to as many as I found, using a partial, as a nondestructive step. 