### PR TITLE
Fix nav link tag

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -65,7 +65,7 @@
         <%= nav_link "Scale the Number of Machines", "/docs/apps/scale-count/" %>
       </li>
       <li>
-        <% nav_link "Auto Stop and Start Machines", "/docs/apps/autostart-stop/" %>
+        <%= nav_link "Auto Stop and Start Machines", "/docs/apps/autostart-stop/" %>
       </li>
       <li>
         <%= nav_link "Restart an App", "/docs/apps/restart/" %>


### PR DESCRIPTION
add missing `=` in new nav link tag