### PR TITLE
fix broken livebook desktop link

### DIFF
--- a/elixir/advanced-guides/connect-livebook-to-your-app.html.md
+++ b/elixir/advanced-guides/connect-livebook-to-your-app.html.md
@@ -42,7 +42,7 @@ Livebook Desktop can be installed as an app on Mac and Window. For Linux, we can
 
 ### Using Livebook Desktop
 
-When running [Livebook Desktop]((https://livebook.dev/#install)), Livebook will invoke on boot a file named `~/.livebookdesktop.sh` on macOS or `%USERPROFILE%\.livebookdesktop.bat` on Windows. This file can be modified to set environment variables used by Livebook, such as:
+When running [Livebook Desktop](https://livebook.dev/#install), Livebook will invoke on boot a file named `~/.livebookdesktop.sh` on macOS or `%USERPROFILE%\.livebookdesktop.bat` on Windows. This file can be modified to set environment variables used by Livebook, such as:
 
 ```
 export LIVEBOOK_DISTRIBUTION=name


### PR DESCRIPTION
One more broken link. When GitHub parses this, it determines that it's not a link at all, but on the documentation site it links to `https://fly.io/docs/elixir/advanced-guides/connect-livebook-to-your-app/(https://livebook.dev/#install)`.