### PR TITLE
Add volume path when copying existing database

### DIFF
--- a/elixir/advanced-guides/sqlite3.html.md
+++ b/elixir/advanced-guides/sqlite3.html.md
@@ -225,8 +225,10 @@ And use the `put` command to transfer your file to the volume path.
 **NOTE**: Because our server is running, we first need to give the database a new name. Do **not** try to put this file in the same place as your current `DATABASE_PATH`.
 
 ```
-» put ./name.db mnt/name-prod.db
+» put ./name.db mnt/volume_name/name-prod.db
 ```
+
+Where `volume_name` corresponds to the name you used when [creating your volume](#create-volume).
 
 Check that it's there:
 


### PR DESCRIPTION
Volumes are mounted under `/mnt/volume_name`.

Add explicit `volume_path` to the sample upload command to make it clearer.