### PR TITLE
Update node.html.md.erb

### DIFF
--- a/languages-and-frameworks/node.html.md.erb
+++ b/languages-and-frameworks/node.html.md.erb
@@ -113,7 +113,7 @@ This will lookup our `fly.toml` file, and get the app name `hellonode` from ther
 
 ## _Viewing the Deployed App_
 
-Now the application has been deployed, let's find out more about its deployment. The command `flyctl info` will give you all the essential details.
+Now the application has been deployed, let's find out more about its deployment. The command `flyctl status` will give you all the essential details.
 
 ```cmd
 flyctl status


### PR DESCRIPTION
Updated `fly info` to `fly status` in the writing above the code block, since `fly info` is a removed/deprecated command.

Link for reference- https://fly.io/docs/languages-and-frameworks/node/#:~:text=Now%20the%20application%20has%20been%20deployed%2C%20let%27s%20find%20out%20more%20about%20its%20deployment.%20The%20command%20flyctl%20info%20will%20give%20you%20all%20the%20essential%20details.