### PR TITLE
fix capitalization of GitHub

### DIFF
--- a/elixir/advanced-guides/github-actions-elixir-ci-cd.html.md
+++ b/elixir/advanced-guides/github-actions-elixir-ci-cd.html.md
@@ -1,8 +1,8 @@
 ---
-title: Github Actions for Elixir CI/CD
+title: GitHub Actions for Elixir CI/CD
 layout: framework_docs
 order: 1
-objective: Setup Github CI/CD for your Elixir project.
+objective: Setup GitHub CI/CD for your Elixir project.
 author: mark
 categories:
   - elixir
@@ -21,7 +21,7 @@ changes into the main development branch. The goal is to find and correct bugs
 faster, improve software quality and enable software releases to happen
 faster.
 
-To get started with Github Actions in your project, let's create a "test"
+To get started with GitHub Actions in your project, let's create a "test"
 workflow. To do this, create this path and file in the root of your project:
 
 `.github/workflows/elixir.yaml`

--- a/laravel/the-basics/github-actions.html.md
+++ b/laravel/the-basics/github-actions.html.md
@@ -1,16 +1,16 @@
 ---
-title: Github Actions - CICD
+title: GitHub Actions - CICD
 layout: framework_docs
-objective: Configure continous integration and development on your Laravel Fly App through Github. 
+objective: Configure continous integration and development on your Laravel Fly App through GitHub. 
 order: 7
 ---
 
-Laravel applications are alive and bustling with feature updates and revisions. You'll want to add your Laravel Fly App in a Github repository for safe-versions-keeping, healthy-code-reviews, and good-old team-code management.
+Laravel applications are alive and bustling with feature updates and revisions. You'll want to add your Laravel Fly App in a GitHub repository for safe-versions-keeping, healthy-code-reviews, and good-old team-code management.
 
-Once you've set up a repository for your Fly App, you can automate your team's deployment workflow with [Github Actions](https://docs.github.com/en/actions)---a really neat way to automate most things you'd manually do during and after code reviews!
+Once you've set up a repository for your Fly App, you can automate your team's deployment workflow with [GitHub Actions](https://docs.github.com/en/actions)---a really neat way to automate most things you'd manually do during and after code reviews!
 
 ## _Initialization_
-In this section, you'll create a new Laravel application, configure and deploy it as a Fly App, and finally add it to a Github repository.
+In this section, you'll create a new Laravel application, configure and deploy it as a Fly App, and finally add it to a GitHub repository.
 
 1) Start with a [clean slate](/docs/laravel/): create a new Laravel project and configure it as a deployable Fly app by using the `flyctl` launch command:
 
@@ -27,9 +27,9 @@ flyctl launch --region ams --now
 
 2) Create a new github repository for your current Laravel Fly App. You can create one either through:
 
