### PR TITLE
State http_checks timeout time is in milliseconds

### DIFF
--- a/reference/configuration.html.md
+++ b/reference/configuration.html.md
@@ -355,7 +355,7 @@ Roughly translated, this section says every ten seconds, perform a HTTP GET on t
 * `path`: The path of the URL to be requested.
 * `protocol`: The protocol to be used (`http` or `https`)
 * `restart_limit`: The number of consecutive HTTP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed HTTP health checks.
-* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `timeout`: The maximum time in milliseconds a connection can take before being reported as failing its healthcheck.
 * `tls_skip_verify`: When `true` (and using HTTPS protocol) skip verifying the certificates sent by the server.
 * `services.http_checks.headers`: This is a sub-section of `services.http_checks`. It uses the key/value pairs as a specification of header and header values that will get passed with the http_check call.
 


### PR DESCRIPTION
As in other time related attributes, milliseconds is stated. I believe is helpful to avoid any kind of confusion, personally I was doubting when I read the first time, had to double check the example statement to realize it was in millis.