### PR TITLE
config doc: clarify how release_command works

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -138,7 +138,7 @@ A non-zero exit status from this command will stop the deployment. `fly deploy` 
 
 To ensure the command runs in a specific region - say `dfw` - set `PRIMARY_REGION = 'dfw'` on in your application environment in `fly.toml` or with `fly deploy -e PRIMARY_REGION=dfw`. Setting `PRIMARY_REGION` is important if when running [database replicas in multiple regions](/docs/postgres/high-availability-and-global-replication).
 
-The environment variable `RELEASE_COMMAND=1` is set for you within the temporary release VM. This might be useful if you need to customize your Dockerfile `ENTRYPOINT` to behave differently within a release VM.
+The environment variable `RELEASE_COMMAND=1` is set within the temporary release VM. You can use this to define behavior in your Dockerfile's `ENTRYPOINT`  that's conditional on being run on a release VM.
 
 ### Picking a deployment strategy
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -132,7 +132,7 @@ To run a command in a temporary VM&mdash;using the app's successfully built Dock
 ```
 The `release_command` value replaces `CMD` in the temporary VM. This is useful for running database migrations before app VMs are created or updated with the new release. Note that the Docker image's `ENTRYPOINT` is not overridden by the `release_command`; `ENTRYPOINT` always runs.
 
-The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes. Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` in your Dockerfile, or of a [process group command](#the-processes-section).
+The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes. Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` or `ENTRYPOINT` in your Dockerfile, or of a [process group command](#the-processes-section).
 
 A non-zero exit status from this command will stop the deployment. `fly deploy` will display logs from the command. Logs are available via `fly logs` as well.
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -124,14 +124,15 @@ This section configures deployment-related settings such as the release command 
 
 ### Run one-off commands before releasing a deployment
 
+To run a command in a temporary VM&mdash;using the app's successfully built Docker image&mdash;*before* the release is deployed, define a `release_command`:
+
 ```toml
 [deploy]
   release_command = "bundle exec rails db:migrate"
 ```
+The `release_command` value replaces `CMD` in the temporary VM. This is useful for running database migrations before app VMs are created or updated with the new release. Note that the Docker image's `ENTRYPOINT` is not overridden by the `release_command`; `ENTRYPOINT` always runs.
 
-This command runs in a temporary VM - using the successfully built release - *before* that release is deployed. This is useful for running database migrations.
-
-The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes.  Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` or `ENTRYPOINT` in your Dockerfile.
+The temporary VM has full access to the network, environment variables and secrets, but *not* to persistent volumes. Changes made to the filesystem on the temporary VM will not be retained or deployed.  If you need to modify persistent volumes or configure your application, consider making use of `CMD` in your Dockerfile, or of a [process group command](#the-processes-section).
 
 A non-zero exit status from this command will stop the deployment. `fly deploy` will display logs from the command. Logs are available via `fly logs` as well.
 


### PR DESCRIPTION
@brenol pointed out some clarifications for the release command option in fly.toml. (https://github.com/superfly/docs/pull/690) 

Github's not letting me make suggestions on the PR and I wanted to change some more things, thus this new PR