### PR TITLE
Update crystal.html.md.erb

### DIFF
--- a/languages-and-frameworks/crystal.html.md.erb
+++ b/languages-and-frameworks/crystal.html.md.erb
@@ -141,7 +141,7 @@ Alternatively, you can use [GitHub Actions to deploy your app to Fly](/docs/app-
 
 ## _Viewing the Deployed App_
 
-Now the application has been deployed, let's find out more about its deployment. The command `flyctl info` will give you all the essential details.
+Now the application has been deployed, let's find out more about its deployment. The command `fly status` will give you all the essential details.
 
 ```cmd
 fly status


### PR DESCRIPTION
Changed deprecated/removed command `fly info` to `fly status` to match with the rest of the docs.