### PR TITLE
Update sign-in.html.md.erb

### DIFF
--- a/hands-on/sign-in.html.md.erb
+++ b/hands-on/sign-in.html.md.erb
@@ -9,7 +9,7 @@ toc: false
 If you already have a Fly.io account, all you need to do is sign in with flyctl. Simply run:
 
 ```cmd
-fly auth login
+flyctl auth login
 ```
 
 Your browser will open up with the Fly.io sign-in screen, enter your user name and password to sign in. If you signed up with GitHub, use the `Sign in with GitHub` button to sign in.


### PR DESCRIPTION
`fly` is not a recognized command, the tutorial instructs the user to install `flyctl`.