### PR TITLE
Fix typo

### DIFF
--- a/app-guides/functions-with-machines.html.md.erb
+++ b/app-guides/functions-with-machines.html.md.erb
@@ -54,7 +54,7 @@ Your users' service will boot immediately after this API call. Launch speed is a
 
 Try accessing your new machine at `https://user-functions.fly.dev`. If no requests arrive within 4 seconds, the machine will exit, but a request will force it to start back up automatically.
 
-## Launch a in another region
+## Launch in another region
 
 That machine was launched in the region nearest to you. Say you want your user function to run fast for users in Australia. Let's launch another machine there.
 


### PR DESCRIPTION
Remove an extra, unneeded 'a' in a header.