### PR TITLE
correct anchor link on machines/working-with-machines to wait-for-a-machine-to-reach-a-specified-state

### DIFF
--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -115,7 +115,7 @@ For non-sensitive information, you _can_ set different environment variables per
 
 Create machine, which starts running immediately. This is where you configure the machine characteristics, like its CPU and memory. You can also allow connections from the internet through the Fly proxy. Learn more about this behavior in the [networking section](#networking).
 
-Following this call, you can make a [blocking API request](#wait-for-a-machine-to-start) to wait for a machine to start.
+Following this call, you can make a [blocking API request](#wait-for-a-machine-to-reach-a-specified-state) to wait for a machine to start.
 
 The only required parameter is `image` in the `config` object. Other parameters:
 


### PR DESCRIPTION
Stumbled across this on:
https://fly.io/docs/machines/working-with-machines/
