### PR TITLE
Update broken link on migrate-from-heroku.html.md

### DIFF
--- a/postgres/getting-started/migrate-from-heroku.html.md
+++ b/postgres/getting-started/migrate-from-heroku.html.md
@@ -133,4 +133,4 @@ myapp=# \dt
 
 ## Connect it to your application
 
-Read through [the documentation on connecting to your Postgres instances](/docs/postgres/this-basics/connecting) to start accessing your data.
+Read through [the documentation on connecting to your Postgres instances](/docs/postgres/the-basics/connecting) to start accessing your data.


### PR DESCRIPTION
On the very last line of this file there is a link leading to "/docs/postgres/this-basics/connecting". This link is broken. I believe the link should actually be to "/docs/postgres/the-basics/connecting". Changing the word "this" to "the" within the link.