### PR TITLE
possible drift between new user documentation and current implementation

### DIFF
--- a/hands-on/partials/_launch-app.html.md
+++ b/hands-on/partials/_launch-app.html.md
@@ -33,9 +33,16 @@ You will also be prompted for credit card payment information, required for char
 ```output
 ? Would you like to set up a Postgresql database now? (y/N)
 ```
-Lastly, the CLI will ask if you need a Postgresql database. You can reply no for now.
+Then CLI will ask if you need a Postgresql database. You can reply no for now.
 
 At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. The `fly.toml` file now contains a default configuration for deploying your app.
+
+Lastly, the CLI will ask you if you would like to deploy now - please say no if your app doesn't use `internal_port = 8080`.
+
+```output
+? Would you like to deploy now? Yes
+==> Building image
+```
 
 ```toml
 


### PR DESCRIPTION
What I saw:

```output
sven@x1carbon:~/Dendron/notes$ fly launch --image svendowideit/echo:latest 
Creating app in /home/sven/Dendron/notes
Using image svendowideit/echo:latest
? Choose an app name (leave blank to generate one): 
automatically selected personal organization: Sven Dowideit
? Choose a region for deployment: Singapore, Singapore (sin)
Created app small-shadow-4841 in organization personal
Admin URL: https://fly.io/apps/small-shadow-4841
Hostname: small-shadow-4841.fly.dev
Wrote config file fly.toml
? Would you like to set up a Postgresql database now? No
? Would you like to set up an Upstash Redis database now? No
? Would you like to deploy now? Yes
==> Building image
Searching for image 'svendowideit/echo:latest' remotely...
image found: img_nr0lpj73616p5q98
```