### PR TITLE
Add autostart and stop docs

### DIFF
--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Automatically Stop and Start App Machines
+title: Automatically Stop and Start App V2 Machines
 objective: 
 layout: docs
 nav: firecracker
@@ -13,8 +13,8 @@ You can decide whether you want to automatically stop, or downscale, instances o
 ```toml
 ...
 [[services]]
-  autostart = true
-  autostop = true
+  auto_stop_machines = true
+  auto_start_machines = true
 ...
 ```
 
@@ -28,16 +28,16 @@ You can decide whether you want to automatically stop, or downscale, instances o
 ...
 ```
 
-## Default and recomended values
+## Default and recommended values
 
-New V2 apps are automatically started and automatically stopped by default:
+New V2 app created using the `fly launch` command are automatically started and automatically stopped by default:
 
 ```toml
 auto_stop_machines = true
 auto_start_machines = true
 ```
 
-Existing apps are automatically started but not automatically stopped by default:
+Existing apps—or any apps that don't have these settings in `fly.toml`—are automatically started but not automatically stopped by default:
 
 ```toml
 auto_stop_machines = false

--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -10,11 +10,15 @@ order: 65
 This feature only works for V2 apps. For information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
 </div>
 
-You can decide whether you want to automatically stop an app's Fly Machines when they're idle and automatically restart them when they're needed. Fly Proxy controls automatically starting and automatically stopping Machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
+Fly Machines are fast to start and stop, and you don't pay for their CPU and RAM when they're in the `stopped` state. For Fly Apps with a service configured, Fly Proxy can start and stop existing Machines based on incoming requests, so that your app can accommodate bursts in demand without keeping extra Machines running constantly.
+
+You can configure automatic starts and automatic stops independently with the `auto_stop_machines` and `auto_start_machines` settings, and tune them with concurrency limits, within the [[[services]]](/docs/reference/configuration/#the-services-sections) or [[http_service]](/docs/reference/configuration/#the-http_service-section) sections of `fly.toml`.
 
 ```toml
 ...
 [[services]]
+  internal_port = 8080
+  protocol = "tcp"
   auto_stop_machines = true
   auto_start_machines = true
 ...
@@ -56,7 +60,7 @@ If `auto_start_machines = false` and `auto_stop_machines = true`, Fly Proxy will
 
 The Fly Proxy runs a process to automatically stop and start Fly Machines every few minutes.
 
-When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capcity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
+When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capacity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
 
 Fly Proxy considers all of the app's Machines that are currently running in a given region, such as `fra`, and determines excess capacity as follows:
 
@@ -67,7 +71,7 @@ Fly Proxy considers all of the app's Machines that are currently running in a gi
   * the proxy checks if the Machine has any traffic
   * if the Machine has no traffic (a load of 0), then the proxy stops the Machine
 
-When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an a Machine in the nearest region when required.
+When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts a Machine in the nearest region when required.
 
 Fly Proxy determines when to start a Machine as follows:
 

--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Automatically Stop and Start App V2 Machines
+title: Automatically Stop and Start App V2 Fly Machines
 objective: 
 layout: docs
 nav: firecracker
@@ -7,10 +7,10 @@ order: 65
 ---
 
 <div class="callout">
-This feature only works for V2 apps. For more information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
+This feature only works for V2 apps. For information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
 </div>
 
-You can decide whether you want to automatically stop an app's machines when they're idle and automatically restart them when they're needed. Fly Proxy controls automatically starting and automatically stopping machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
+You can decide whether you want to automatically stop an app's Fly Machines when they're idle and automatically restart them when they're needed. Fly Proxy controls automatically starting and automatically stopping Machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
 
 ```toml
 ...
@@ -32,53 +32,53 @@ You can decide whether you want to automatically stop an app's machines when the
 
 ## Default and recommended values
 
-New V2 apps created using the `fly launch` command are automatically started and automatically stopped by default:
+New V2 apps created using the `fly launch` command are configured to automatically start and automatically stop Fly Machines by default:
 
 ```toml
 auto_stop_machines = true
 auto_start_machines = true
 ```
 
-Existing apps—or any apps that don't have these settings in `fly.toml`—are automatically started but not automatically stopped by default:
+Existing V2 apps—or any V2 apps that don't have these settings in `fly.toml`—will automatically start but not automatically stop Machines by default:
 
 ```toml
 auto_stop_machines = false
 auto_start_machines = true
 ```
 
-In most cases, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. 
+In most cases, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having Machines that either never start or never stop. 
 
-If `auto_start_machines = true` and `auto_stop_machines = false`, the proxy will start your machines but they will never be stopped automatically. If you have a reason to only stop machines manually, then these settings are just fine.
+If `auto_start_machines = true` and `auto_stop_machines = false`, Fly Proxy will automatically start your Machines but will never stop them. If you have a reason to only stop Machines manually, then these settings are just fine.
 
-If `auto_start_machines = false` and `auto_stop_machines = true`, the proxy will stop your machines when there's low traffic, but won't be able to start them again. If all or most of your machines are stopped, then requests will start failing.
+If `auto_start_machines = false` and `auto_stop_machines = true`, Fly Proxy will automatically stop your Machines when there's low traffic, but won't be able to start them again. If all or most of your Machines are stopped, then requests will start failing.
 
 ## How It Works
 
-The Fly Proxy runs the process to stop and start machines automatically every few minutes.
+The Fly Proxy runs a process to automatically stop and start Fly Machines every few minutes.
 
-When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each machine to determine if there's excess capacity. If the proxy decides there's excess capcity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
+When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capcity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
 
-Fly Proxy considers all of the app's machines that are currently running in a given region, such as `fra`, and determines excess capacity as follows:
+Fly Proxy considers all of the app's Machines that are currently running in a given region, such as `fra`, and determines excess capacity as follows:
 
-* If there's more than one machine in the region:
-  * the proxy determines how many machines are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of machines - (num machines over soft limit + 1)`
+* If there's more than one Machine in the region:
+  * the proxy determines how many Machines are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of machines - (num machines over soft limit + 1)`
   * if excess capacity is 1 or greater, then the proxy stops one machine
-* If there's only one machine in the region:
-  * the proxy checks if the machine has any traffic
-  * if the machine has no traffic (a load of 0), then the proxy stops the machine
+* If there's only one Machine in the region:
+  * the proxy checks if the Machine has any traffic
+  * if the Machine has no traffic (a load of 0), then the proxy stops the Machine
 
-When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an a machine in the nearest region when required.
+When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an a Machine in the nearest region when required.
 
-Fly Proxy determines when to start a machine as follows:
+Fly Proxy determines when to start a Machine as follows:
 
 * The proxy waits for a request to your app.
-* If all running machines are above their `soft_limit` setting, then the proxy starts a stopped machine in the nearest region (if there are any stopped machines).
-* The proxy routes the request to the newly started machine.
+* If all running Machines are above their `soft_limit` setting, then the proxy starts a stopped Machine in the nearest region (if there are any stopped Machines).
+* The proxy routes the request to the newly started Machine.
 
-## When to Stop and Start Machines Automatically, or Not
+## When to Stop and Start Fly Machines Automatically, or Not
 
-If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your machines as demand decreases and increases. This could reduce costs, because you'll never have to run excess machines to handle peak load; you'll only run, and be charged for, the number of machines that are needed at any given time.
+If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your Fly Machines as demand decreases and increases. This could reduce costs, because you'll never have to run excess Machines to handle peak load; you'll only run, and be charged for, the number of Machines that are needed at any given time.
 
-The difference between this feature and what is typical in autoscaling, is that it doesn't create new machines up to a specified maximum. It will automatically start only existing machines. For example, if you want to have a maximum of 10 machines available to service requests, then you need to create 10 machines for your app.
+The difference between this feature and what is typical in autoscaling, is that it doesn't create new Machines up to a specified maximum. It will automatically start only existing Machines. For example, if you want to have a maximum of 10 Machines available to service requests, then you need to create 10 Machines for your app.
 
-If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines` is set to `true` and there’s no traffic to your app, eventually all of your app's machines could be stopped.
+If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines` is set to `true` and there’s no traffic to your app, eventually all of your app's Machines could be stopped.

--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -1,0 +1,83 @@
+---
+title: Automatically Stop and Start App Machines
+objective: 
+layout: docs
+nav: firecracker
+order: 65
+---
+
+<%= partial "/docs/partials/v2_transition_banner" %>
+
+You can decide whether you want to automatically stop, or downscale, instances of your app when they're idle and automatically restart them when they're needed. Each instance of your app is running on a Fly machine. Fly Proxy controls automatically starting and automaticaly stopping machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
+
+```toml
+...
+[[services]]
+  autostart = true
+  autostop = true
+...
+```
+
+```toml
+...
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+...
+```
+
+## Default and recomended values
+
+New V2 apps are automatically started and automatically stopped by default:
+
+```toml
+auto_stop_machines = true
+auto_start_machines = true
+```
+
+Existing apps are automatically started but not automatically stopped by default:
+
+```toml
+auto_stop_machines = false
+auto_start_machines = true
+```
+
+In most cases, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having instances that either never start or never stop. 
+
+If `auto_start_machines = true` and `auto_stop_machines = false`, the proxy will start your instances but they will never be stopped automatically. If you have a reason to only stop instances manually, then these settings are just fine.
+
+If `auto_start_machines = false` and `auto_stop_machines = true`, the proxy will scale your instances down but won't be able to start them again. If all of your instances are scaled down, then requests will start failing.
+
+## How It Works
+
+The Fly Proxy runs the process to stop and start machines automatically every few minutes.
+
+When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each machine to determine if there's excess capacity. If the proxy decides there's excess capcity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
+
+Fly proxy considers all of the running instances of your app in a given region, such as `fra`, and determines excess capacity as follows:
+
+* If there's more than one instance in the region:
+  * the proxy determines how many instances are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of instances - (num instances over soft limit + 1)`
+  * if excess capacity is 1 or greater, then the proxy stops 1 instance
+* If there's only one instance in the region:
+  * the proxy checks if the instance has any traffic
+  * if the instance has no traffic (a load of 0), then the proxy stops the instance
+
+When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an instance in the nearest region when required.
+
+Fly proxy determines when to start an instance as follows:
+
+* The proxy waits for a request to your app.
+* If all running instances are above their `soft_limit` setting, then the proxy starts a stopped instance from the nearest region (if there are any stopped instances).
+* The proxy routes the request to the newly started instance.
+
+## When to Stop and Start Machines Automatically, or Not
+
+If your app has highly variable workloads, then you can set `auto_stop_machines` and `auto_start_machines` to true to manage your instances as demand decreases and increases. This could reduce costs, because you'll never have to run excess instances to handle peak load; you'll only run what's necessary at any given time.
+
+The difference between this feature and what is typical in autoscaling, is that there's no specified maximum for creating new instances. It will automatically start only existing instances. For example, if you want to have a maximum of 10 instances available to service requests, then you need to create 10 instances of your app.
+
+If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to false. Instances will scale down to zero if `auto_stop_machines` is true and there’s no traffic to your app.
+

--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -6,9 +6,11 @@ nav: firecracker
 order: 65
 ---
 
-<%= partial "/docs/partials/v2_transition_banner" %>
+<div class="callout">
+This feature only works for V2 apps. For more information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
+</div>
 
-You can decide whether you want to automatically stop, or downscale, instances of your app when they're idle and automatically restart them when they're needed. Each instance of your app is running on a Fly machine. Fly Proxy controls automatically starting and automatically stopping machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
+You can decide whether you want to automatically stop an app's machines when they're idle and automatically restart them when they're needed. Fly Proxy controls automatically starting and automatically stopping machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
 
 ```toml
 ...
@@ -44,11 +46,11 @@ auto_stop_machines = false
 auto_start_machines = true
 ```
 
-In most cases, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having instances that either never start or never stop. 
+In most cases, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. 
 
-If `auto_start_machines = true` and `auto_stop_machines = false`, the proxy will start your instances but they will never be stopped automatically. If you have a reason to only stop instances manually, then these settings are just fine.
+If `auto_start_machines = true` and `auto_stop_machines = false`, the proxy will start your machines but they will never be stopped automatically. If you have a reason to only stop machines manually, then these settings are just fine.
 
-If `auto_start_machines = false` and `auto_stop_machines = true`, the proxy will scale your instances down but won't be able to start them again. If all of your instances are scaled down, then requests will start failing.
+If `auto_start_machines = false` and `auto_stop_machines = true`, the proxy will stop your machines when there's low traffic, but won't be able to start them again. If all or most of your machines are stopped, then requests will start failing.
 
 ## How It Works
 
@@ -56,28 +58,27 @@ The Fly Proxy runs the process to stop and start machines automatically every fe
 
 When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each machine to determine if there's excess capacity. If the proxy decides there's excess capcity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
 
-Fly Proxy considers all of the running instances of your app in a given region, such as `fra`, and determines excess capacity as follows:
+Fly Proxy considers all of the app's machines that are currently running in a given region, such as `fra`, and determines excess capacity as follows:
 
-* If there's more than one instance in the region:
-  * the proxy determines how many instances are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of instances - (num instances over soft limit + 1)`
-  * if excess capacity is 1 or greater, then the proxy stops 1 instance
-* If there's only one instance in the region:
-  * the proxy checks if the instance has any traffic
-  * if the instance has no traffic (a load of 0), then the proxy stops the instance
+* If there's more than one machine in the region:
+  * the proxy determines how many machines are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of machines - (num machines over soft limit + 1)`
+  * if excess capacity is 1 or greater, then the proxy stops one machine
+* If there's only one machine in the region:
+  * the proxy checks if the machine has any traffic
+  * if the machine has no traffic (a load of 0), then the proxy stops the machine
 
-When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an instance in the nearest region when required.
+When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an a machine in the nearest region when required.
 
-Fly Proxy determines when to start an instance as follows:
+Fly Proxy determines when to start a machine as follows:
 
 * The proxy waits for a request to your app.
-* If all running instances are above their `soft_limit` setting, then the proxy starts a stopped instance from the nearest region (if there are any stopped instances).
-* The proxy routes the request to the newly started instance.
+* If all running machines are above their `soft_limit` setting, then the proxy starts a stopped machine in the nearest region (if there are any stopped machines).
+* The proxy routes the request to the newly started machine.
 
 ## When to Stop and Start Machines Automatically, or Not
 
-If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your instances as demand decreases and increases. This could reduce costs, because you'll never have to run excess instances to handle peak load; you'll only run and be charged for the number of machines that are needed at any given time.
+If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your machines as demand decreases and increases. This could reduce costs, because you'll never have to run excess machines to handle peak load; you'll only run, and be charged for, the number of machines that are needed at any given time.
 
-The difference between this feature and what is typical in autoscaling, is that there's no specified maximum for creating new instances. It will automatically start only existing instances. For example, if you want to have a maximum of 10 instances available to service requests, then you need to create 10 instances of your app.
+The difference between this feature and what is typical in autoscaling, is that it doesn't create new machines up to a specified maximum. It will automatically start only existing machines. For example, if you want to have a maximum of 10 machines available to service requests, then you need to create 10 machines for your app.
 
-If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. Instances will scale down to zero if `auto_stop_machines` is set to `true` and there’s no traffic to your app.
-
+If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines` is set to `true` and there’s no traffic to your app, eventually all of your app's machines could be stopped.

--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -8,7 +8,7 @@ order: 65
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-You can decide whether you want to automatically stop, or downscale, instances of your app when they're idle and automatically restart them when they're needed. Each instance of your app is running on a Fly machine. Fly Proxy controls automatically starting and automaticaly stopping machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
+You can decide whether you want to automatically stop, or downscale, instances of your app when they're idle and automatically restart them when they're needed. Each instance of your app is running on a Fly machine. Fly Proxy controls automatically starting and automatically stopping machines according to settings in your `fly.toml` file, in either the `services` or `http_service` sections:
 
 ```toml
 ...
@@ -30,7 +30,7 @@ You can decide whether you want to automatically stop, or downscale, instances o
 
 ## Default and recommended values
 
-New V2 app created using the `fly launch` command are automatically started and automatically stopped by default:
+New V2 apps created using the `fly launch` command are automatically started and automatically stopped by default:
 
 ```toml
 auto_stop_machines = true
@@ -56,7 +56,7 @@ The Fly Proxy runs the process to stop and start machines automatically every fe
 
 When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each machine to determine if there's excess capacity. If the proxy decides there's excess capcity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
 
-Fly proxy considers all of the running instances of your app in a given region, such as `fra`, and determines excess capacity as follows:
+Fly Proxy considers all of the running instances of your app in a given region, such as `fra`, and determines excess capacity as follows:
 
 * If there's more than one instance in the region:
   * the proxy determines how many instances are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of instances - (num instances over soft limit + 1)`
@@ -67,7 +67,7 @@ Fly proxy considers all of the running instances of your app in a given region, 
 
 When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts an instance in the nearest region when required.
 
-Fly proxy determines when to start an instance as follows:
+Fly Proxy determines when to start an instance as follows:
 
 * The proxy waits for a request to your app.
 * If all running instances are above their `soft_limit` setting, then the proxy starts a stopped instance from the nearest region (if there are any stopped instances).
@@ -75,9 +75,9 @@ Fly proxy determines when to start an instance as follows:
 
 ## When to Stop and Start Machines Automatically, or Not
 
-If your app has highly variable workloads, then you can set `auto_stop_machines` and `auto_start_machines` to true to manage your instances as demand decreases and increases. This could reduce costs, because you'll never have to run excess instances to handle peak load; you'll only run what's necessary at any given time.
+If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your instances as demand decreases and increases. This could reduce costs, because you'll never have to run excess instances to handle peak load; you'll only run and be charged for the number of machines that are needed at any given time.
 
 The difference between this feature and what is typical in autoscaling, is that there's no specified maximum for creating new instances. It will automatically start only existing instances. For example, if you want to have a maximum of 10 instances available to service requests, then you need to create 10 instances of your app.
 
-If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to false. Instances will scale down to zero if `auto_stop_machines` is true and there’s no traffic to your app.
+If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. Instances will scale down to zero if `auto_stop_machines` is set to `true` and there’s no traffic to your app.
 

--- a/apps/index.html.md.erb
+++ b/apps/index.html.md.erb
@@ -28,6 +28,8 @@ In this section we'll talk about how to create and manage a [Fly App](/docs/refe
     <%= nav_link "Add or Remove Machines", "/docs/apps/scale-count/" %>
     </li>
     <li>
+    <%= nav_link "Automatically Stop and Start App Machines", "/docs/apps/autostart-stop/" %>
+    <li>
     <%= nav_link "Restart an App", "/docs/apps/restart/" %>
     </li>
     <li>

--- a/apps/index.html.md.erb
+++ b/apps/index.html.md.erb
@@ -28,7 +28,7 @@ In this section we'll talk about how to create and manage a [Fly App](/docs/refe
     <%= nav_link "Add or Remove Machines", "/docs/apps/scale-count/" %>
     </li>
     <li>
-    <%= nav_link "Automatically Stop and Start App Machines", "/docs/apps/autostart-stop/" %>
+    <%= nav_link "Automatically Stop and Start App Fly Machines", "/docs/apps/autostart-stop/" %>
     <li>
     <%= nav_link "Restart an App", "/docs/apps/restart/" %>
     </li>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -65,6 +65,8 @@
         <%= nav_link "Scale the Number of Machines", "/docs/apps/scale-count/" %>
       </li>
       <li>
+        <% nav_link "Auto Stop and Start Machines", "/docs/apps/autostart-stop/" %>
+      <li>
         <%= nav_link "Restart an App", "/docs/apps/restart/" %>
       </li>
       <li>
@@ -76,7 +78,7 @@
       <li>
         <%= nav_link "Scale V1 (Nomad) Apps", "/docs/apps/legacy-scaling/" %>
       </li>
-            <li>
+      <li>
         <%= nav_link "Migrate an Existing Fly App to Apps V2", "/docs/apps/migrate-to-v2/" %>
       </li>      
       <li>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -66,6 +66,7 @@
       </li>
       <li>
         <% nav_link "Auto Stop and Start Machines", "/docs/apps/autostart-stop/" %>
+      </li>
       <li>
         <%= nav_link "Restart an App", "/docs/apps/restart/" %>
       </li>

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -208,7 +208,7 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `force_https`: A boolean which determines whether to enforce HTTP to HTTPS redirects.
-* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop machines every few minutes. The default it `true`.
+* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop machines every few minutes. The default it `true`.
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 
 <div class="callout">

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -208,11 +208,11 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `force_https`: A boolean which determines whether to enforce HTTP to HTTPS redirects.
-* `auto_stop_machines`: Whether to automatically stop instances of an application when there's excess capacity, per region. If there's only one instance in a region, then the instance is stopped if it has no traffic when the autostop process runs. The default it `true`.
-* `auto_start_machines`: Whether to automatically start instances of an application when a new request is made to the application and there's no excess capacity, per region. If there's only one instance in a region, then it's started whenever a request is made to the application. The default is `true`.
+* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop machines every few minutes. The default it `true`.
+* `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 
 <div class="callout">
-We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having instances that either never start or never stop. Learn more about [automatically starting and stopping Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
+We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
 The `[http_service.concurrency]` section has the same settings as `[services.concurrency]`, which are:
@@ -248,11 +248,11 @@ The `services` section itself is a table of tables in TOML, so the section is de
 
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `protocol` : The protocol that this service will use to communicate. Typically `tcp` for most applications, but can also be `udp`.
-* `auto_stop_machines`: Whether to automatically stop instances of an application when there's excess capacity, per region. If there's only one instance in a region, then the instance is stopped if it has no traffic when the autostop process runs. The default it `true`.
-* `auto_start_machines`: Whether to automatically start instances of an application when a new request is made to the application and there's no excess capacity, per region. If there's only one instance in a region, then it's started whenever a request is made to the application. The default is `true`.
+* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop machines every few minutes. The default it `true`.
+* `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 
 <div class="callout">
-We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having instances that either never start or never stop. Learn more about [automatically starting and stopping Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
+We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
 ### `services.concurrency`

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -198,6 +198,8 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 [http_service]
   internal_port = 8080
   force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
   [http_service.concurrency]
     type = "requests"
     soft_limit = 200
@@ -206,6 +208,12 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `force_https`: A boolean which determines whether to enforce HTTP to HTTPS redirects.
+* `auto_stop_machines`: Whether to automatically stop instances of an application when there's excess capacity, per region. If there's only one instance in a region, then the instance is stopped if it has no traffic when the autostop process runs. The default it `true`.
+* `auto_start_machines`: Whether to automatically start instances of an application when a new request is made to the application and there's no excess capacity, per region. If there's only one instance in a region, then it's started whenever a request is made to the application. The default is `true`.
+
+<div class="callout">
+We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having instances that either never start or never stop. Learn more about [automatically starting and stopping Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
+</div>
 
 The `[http_service.concurrency]` section has the same settings as `[services.concurrency]`, which are:
 
@@ -234,10 +242,18 @@ The `services` section itself is a table of tables in TOML, so the section is de
 [[services]]
   internal_port = 8080
   protocol = "tcp"
+  auto_stop_machines = true
+  auto_start_machines = true
 ```
 
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `protocol` : The protocol that this service will use to communicate. Typically `tcp` for most applications, but can also be `udp`.
+* `auto_stop_machines`: Whether to automatically stop instances of an application when there's excess capacity, per region. If there's only one instance in a region, then the instance is stopped if it has no traffic when the autostop process runs. The default it `true`.
+* `auto_start_machines`: Whether to automatically start instances of an application when a new request is made to the application and there's no excess capacity, per region. If there's only one instance in a region, then it's started whenever a request is made to the application. The default is `true`.
+
+<div class="callout">
+We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having instances that either never start or never stop. Learn more about [automatically starting and stopping Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
+</div>
 
 ### `services.concurrency`
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -212,7 +212,7 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 
 <div class="callout">
-We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
+We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
 The `[http_service.concurrency]` section has the same settings as `[services.concurrency]`, which are:
@@ -252,7 +252,7 @@ The `services` section itself is a table of tables in TOML, so the section is de
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 
 <div class="callout">
-We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how the process determines excess capacity in a region using the `soft_limit` setting.
+We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
 ### `services.concurrency`


### PR DESCRIPTION
This PR: 
- adds a new page under Apps about automatically stopping and starting Machines
- adds the new settings to the fly.toml config doc page
- adds new page to sidenav and apps index page

Source material: https://community.fly.io/t/automatically-starting-stopping-apps-v2-instances/12342

Tested locally. See comments for questions/issues.