-a. <b>Github Console</b> - Visiting your [create a new repository](https://github.com/new) page in your console
+a. <b>GitHub Console</b> - Visiting your [create a new repository](https://github.com/new) page in your console
 
-b. <b>Github CLI</b> - run the create repo command:
+b. <b>GitHub CLI</b> - run the create repo command:
 ```cmd
 gh repo create <repository-name> --public
 ```
@@ -40,18 +40,18 @@ git init
 git remote add origin git@github.com:<username>/<repository-name>.git
 ```
 
-## _Github CI Action: Auto Deploy to Fly.io_
-Once you have your Laravel application set up with a github repository, you can configure some Github Actions to auto deploy your changes. 
+## _GitHub CI Action: Auto Deploy to Fly.io_
+Once you have your Laravel application set up with a github repository, you can configure some GitHub Actions to auto deploy your changes. 
 
-In this guide, you'll be using `Fly.io`'s very own [Github action template here](https://github.com/superfly/flyctl-actions) to help deploy your application.
+In this guide, you'll be using `Fly.io`'s very own [GitHub action template here](https://github.com/superfly/flyctl-actions) to help deploy your application.
 
 1) Generate a `Fly token` with `fly auth token`
 
-2) Then save your newly generated `FLY_API_TOKEN` in your github repository either through the Github Console or Github CLI:
+2) Then save your newly generated `FLY_API_TOKEN` in your github repository either through the GitHub Console or GitHub CLI:
 
-a. <b>Github Console</b> - Open your repository's Settings tab, then add a secret named `FLY_API_TOKEN` under the Secrets section.
+a. <b>GitHub Console</b> - Open your repository's Settings tab, then add a secret named `FLY_API_TOKEN` under the Secrets section.
 
-b. <b>Github CLI</b> - run the command below
+b. <b>GitHub CLI</b> - run the command below
 ```cmd
 gh secret set FLY_API_TOKEN --repos <username>/<repository-name>
 ```
@@ -61,7 +61,7 @@ gh secret set FLY_API_TOKEN --repos <username>/<repository-name>
 ✓ Set Actions secret FLY_API_TOKEN for <username>/<repository-name>
 ```
 
-3) Once you have your `FLY_API_TOKEN` safely stored as a secret in your github repository, proceed with creating a Github workflow yml file in `.github/workflows/main.yml`:
+3) Once you have your `FLY_API_TOKEN` safely stored as a secret in your github repository, proceed with creating a GitHub workflow yml file in `.github/workflows/main.yml`:
 
 ```cmd
 mkdir -p .github/workflows
@@ -85,15 +85,15 @@ Let's go through each line above, shall we?
 <ul>
   <li><b>name: Fly Deploy</b> => This is the Workflow name</li>
   <li><b>on: [push]</b> => Any push action to the repository triggers the current workflow</li>
-  <li><b>env: `FLY_API_TOKEN`</b> => Environment variable set for the Github Actions container</li>
+  <li><b>env: `FLY_API_TOKEN`</b> => Environment variable set for the GitHub Actions container</li>
   <li><b>jobs:</b> => This is the list of jobs to run for the workflow
     <ul>
       <li><b>name: Deploy app</b> => Each job would have a name</li>
       <li><b>runs-on: ubuntu-latest</b> => Each job would have an container environment we want to run its virtual machine on</li>
       <li><b>steps:</b> => Each job would have a list of steps, see below:
       <ul>
-        <li><b>uses: actions/checkout@v2</b> => This is a pre-made Github Action. It allows checking out of your repository into the virtual machine spun up for the job</li>
-        <li><b>uses: superfly/flyctl-actions/setup-flyctl@master</b> => This is one of Fly.io's pre-made Github action. It sets up `flyctl` in the virtual machine spun up for the job</li>
+        <li><b>uses: actions/checkout@v2</b> => This is a pre-made GitHub Action. It allows checking out of your repository into the virtual machine spun up for the job</li>
+        <li><b>uses: superfly/flyctl-actions/setup-flyctl@master</b> => This is one of Fly.io's pre-made GitHub action. It sets up `flyctl` in the virtual machine spun up for the job</li>
         <li><b>run: flyctl deploy</b> => Need I say more? </li>
       </ul>
       </li>
@@ -104,7 +104,7 @@ Let's go through each line above, shall we?
 4) Save and push your changes with:
 ```cmd
 git add .
-git commit -m "Configure auto-deploy through Github Actions"
+git commit -m "Configure auto-deploy through GitHub Actions"
 git push
 ```
 

--- a/rails/getting-started/migrate-from-heroku.html.md
+++ b/rails/getting-started/migrate-from-heroku.html.md
@@ -235,7 +235,7 @@ Check out the [Fly CLI docs](https://fly.io/docs/flyctl/) for a more extensive i
 
 By default Heroku deployments are kicked off via the `git push heroku` command. Fly works a bit differently by kicking of deployments via `fly deploy`—git isn't needed to deploy to Fly. The advantage to this approach is your git history will be clean and not full of commits like `git push heroku -am "make app work"` or `git push heroku -m "ok it will really work this time"`.
 
-To achieve the desired `git push` behavior, we recommend setting up `fly deploy` as the final command in your continious integration pipeline, as outlined for Github in the [Continuous Deployment with Fly and GitHub Actions](https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/) docs.
+To achieve the desired `git push` behavior, we recommend setting up `fly deploy` as the final command in your continious integration pipeline, as outlined for GitHub in the [Continuous Deployment with Fly and GitHub Actions](https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/) docs.
 
 #### Release phase tasks
 
@@ -261,7 +261,7 @@ Remove this dependency or add more depending on the build process required for y
 
 Heroku's default deployment technique is via `git push heroku`. Fly doesn't require a git commit, just run `fly deploy` and the files on your local workstation will be deployed.
 
-Fly can be configured to deploy on git commits with the following techniques with a [Github Action](https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/).
+Fly can be configured to deploy on git commits with the following techniques with a [GitHub Action](https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/).
 
 ### Databases
 


### PR DESCRIPTION
`GitHub` is spelled with a capital H.

Disclosure: I am a GitHub employee.