### PR TITLE
Add missing "-a" app flag to command

### DIFF
--- a/postgres/managing/users-and-roles.html.md.erb
+++ b/postgres/managing/users-and-roles.html.md.erb
@@ -14,7 +14,7 @@ A Postgres cluster is configured with three users when created:
 You can view a list of users using `flyctl`:
 
 ```cmd
-flyctl postgres users list -a pg-test
+fly postgres users list -a pg-test
 ```
 
 ```output

--- a/postgres/managing/users-and-roles.html.md.erb
+++ b/postgres/managing/users-and-roles.html.md.erb
@@ -14,7 +14,7 @@ A Postgres cluster is configured with three users when created:
 You can view a list of users using `flyctl`:
 
 ```cmd
-flyctl postgres users list pg-test
+flyctl postgres users list -a pg-test
 ```
 
 ```output


### PR DESCRIPTION
The rest of the Postgres docs includes the `-a` app flag as opposed to referring to a local fly.toml file, so I'd imagine the like the lack of it here is a typo.

Flyctl returns this error message as expected when the command is run without the `-a` flag or a local Postgres app project, `Error we couldn't find a fly.toml nor an app specified by the -a flag. If you want to launch a new app, use 'flyctl launch'`