### PR TITLE
Fixed link to install flyctl

### DIFF
--- a/reference/redis.html.md
+++ b/reference/redis.html.md
@@ -11,7 +11,7 @@ status: alpha
 See the [What you Should Know](#what-you-should-know) section for more details about this service.
 ## Create and manage a Redis database
 
-Creating and managing databases happens exclusively via the [Fly CLI](/getting-started/installing-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
+Creating and managing databases happens exclusively via the [Fly CLI](/docs/hands-on/install-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
 
 ### Create and get status of a Redis database
 


### PR DESCRIPTION
Noticed in passing... was linking to non-existant getting-started/install... 