### PR TITLE
mention that ENTRYPOINT always runs after release_command

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -131,7 +131,7 @@ This section configures deployment-related settings such as the release command 
 
 This command runs in a temporary VM - using the successfully built release - *before* that release is deployed. This is useful for running database migrations.
 
-The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes.  Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` or `ENTRYPOINT` in your Dockerfile.
+The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes.  Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` or `ENTRYPOINT` in your Dockerfile. Note that `ENTRYPOINT` will always run, as `release_command` only overrides `CMD`.
 
 A non-zero exit status from this command will stop the deployment. `fly deploy` will display logs from the command. Logs are available via `fly logs` as well.
 


### PR DESCRIPTION
Hello!

I had an issue today with my deployments not finishing  and I ended up opening an issue as I had no idea what was causing it:
https://community.fly.io/t/deployment-issue-release-command-timing-out/12395/7

Here's the PR that adds to the release_command documentation that it only overrides `CMD`, and that `ENTRYPOINT` will always run.

Wasn't sure where to put it, so I left it right at the start of the docs. But I also think it could be near the `RELEASE_COMMAND` env var, so I just went with what had the smallest change overall.