### PR TITLE
removes old behavior

### DIFF
--- a/rails/the-basics/sidekiq.html.md
+++ b/rails/the-basics/sidekiq.html.md
@@ -36,20 +36,10 @@ Add the following to the `fly.toml`:
 
 ```toml
 [processes]
-web = "bin/rails fly:server"
+app = "bin/rails fly:server"
 worker = "bundle exec sidekiq"
 ```
 
-Then under the `[[services]]` directive, find the entry that maps to `internal_port = 8080`, and change `processes = ["app"]` to `processes = ["web"]`. The configuration file should look something like this:
-
-```toml
-[[services]]
-  processes = ["web"] # this service only applies to the web process
-  http_checks = []
-  internal_port = 8080
-  protocol = "tcp"
-  script_checks = []
-```
 
 This associates the process with the service that Fly launches.
 
@@ -61,7 +51,7 @@ Once multiple processes are configured in the `fly.toml` file, deploy them via:
 fly deploy
 ```
 
-If all goes well the application should launch with both `web` and `worker` processes. Be sure to run through the application and test features that kick-off background jobs. If you're having issues getting it working, run `fly logs` to see errors.
+If all goes well the application should launch with both `app` and `worker` processes. Be sure to run through the application and test features that kick-off background jobs. If you're having issues getting it working, run `fly logs` to see errors.
 
 ## Scaling
 


### PR DESCRIPTION
I have ran in issue while trying to setup Sidekiq. Following the current version of the tutorial,  I got 3 `processes` after deploy.

* app
* web
* worker 

even without have any reference to app on my fly.toml. So, I believe this tutorial is not accurate anymore. Sorry if I'm wrong but I ended up with 3 'processes'. 

At least in the application information: I could even scale this third machine,
<img width="808" alt="Screen Shot 2023-01-18 at 09 53 10" src="https://user-images.githubusercontent.com/10491484/213843149-649d9010-732c-4051-bc26-281cb9b45c81.png">

However in the monitoring window I had only two: web and worker. 

<img width="1230" alt="Screen Shot 2023-01-18 at 09 53 24" src="https://user-images.githubusercontent.com/10491484/213843167-aaa10a88-f2b4-4c92-9ad9-11b3fcfb1bef.png">


Anyhow, if we go with app and worker it's working fine.


Please close this if I'm wrong. 

btw - app is deleted now
