### PR TITLE
Modify steps to match CLI experience

### DIFF
--- a/hands-on/launch-app.html.md.erb
+++ b/hands-on/launch-app.html.md.erb
@@ -47,9 +47,15 @@ You will also be prompted for credit card payment information, required for char
 ```
 Then CLI will ask if you need a Postgresql database. You can reply no for now.
 
+```output
+? Would you like to set up an Upstash Redis database now? (y/N)
+```
+
+Next, the CLI will ask if you need an Upstash Redis database. You can reply no for now.
+
 At this point, `flyctl` creates an app for you and writes your configuration to a `fly.toml` file. The `fly.toml` file now contains a default configuration for deploying your app.
 
-Lastly, the CLI will ask you if you would like to deploy now - please say no if your app doesn't use `internal_port = 8080`.
+Lastly, the CLI will ask you if you would like to deploy now - please say no if your app doesn't use `internal_port = 8080`. For the purposes of this example, select Yes. This step will look up our `fly.toml` file, and get the app name `hellofly` from there. Then, flyctl will start the process of deploying our application to the Fly.io platform. flyctl will return you to the command line when it's done.
 
 ```output
 ? Would you like to deploy now? Yes
@@ -73,15 +79,6 @@ The `flyctl` command will always refer to this file in the current directory if 
 
 We'll have more details about these properties as we progress, but for now, it's enough to say that they mostly configure which ports the application will be visible on.
 
-[Next: Deploying Your App](/docs/hands-on/deploy-app/)
-
-
-We are now ready to deploy our containerized app. At the command line, just run:
-
-```cmd
-flyctl deploy
-```
-
-This will look up our `fly.toml` file, and get the app name `hellofly` from there. Then flyctl will start the process of deploying our application to the Fly.io platform. flyctl will return you to the command line when it's done.
+You can make new deployments from the CLI by running `flyctl deploy`.
 
 [Next: Check your app's status](/docs/hands-on/check-app-status/)


### PR DESCRIPTION
- The CLI now includes a question about Upstash Redis
- The CLI prompts for the first deployment, so running `flyctl deploy` after that in this example is redundant