### PR TITLE
Escape unescaped underscores in Machines leases partials

### DIFF
--- a/reference/machines/lease.html.md
+++ b/reference/machines/lease.html.md
@@ -2,12 +2,12 @@
 Add the `fly-machine-lease-nonce` header to all subsequent API calls.
 ```
 curl -i -X POST \
-    -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
+    -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
+    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
 ```
 #### Release the lease
 ```
 curl -i -X DELETE \
-    -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
+    -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
+    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
 ```

--- a/reference/machines/lease_req.html.md
+++ b/reference/machines/lease_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \
-    -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \
-    "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
+    -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \
+    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
     -d '{
         "ttl": 500
     }'


### PR DESCRIPTION
Unescaped underscores were turning into italics in several curl literal blocks here: https://fly.io/docs/machines/working-with-machines/

![image](https://user-images.githubusercontent.com/1284973/212745477-fe88e771-56ce-481f-9f3e-57b1218a7634.png)