### PR TITLE
Add beta disclaimer to LiteFS docs

### DIFF
--- a/litefs/config.html.md.erb
+++ b/litefs/config.html.md.erb
@@ -6,6 +6,8 @@ nav: litefs
 toc: true
 ---
 
+<%= partial "partials/disclaimer" %>
+
 LiteFS is primarily configured via a `litefs.yml` config file. This file can
 be in the current directory, the home directory, or at `/etc/litefs.yml`. You
 can also pass in a path using a command line flag:

--- a/litefs/files.html.md.erb
+++ b/litefs/files.html.md.erb
@@ -6,6 +6,8 @@ nav: litefs
 toc: true
 ---
 
+<%= partial "partials/disclaimer" %>
+
 LiteFS handles user-created files based on their suffix:
 
 - Journal files have a `-journal` suffix.

--- a/litefs/getting-started.html.md.erb
+++ b/litefs/getting-started.html.md.erb
@@ -6,6 +6,8 @@ nav: litefs
 toc: true
 ---
 
+<%= partial "partials/disclaimer" %>
+
 This tutorial will get you up and running with LiteFS on Fly.io. While using
 Fly.io is not required, it provides services such as Consul that make it easy
 to run LiteFS with minimal configuration. It should take you about 10 minutes

--- a/litefs/how-it-works.html.md.erb
+++ b/litefs/how-it-works.html.md.erb
@@ -6,6 +6,8 @@ nav: litefs
 toc: true
 ---
 
+<%= partial "partials/disclaimer" %>
+
 LiteFS is a distributed file system specifically built for replicating SQLite
 databases. This allows each application node to have a full, local copy of the
 database and respond to requests with minimal latency. LiteFS is built for high

--- a/litefs/index.html.md.erb
+++ b/litefs/index.html.md.erb
@@ -5,6 +5,8 @@ sitemap: false
 nav: litefs
 ---
 
+<%= partial "partials/disclaimer" %>
+
 LiteFS is a distributed file system that transparently replicates SQLite
 databases. This lets you run your application like it's running against a local
 on-disk SQLite database but behind the scenes the database is replicated to all

--- a/litefs/partials/_disclaimer.html.md
+++ b/litefs/partials/_disclaimer.html.md
@@ -1,0 +1,3 @@
+<div class="callout">
+LiteFS is currently in beta and is not recommended for production use yet.
+</div>


### PR DESCRIPTION
We have a "beta" tag on the GitHub repo but I forgot to add a callout to the docs. There are definitely some rough edges with LiteFS still so I want to be clear about its level of stability.