### PR TITLE
fix: link to high-availability-and-global-replication

### DIFF
--- a/postgres/getting-started/create-pg-cluster.html.md.erb
+++ b/postgres/getting-started/create-pg-cluster.html.md.erb
@@ -39,7 +39,7 @@ During this process, you get to choose from several preset resource configuratio
   Specify custom configuration
 ```
 
-The "Production" options give you a two-node cluster in a leader-replica configuration. A single-node "Development" instance can readily be scaled and [expanded to more regions](https://fly.io/docs/postgres/advanced-guides/high-availability-and-global-replication).
+The "Production" options give you a two-node cluster in a leader-replica configuration. A single-node "Development" instance can readily be scaled and [expanded to more regions](/docs/postgres/advanced-guides/high-availability-and-global-replication/).
 
 ```
 Creating postgres cluster pg-test in organization TestOrg

--- a/postgres/getting-started/create-pg-cluster.html.md.erb
+++ b/postgres/getting-started/create-pg-cluster.html.md.erb
@@ -39,7 +39,7 @@ During this process, you get to choose from several preset resource configuratio
   Specify custom configuration
 ```
 
-The "Production" options give you a two-node cluster in a leader-replica configuration. A single-node "Development" instance can readily be scaled and [expanded to more regions](#high-availability-and-global-replication).
+The "Production" options give you a two-node cluster in a leader-replica configuration. A single-node "Development" instance can readily be scaled and [expanded to more regions](https://fly.io/docs/postgres/advanced-guides/high-availability-and-global-replication).
 
 ```
 Creating postgres cluster pg-test in organization TestOrg


### PR DESCRIPTION
While browsing the docs for setting up a AppsV2 postgres i stumbled across a link to the global replication guide, which did not work. I think this was meant to link to the advanced guides section? 