### PR TITLE
Fix 404 and remove useless Additional

### DIFF
--- a/django/getting-started/existing.html.md
+++ b/django/getting-started/existing.html.md
@@ -7,7 +7,6 @@ objective: Learn how to run your existing Django applications on Fly.
 related_pages:
   - /docs/django/getting-started/existing
   - /docs/flyctl/
-  - /docs/postgres/
 ---
 
 If you have an existing Django app that you want to move over to Fly, this guide

--- a/django/index.html.md.erb
+++ b/django/index.html.md.erb
@@ -14,4 +14,4 @@ Run through the [Starter Django App](./getting-started/) guide to get a feel for
 
 ## [Existing Django Apps](./existing)
 
-The [Existing Django Apps](./existing) guide walks through deploying a production-ready project to Fly. If you are coming from another hosting platform like Heroku there are additional tips for managing the migration.
+The [Existing Django Apps](./getting-started/existing/) guide walks through deploying a production-ready project to Fly. If you are coming from another hosting platform like Heroku there are additional tips for managing the migration.


### PR DESCRIPTION
- On https://fly.io/docs/django/, `Existing Django Apps` link returns 404 page when you click it. I fixed it
- On https://fly.io/docs/django/getting-started/existing/,  `Existing Django Apps` link in `Additional resources` returns same page. That's why I removed it
