### PR TITLE
Always run Windows flyctl installation command in powershell.

### DIFF
--- a/hands-on/install-flyctl.html.md.erb
+++ b/hands-on/install-flyctl.html.md.erb
@@ -58,7 +58,7 @@ curl -L https://fly.io/install.sh | sh
 Run the Powershell install script:
 
 ```cmd
-iwr https://fly.io/install.ps1 -useb | iex
+powershell -Command "iwr https://fly.io/install.ps1 -useb | iex"
 ```
 
 


### PR DESCRIPTION
The docs clearly indicate that the installation script needs powershell, but I run in git-bash and always have to spin up a separate shell for the installation script. This ensures that the command always works regardless of the user's current shell.

I've tested the command itself, but because I don't have access to the landing repo, I haven't ensured that the Copy button captures the command correctly and works. Happy to either do that myself or hand it off to someone else.