### PR TITLE
shorten v2 banner; move some of it to apps ref doc

### DIFF
--- a/partials/_v2_transition_banner.html.erb
+++ b/partials/_v2_transition_banner.html.erb
@@ -1,7 +1,5 @@
-<div class="border border-violet-600 bg-violet-50 rounded-l p-4 my-4 text-base text-navy">
-We're rolling out [**V2 of the Fly Apps platform**](/docs/reference/apps/#apps-v2), running on [**Fly Machines**](/docs/machines/). New customers' organizations now default to deploying V2 apps, and docs put Apps V2 in the foreground. Much remains the same! But where there's a difference between Apps V2 and the [**original Nomad-orchestrated Fly Apps**](/docs/reference/apps/#legacy-apps-fly-apps-v1), we'll supply Nomad-specific information either inline or at the end of the doc. 
+<div class="border border-blue-600 bg-blue-50 rounded-l p-4 my-4 text-base text-navy">
+New customers' organizations now deploy to <u>[V2](/docs/reference/apps/#apps-v2)</u> of the <u>[Fly Apps platform](/docs/reference/apps/)</u>, running on <u>[Fly Machines](/docs/machines/)</u>. Docs put Apps V2 in the foreground, but include information specific to the legacy <u>[Fly Apps V1](/docs/reference/apps/#legacy-apps-fly-apps-v1)</u> where appropriate.
 <br><br>
-You can check if your org defaults to Apps V2 deployments with `fly orgs apps-v2 show <org-slug>`. Get your organization slug using `fly orgs list`. 
-<br><br>
-If you're not a new customer but want to ride the wave of the future, start deploying your new apps to Apps V2 with `fly orgs apps-v2 default-on <org-slug>`.
+Start deploying your new apps to Apps V2 with `fly orgs apps-v2 default-on <org-slug>`. You can also <u>[migrate your V1 apps](/docs/apps/migrate-to-v2/)</u>!
 </div>

--- a/reference/apps.html.md.erb
+++ b/reference/apps.html.md.erb
@@ -4,8 +4,16 @@ layout: docs
 toc: false
 nav: firecracker
 ---
+<div class="callout">
 
-<%= partial "/docs/partials/v2_transition_banner" %>
+New customers' organizations use [V2 of the Fly Apps platform](/docs/reference/apps/#apps-v2), running on [Fly Machines](/docs/machines/).
+
+You can check if your org defaults to Apps V2 deployments with `fly orgs apps-v2 show <org-slug>`. Get your organization slug using `fly orgs list`. 
+
+Flip the switch to start deploying your new apps to Apps V2 with `fly orgs apps-v2 default-on <org-slug>`.
+
+You can also [migrate your existing V1 apps to Apps V2](/docs/apps/migrate-to-v2/).
+</div>
 
 On Fly.io, an App is an abstraction for a group of virtual machines running your code, along with the the configuration, provisioned resources, and data we need to keep track of to run and route to your VMs. 
 


### PR DESCRIPTION
This was way too long, and not so much info is needed now that V2 has been around for a while.

Also distinguish banner from the new callout style. It ain't exactly pretty.