### PR TITLE
Remove redundant text

### DIFF
--- a/rails/getting-started/dockerfiles.html.md
+++ b/rails/getting-started/dockerfiles.html.md
@@ -166,8 +166,6 @@ docker compose build
 docker compose up
 ```
 
-Change `rails-welcome` to the name of your application.
-
 Windows Powershell users will want to use the following command instead of export:
 
 ```powershell


### PR DESCRIPTION
"Change `rails-welcome` to the name of your application." line doesn't have any significance to the doc.