### PR TITLE
Fix spelling error

### DIFF
--- a/postgres/index.html.md
+++ b/postgres/index.html.md
@@ -23,7 +23,7 @@ When you create a Fly Postgres cluster, you're offered several preset configurat
 
 Flyctl also offers a single-instance "Development" config. If you choose this option and the hardware it's running on has network problems or the SSD fails, your database will go down. In the latter case, you will lose any data accumulated since the last snapshot. Fly Postgres is designed so that you can turn a single-node cluster into a high-availability one just by adding a second instance in the same region.
 
-In the single-instance "Development" config, you'll aslo be given the option to activate "automatic scale to zero". It's not magic: it's just [how our apps work](/docs/apps/scale-count/#scale-to-zero). If you have an app that connects to your database, make sure that [it also scales to zero](/docs/apps/scale-count/#scale-to-zero) (otherwise the connection remaining open will prevent it from "going to sleep").
+In the single-instance "Development" config, you'll also be given the option to activate "automatic scale to zero". It's not magic: it's just [how our apps work](/docs/apps/scale-count/#scale-to-zero). If you have an app that connects to your database, make sure that [it also scales to zero](/docs/apps/scale-count/#scale-to-zero) (otherwise the connection remaining open will prevent it from "going to sleep").
 
 You can also add read-only replicas in other regions and take advantage of the Fly.io platform's proxy features to build a [Globally Distributed Postgres cluster](/docs/postgres/advanced-guides/high-availability-and-global-replication).
 


### PR DESCRIPTION
Fixes the spelling error on [this page](https://fly.io/docs/postgres/) of the docs. Changes `aslo` to `also`.