### PR TITLE
Update working-with-machines.html.md.erb

### DIFF
--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -55,7 +55,7 @@ In order to access this API on a fly VM, make the token available as a secret:
 flyctl secrets set FLY_API_TOKEN=$(fly auth token)
 ```
 
-A convenient way to set the FLY_API_HOSTNAME is to add it to your `Dockerfile`:
+A convenient way to set the `FLY_API_HOSTNAME` is to add it to your `Dockerfile`:
 
 ```
 ENV FLY_API_HOSTNAME="_api.internal:4280
@@ -282,4 +282,4 @@ This table explains the possible machine states. A machine may only be in one st
   </table>
 
 
-Internal note: the replaced state is only possible when requesting a specific instance_id.
+Internal note: the replaced state is only possible when requesting a specific `instance_id`.


### PR DESCRIPTION
Pairs of underscores outside of code blocks resulted in italics:

![image](https://user-images.githubusercontent.com/206973/208981425-f7407a68-d3c3-44a1-8d69-6bac8667f337.png)


Additionally wrap instance_id in a code block (not italic in doc, but is a code token that could be pretty code purple and to safeguard against future underscore pairs on that line).