### PR TITLE
Update getting-started.html.md

### DIFF
--- a/litefs/getting-started.html.md
+++ b/litefs/getting-started.html.md
@@ -67,6 +67,13 @@ configure your application so it's publicly visible over HTTPS.
 
 ### Launching your app
 
+Prepare Docker to build the image with the following command:
+
+```sh
+export DOCKER_BUILDKIT=0
+export COMPOSE_DOCKER_CLI_BUILD=0
+```
+
 The next step is to launch & deploy your app with the following command:
 
 ```sh


### PR DESCRIPTION
When building the docker image this error **"failed to solve with frontend dockerfile.v0: failed to create LLB definition"** keeps popping up. Fix for this is to type in the terminal:


```
export DOCKER_BUILDKIT=0
export COMPOSE_DOCKER_CLI_BUILD=0
```

before the fly launch command