### PR TITLE
move exit-from-within discussion to autostart doc

### DIFF
--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -12,6 +12,8 @@ This feature only works for V2 apps. For information about scaling V1 apps, refe
 
 Fly Machines are fast to start and stop, and you don't pay for their CPU and RAM when they're in the `stopped` state. For Fly Apps with a service configured, Fly Proxy can start and stop existing Machines based on incoming requests, so that your app can accommodate bursts in demand without keeping extra Machines running constantly.
 
+This Fly Proxy feature also plays well with apps whose Machines [exit from within](#stop-a-machine-by-terminating-its-main-process) when idle.
+
 You can configure automatic starts and automatic stops independently with the `auto_stop_machines` and `auto_start_machines` settings, and tune them with concurrency limits, within the [[[services]]](/docs/reference/configuration/#the-services-sections) or [[http_service]](/docs/reference/configuration/#the-http_service-section) sections of `fly.toml`.
 
 ```toml
@@ -86,3 +88,14 @@ If your app has highly variable request workloads, then you can set `auto_stop_m
 The difference between this feature and what is typical in autoscaling, is that it doesn't create new Machines up to a specified maximum. It will automatically start only existing Machines. For example, if you want to have a maximum of 10 Machines available to service requests, then you need to create 10 Machines for your app.
 
 If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines` is set to `true` and there’s no traffic to your app, eventually all of your app's Machines could be stopped.
+
+## Stop a Machine by terminating its main process
+
+There are many ways to make a web app exit after some inactivity. Here are some examples:
+
+* [Shutting Down a Phoenix App When Idle](https://fly.io/phoenix-files/shut-down-idle-phoenix-app/): a post by Chris McCord on adding a task to an Elixir app's supervision tree that shuts down the Erlang runtime when there are no active connections.
+* For Rails apps, dockerfile-rails provides a [--max-idle](https://github.com/rubys/dockerfile-rails#addremove-a-feature) option that will exit after _n_ seconds of inactivity.
+* [A Tired Proxy in Go](https://github.com/superfly/tired-proxy) used in [Building an In-Browser IDE the Hard Way](https://fly.io/blog/remote-ide-machines/). [There's a community fork with more recent updates](https://community.fly.io/t/improved-tired-proxy-for-use-with-fly-machines/10584).
+* A minimal demo app in Typescript/Remix: [code](https://github.com/fly-apps/autoscale-to-zero-demo) &amp; [demo](https://autoscale-to-zero-demo.fly.dev/).
+
+As of `flyctl` v0.0.520, Fly Postgres [supports this too](https://community.fly.io/t/scale-to-zero-postgres-for-hobby-projects/12212)!

--- a/apps/scale-count.html.md.erb
+++ b/apps/scale-count.html.md.erb
@@ -37,12 +37,3 @@ fly machine destroy --force 0e286039f42e86
 If you `destroy` a Machine, don't forget that any volume that it had been using still exists until you either `fly volumes delete` it or `fly destroy` the Fly App it belongs to.
 
 **For existing Nomad/V1 Fly Apps**: Existing apps whose VMs are managed by Nomad can still be scaled "horizontally" using [`fly scale count`](/docs/flyctl/scale-count/). For more, see [Scale V1 (Nomad) Apps](/docs/apps/legacy-scaling/).
-
-### Scale to zero
-
-To have your app automatically scale to zero, you just need to make its process terminate. If your app's process exits, the Machine running it stops, so you don't get charged for CPU/memory. Then when a request comes, our Fly Proxy will wake it up again. There are many ways to make a web app exit after some inactivity, for example:
-- here is a minimal app in Typescript/Remix: [code](https://github.com/fly-apps/autoscale-to-zero-demo) & [demo](https://autoscale-to-zero-demo.fly.dev/).
-- here is a [blog post](https://fly.io/phoenix-files/shut-down-idle-phoenix-app/) about it in Elixir/Phoenix, that makes sure that no client connection is active when it stops.
-- for Rails apps, dockerfile-rails provides a [--max-idle](https://github.com/rubys/dockerfile-rails#addremove-a-feature) option that will exit after _n_ seconds of inactivity.
-
-As of `flyctl` v0.0.520, Fly Postgres [support this too](https://community.fly.io/t/scale-to-zero-postgres-for-hobby-projects/12212)!


### PR DESCRIPTION
In preparation for new app scaling doc based on new `fly scale count` functionality