### PR TITLE
Put soft_limit and hard_limit in code blocks

### DIFF
--- a/reference/load-balancing.html.md
+++ b/reference/load-balancing.html.md
@@ -66,8 +66,8 @@ When users in Amsterdam generate up to 60 concurrent http requests, those reques
 
 When users generate 61+ concurrent requests from Amsterdam, 60 of those requests will be sent to the 3 instances in the ams region and then the rest will be sent to instances in other regions based on which ones are closest.
 
-That keeps going until we get to 200+ concurrent requests. At 200 concurrent requests all application instances are at their soft_limit, so Fly.io will start routing requests to the ams instances again. E.g., the 201st concurrent request will go to an application instance in the ams region that is currently at its soft_limit.
+That keeps going until we get to 200+ concurrent requests. At 200 concurrent requests all application instances are at their `soft_limit`, so Fly.io will start routing requests to the ams instances again. E.g., the 201st concurrent request will go to an application instance in the ams region that is currently at its `soft_limit`.
 
-When users generate 250 concurrent requests, all instances will be at their hard_limit. The 251st concurrent request will get delayed by the Fly.io proxy until an instance is below its hard_limit.
+When users generate 250 concurrent requests, all instances will be at their `hard_limit`. The 251st concurrent request will get delayed by the Fly.io proxy until an instance is below its `hard_limit`.
 
-If traffic is far above the hard_limit for a long period of time, Fly.io may start returning 503 Service Unavailable responses for requests that are not able to be routed to an instance.
+If traffic is far above the `hard_limit` for a long period of time, Fly.io may start returning 503 Service Unavailable responses for requests that are not able to be routed to an instance.


### PR DESCRIPTION
Avoids markdown formatting italicizing text, and makes it consistent with the rest of the page