### PR TITLE
Update volume docs for clarity and user feedback

### DIFF
--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -10,11 +10,11 @@ order: 30
 
 Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state—to preserve configuration, session or user data—and then be restarted with that information in place.
 
-**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app need to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) for exceptions to the rule and details about how volumes are implemented.
+**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) for exceptions to the rule and details about how volumes are implemented.
 
 ## Launch an app with a Fly Volume
 
-Follow these steps to create a new app, a new volume, and then mount the volume before deply. If you need to add a volume to an exsiting app, refer to TBD. 
+Follow these steps to create a new app, a new volume, and then mount the volume before deploy. If you need to add a volume to an existing app, refer to [Add a volume to an existing app by cloning](#add-a-volume-to-an-existing-app-by-cloning). 
 
 ### Launch the app, but don't deploy it yet
 
@@ -130,7 +130,32 @@ Create an additional volume in the desired region, then [use `fly scale count`](
 
 ## Add a volume to an existing app by cloning
 
-TBD since there are 2 open PRs to possibly improve this process
+If you try to add a volume to an app that's already been deployed, you might get errors because the volume and the Machine created for your app on deploy need to be on the same physical host. One way to get around this is to attach a new volume to a clone of one of your app's Machines.
+
+Create new volume for your app in the same region the app will be deployed:
+
+```cmd
+fly volumes create myapp_data --region lhr --size 1 --app myapp
+```
+
+Clone one of your app's Machine (with no volume) and attach the volume you just created:
+
+```cmd
+fly machine clone <machine-id> --attach-volume <vol-id>
+```
+
+Destroy the Machine you used to create the clone:
+```cmd
+fly machine destroy <non-volume-machine-id>
+```
+
+Check whether the volume is properly attached to the Machine:
+
+```cmd
+fly volumes list
+```
+
+The volume you just created should have the newly-cloned Machine's ID listed under `ATTACHED VM`.
 
 ## Remove a volume from an app
 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Use Volume Storage
+title: Add and Use Volume Storage
 layout: docs
 nav: firecracker
 titlecase: false
@@ -124,7 +124,7 @@ vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            
 
 At this point there are two identically configured Machines on the app, each with a volume of the same size. You take it from here, setting up whatever data replication you need. 
 
-### On a Nomad app
+### On a V1 (Nomad) app
 
 Create an additional volume in the desired region, then [use `fly scale count`](/docs/legacy-scaling/) to add a VM to use it.
 
@@ -161,6 +161,6 @@ The volume you just created should have the newly-cloned Machine's ID listed und
 
 You can't currently unmount a volume from an existing Machine. If you need to remove volumes from your app, you can [scale it](/docs/apps/scale-count/) down to zero Machines, [destroy all the volumes](/docs/reference/volumes#delete-a-volume), remove the `mounts` section from `fly.toml`, and redeploy. **Only destroy a volume whose data you no longer need access to.**
 
-### On a Nomad app
+### On a V1 (Nomad) app
 
-Remove the `mounts` section from `fly.toml` and redeploy. This will create a new VM without a volume. [Destroy any unused volumes](/docs/reference/volumes#delete-a-volume), **only if you no longer need their data**.
+Remove the `mounts` section from `fly.toml` and redeploy. This will create a new Machine without a volume. [Destroy any unused volumes](/docs/reference/volumes#delete-a-volume), **only if you no longer need their data**.

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Add Volume Storage
+title: Use Volume Storage
 layout: docs
 nav: firecracker
 titlecase: false
@@ -8,33 +8,17 @@ order: 30
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Running apps can store ephemeral data on the root file systems of their member Machines, but a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted.
+Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state—to preserve configuration, session or user data—and then be restarted with that information in place.
 
-## Choosing an approach to storage
-
-Often the solution to persistent data storage is to connect your Fly App to a separate [database or object store](/docs/database-storage-guides/).
-
-Fly.io offers a [deploy-it-yourself Postgres app](/docs/postgres/) with some tools to make it easier to manage yourself.
-
-If you need hardware-local disk storage on your Fly App VMs&mdash;for example, if your Fly App _is_ a database (or if you want to use [LiteFS](/docs/litefs))&mdash;you'll want to use [Fly Volumes](/docs/reference/volumes/).
-
-A Fly Volume is a slice of NVMe disk storage attached to the server that hosts your Machine. This has pros and cons, and you should look at the [Fly Volumes](/docs/reference/volumes/) page before deciding that this is the best solution for your use case.
-
-<div class="callout">
-**The TLDC (too lazy, didn't click) of that is:** Volume storage attached to your app's worker is a lot like the disk inside your laptop. It's fast and convenient to use, right there in your app's file system. Also like your laptop, an app with a single Machine and a single volume does not have high availability built in. **Hardware fails. You should run at least two Machines per app, and if you're using volumes, that means two volumes. You will experience downtime at some point if you only create one.**
-</div>
-
-Explore further options for data storage in [Databases & Storage](/docs/database-storage-guides/).
-
-Fly Postgres has [its own usage docs](/docs/postgres/), so here we'll focus on using Fly Volumes with your app.
+**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app need to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) for exceptions to the rule and details about how volumes are implemented.
 
 ## Launch an app with a Fly Volume
 
-**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run two Machines. Volumes don't sync up by themselves; different apps will have their own ways of dealing with this, so we won't get into that here.
+Follow these steps to create a new app, a new volume, and then mount the volume before deply. If you need to add a volume to an exsiting app, refer to TBD. 
 
-### Launch the app, but don't deploy immediately.
+### Launch the app, but don't deploy it yet
 
-The app has to exist for the volume to be created. The volume has to exist before you can mount it to a Machine. The first deployment will create a Machine. So the shortest path to a Machine with a mounted volume begins by launching the app, and saying `N` to "deploy now?":
+The app has to exist for the volume to be created. The volume has to exist before you can mount it to a Machine. The first deployment of your app will create a Machine. So the shortest path to a Machine with a mounted volume begins by launching the app, and saying `N` to "deploy now?":
 
 ```cmd
 fly launch 
@@ -43,25 +27,26 @@ fly launch
 ...
 Wrote config file fly.toml
 ? Would you like to deploy now? No
+...
 Your app is ready! Deploy with `flyctl deploy`
+```
+
+### Provision the volume
+
+Create a volume for the app, with the name you chose, in the same region you're deploying the app to. For example, the following command creates a volume called `myapp_data`, in region `lhr`, with 1GB of storage, for the app named `myapp`:
+
+```cmd
+fly volumes create myapp_data --region lhr --size 1 --app myapp
 ```
 
 ### Configure the app to mount the volume
 
-Make sure there's a `[mounts]` section in `fly.toml`. As an example, the following configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+Add a `[mounts]` section in the app's `fly.toml`. For example, the following configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
 
 ```toml
 [mounts]
 source="myapp_data"
 destination="/data"
-```
-
-### Provision the volume
-
-Create a volume for the app, with the name you chose, in the same region you're deploying the app to:
-
-```cmd
-fly volumes create myapp_data --region lhr --size 1 --app myapp
 ```
 
 ### Deploy the app
@@ -71,6 +56,23 @@ fly deploy
 ```
 
 On the first deployment, you'll get one Machine. You can confirm this with `fly status`.
+
+```cmd
+fly status
+```
+
+```out
+App
+  Name     = myapp
+  Owner    = personal
+  Hostname = myapp.fly.dev
+  Image    = image:latest
+  Platform = machines
+
+Machines
+PROCESS	ID            	VERSION	REGION	STATE  	CHECKS 	LAST UPDATED
+app    	6e82944a79dd87	1      	lhr   	started	1 total	2023-04-26T20:40:48Z
+```
 
 ### Confirm the volume is mounted
 
@@ -125,6 +127,10 @@ At this point there are two identically configured Machines on the app, each wit
 ### On a Nomad app
 
 Create an additional volume in the desired region, then [use `fly scale count`](/docs/legacy-scaling/) to add a VM to use it.
+
+## Add a volume to an existing app by cloning
+
+TBD since there are 2 open PRs to possibly improve this process
 
 ## Remove a volume from an app
 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -14,7 +14,7 @@ Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volume
 
 ## Launch an app with a Fly Volume
 
-Follow these steps to create a new app, a new volume, and then mount the volume before deploy. If you need to add a volume to an existing app, refer to [Add a volume to an existing app by cloning](#add-a-volume-to-an-existing-app-by-cloning). 
+Follow these steps to create a new app, add the volume you want to create to `fly.toml`, and then deploy the app. 
 
 ### Launch the app, but don't deploy it yet
 
@@ -31,17 +31,9 @@ Wrote config file fly.toml
 Your app is ready! Deploy with `flyctl deploy`
 ```
 
-### Provision the volume
+### Configure the app to mount the new volume
 
-Create a volume for the app, with the name you chose, in the same region you're deploying the app to. For example, the following command creates a volume called `myapp_data`, in region `lhr`, with 1GB of storage, for the app named `myapp`:
-
-```cmd
-fly volumes create myapp_data --region lhr --size 1 --app myapp
-```
-
-### Configure the app to mount the volume
-
-Add a `[mounts]` section in the app's `fly.toml`. For example, the following configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+Add a `[mounts]` section in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the volume during the deploy process. For example, the following configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
 
 ```toml
 [mounts]
@@ -71,7 +63,7 @@ App
 
 Machines
 PROCESS	ID            	VERSION	REGION	STATE  	CHECKS 	LAST UPDATED
-app    	6e82944a79dd87	1      	lhr   	started	1 total	2023-04-26T20:40:48Z
+app    	5683606c41098e	1      	lhr   	started	1 total	2023-04-26T20:40:48Z
 ```
 
 ### Confirm the volume is mounted
@@ -101,7 +93,7 @@ tmpfs             113224      0    113224   0% /sys/fs/cgroup
 /dev/vdb         1011672   2564    940500   1% /data
 ```
 
-Voilà: our 1GB volume is mounted at `/data`.
+Voilà: our 1GB volume is mounted at `/data`. You can access and write to a volume on a Machine just like a regular directory.
 
 ### Clone the first Machine to scale out to two VMs
 
@@ -127,35 +119,6 @@ At this point there are two identically configured Machines on the app, each wit
 ### On a V1 (Nomad) app
 
 Create an additional volume in the desired region, then [use `fly scale count`](/docs/legacy-scaling/) to add a VM to use it.
-
-## Add a volume to an existing app by cloning
-
-If you try to add a volume to an app that's already been deployed, you might get errors because the volume and the Machine created for your app on deploy need to be on the same physical host. One way to get around this is to attach a new volume to a clone of one of your app's Machines.
-
-Create new volume for your app in the same region the app will be deployed:
-
-```cmd
-fly volumes create myapp_data --region lhr --size 1 --app myapp
-```
-
-Clone one of your app's Machine (with no volume) and attach the volume you just created:
-
-```cmd
-fly machine clone <machine-id> --attach-volume <vol-id>
-```
-
-Destroy the Machine you used to create the clone:
-```cmd
-fly machine destroy <non-volume-machine-id>
-```
-
-Check whether the volume is properly attached to the Machine:
-
-```cmd
-fly volumes list
-```
-
-The volume you just created should have the newly-cloned Machine's ID listed under `ATTACHED VM`.
 
 ## Remove a volume from an app
 

--- a/database-storage-guides.html.md
+++ b/database-storage-guides.html.md
@@ -5,18 +5,29 @@ toc: true
 nav: firecracker
 ---
 
+## Choosing an approach to storage
+
+Often the solution to persistent data storage is to connect your Fly App to a separate database or object store.
+
+Fly.io offers a [deploy-it-yourself Postgres app](/docs/postgres/) with some tools to make it easier to manage yourself.
+
+If you need hardware-local disk storage on your Fly App VMs&mdash;for example, if your Fly App _is_ a database (or if you want to use [LiteFS](/docs/litefs))&mdash;then you'll want to use [Fly Volumes](/docs/reference/volumes/).
+
+Explore these, and further options, for data storage in the following sections.
+
 ## Fly Volumes - Disk Storage
 
 Anything an App VM writes to its root disk is ephemeral: when the VM is redeployed, the root filesystem is rebuilt using its Docker image, deleting any data written to it since it was started up. This is fine for `/tmp` files, but most apps need to keep state in a database or another form of persistent storage.
 
-- **[Fly Volumes](/docs/reference/volumes/)** - Persistent storage on Fly.io is provided by Fly Volumes, which are slices of SSDs attached to the server your App VM runs on. You can use Volumes on an App directly, or run a separate database App with Volume storage and connect an App to that.
+- **[Fly Volumes](/docs/reference/volumes/)** - Persistent storage on Fly.io is provided by Fly Volumes. You can use Volumes on an App directly, or run a separate database App with Volume storage and connect an App to that. A Fly Volume is a slice of NVMe disk storage attached to the server that hosts your Machine. Volumes have pros and cons, and you should read up on [Fly Volumes](/docs/reference/volumes/) before deciding whether they're the best solution for your use case.
+
 
 ## Fly.io Database Projects
 
 These are projects that we develop and support. They're not managed services; you can deploy them yourself as Fly Apps.
 
 - **[Fly Postgres](/docs/postgres/)** - [PostgreSQL](https://www.postgresql.org/) is a popular relational database. When you deploy an App on Fly.io, we give you the option to launch a Fly Postgres App and attach it to your App. We provide tools for deployment and management; you manage the cluster once it's deployed.
-- **[SQLite & LiteFS](/docs/litefs/)** - [SQLite](https://www.sqlite.org/index.html) is a very lightweight file-based database. [LiteFS](/docs/litefs/) is a distributed filesystem that transparently replicates SQLite databases. You deploy it and you manage it.
+- **[LiteFS for SQLite](/docs/litefs/)** - [SQLite](https://www.sqlite.org/index.html) is a very lightweight file-based database. [LiteFS](/docs/litefs/) is a distributed filesystem that transparently replicates SQLite databases. You deploy it and you manage it.
 
 ## Partner Integrations Running on Fly.io
 

--- a/database-storage-guides.html.md
+++ b/database-storage-guides.html.md
@@ -17,7 +17,7 @@ Explore these, and further options, for data storage in the following sections.
 
 ## Fly Volumes - Disk Storage
 
-Anything an App VM writes to its root disk is ephemeral: when the VM is redeployed, the root filesystem is rebuilt using its Docker image, deleting any data written to it since it was started up. This is fine for `/tmp` files, but most apps need to keep state in a database or another form of persistent storage.
+Anything an App VM writes to its root disk is ephemeral: when the VM is redeployed, the root file system is rebuilt using its Docker image, deleting any data written to it since it was started up. This is fine for `/tmp` files, but most apps need to keep state in a database or another form of persistent storage.
 
 - **[Fly Volumes](/docs/reference/volumes/)** - Persistent storage on Fly.io is provided by Fly Volumes. You can use Volumes on an App directly, or run a separate database App with Volume storage and connect an App to that. A Fly Volume is a slice of NVMe disk storage attached to the server that hosts your Machine. Volumes have pros and cons, and you should read up on [Fly Volumes](/docs/reference/volumes/) before deciding whether they're the best solution for your use case.
 
@@ -27,7 +27,7 @@ Anything an App VM writes to its root disk is ephemeral: when the VM is redeploy
 These are projects that we develop and support. They're not managed services; you can deploy them yourself as Fly Apps.
 
 - **[Fly Postgres](/docs/postgres/)** - [PostgreSQL](https://www.postgresql.org/) is a popular relational database. When you deploy an App on Fly.io, we give you the option to launch a Fly Postgres App and attach it to your App. We provide tools for deployment and management; you manage the cluster once it's deployed.
-- **[LiteFS for SQLite](/docs/litefs/)** - [SQLite](https://www.sqlite.org/index.html) is a very lightweight file-based database. [LiteFS](/docs/litefs/) is a distributed filesystem that transparently replicates SQLite databases. You deploy it and you manage it.
+- **[LiteFS for SQLite](/docs/litefs/)** - [SQLite](https://www.sqlite.org/index.html) is a very lightweight file-based database. [LiteFS](/docs/litefs/) is a distributed file system that transparently replicates SQLite databases. You deploy it and you manage it.
 
 ## Partner Integrations Running on Fly.io
 

--- a/database-storage-guides.html.md
+++ b/database-storage-guides.html.md
@@ -11,7 +11,7 @@ Often the solution to persistent data storage is to connect your Fly App to a se
 
 Fly.io offers a [deploy-it-yourself Postgres app](/docs/postgres/) with some tools to make it easier to manage yourself.
 
-If you need hardware-local disk storage on your Fly App VMs&mdash;for example, if your Fly App _is_ a database (or if you want to use [LiteFS](/docs/litefs))&mdash;then you'll want to use [Fly Volumes](/docs/reference/volumes/).
+If you need hardware-local disk storage on your Fly App Machines&mdash;for example, if your Fly App _is_ a database (or if you want to use [LiteFS](/docs/litefs))&mdash;then you'll want to use [Fly Volumes](/docs/reference/volumes/).
 
 Explore these, and further options, for data storage in the following sections.
 
@@ -20,7 +20,6 @@ Explore these, and further options, for data storage in the following sections.
 Anything an App VM writes to its root disk is ephemeral: when the VM is redeployed, the root file system is rebuilt using its Docker image, deleting any data written to it since it was started up. This is fine for `/tmp` files, but most apps need to keep state in a database or another form of persistent storage.
 
 - **[Fly Volumes](/docs/reference/volumes/)** - Persistent storage on Fly.io is provided by Fly Volumes. You can use Volumes on an App directly, or run a separate database App with Volume storage and connect an App to that. A Fly Volume is a slice of NVMe disk storage attached to the server that hosts your Machine. Volumes have pros and cons, and you should read up on [Fly Volumes](/docs/reference/volumes/) before deciding whether they're the best solution for your use case.
-
 
 ## Fly.io Database Projects
 

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -105,7 +105,7 @@
         <%= nav_link "Redis by Upstash", "/docs/reference/redis/" %>
       </li>
       <li>
-        <%= nav_link "More...", "/docs/database-storage-guides/" %>
+        <%= nav_link "More...", "/docs/database-storage-guides/#other-storage-apps" %>
       </li>
     </ul>
   </li>

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -41,11 +41,11 @@ Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command.
 
 ## Working with volumes
 
-This section is a reference for working with volumes. If you want the steps to create a new app with a volume, or to add a a volume to an app, then refer to [Add and Use Volume Storage](/docs/apps/volume-storage/).
+This section is a reference for working with volumes. If you want the steps to launch a new app with a volume then refer to [Add and Use Volume Storage](/docs/apps/volume-storage/).
 
 ### Create a Volume
 
-Every Fly Volume belongs to a [Fly App](/docs/reference/apps/). 
+Every Fly Volume belongs to a [Fly App](/docs/reference/apps/).
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -127,7 +127,11 @@ fly volumes extend vol_od56vjp5pzmvny30 -s 2
 
 where `<new-size>` is the extended size in GB. 
 
-You'll need to restart the Machine attached to the target volume to allow the file system to be resized. On Nomad (V1) Apps, the instance is automatically restarted, so this step isn't needed.
+You'll need to restart the Machine attached to the target volume to allow the file system to be resized. 
+
+<div class="callout">
+On Nomad (V1) Apps, the instance is automatically restarted, so this step isn't needed.
+</div>
 
 Get the `id` of the Machine that has the volume mounted (find it under `ATTACHED VM`).
 
@@ -207,7 +211,7 @@ The `flyctl` output shows the details of the new volume, including its size.
 
 ### Destroy a Volume
 
-Delete a volume using the `fly volumes destroy` command. Refer to in the [flyctl reference](/docs/flyctl) for usage and options.
+Destroy a volume using the `fly volumes destroy` command. Refer to in the [flyctl reference](/docs/flyctl) for usage and options.
 
 ```cmd
 fly volumes destroy vol_2n0l9vlnklpr635d -a myapp

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -15,35 +15,35 @@ A Fly Volume is a slice of an NVMe drive on the physical server your Fly App run
 **The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime whenever you deploy your app, because only one Machine can be attached to a volume at a time. 
 </div>
 
-There are exceptions to the rule of running at least two Fly Volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime while you redeply your app, then you can run a single Machine with an attached volume.
+There are exceptions to the rule of running at least two Fly Volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime while you deploy it, then you can run a single Machine with an attached volume.
 
 **Things to consider before settling on volume storage:**
 
 * You'll need to run as many volumes as there are Machines.
-* There's a one-to-one mapping between VMs and volumes. You can't share a volume between apps, nor can two VMs mount the same volume at the same time. A single VM can only mount one volume at a time.
+* There's a one-to-one mapping between Machines and volumes. You can't share a volume between apps, nor can two Machines mount the same volume at the same time. A single Machine can only mount one volume at a time.
 * Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, your app has to make that happen.
 * If your app needs a volume to function, and the NVMe drive hosting your volume fails, that instance of your app goes down. There's no way around that. 
-* If you only have a single copy of your data on a single Fly Volume, and that drive fails, data is lost. Fly.io takes daily snapshots, retained for 5 days, but these are meant as a backstop, not your primary backup method.
+* If you only have a single copy of your data on a single Fly Volume, and that drive fails, data is lost. Fly.io takes daily snapshots and retains them for 5 days, but these are meant as a backstop, not your primary backup method.
 
-If volumes won't work for your use case, you can explore further options for data storage in [Databases & Storage](/docs/database-storage-guides/).
-
-## Fly Volumes and flyctl
-
-Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command. 
+If volumes won't work for your use case, you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
 <div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
 
 ## Fly Volumes and Fly Apps
 
-Learn how to more about [launch an app with a volume](/docs/apps/volume-storage/).
+Learn how to [use volume storage with apps](/docs/apps/volume-storage/).
+
+## Fly Volumes and flyctl
+
+Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command. 
 
 ## Create a Volume
 
 Every Fly Volume belongs to a [Fly App](/docs/reference/apps/).
 
-Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. See [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
+Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
-The following command creates a new volume named "myapp_data" with 1GB of storage in the yyz (Toronto) region, for the application whose `fly.toml` file is in the working directory. To specify a different app, use the `-a` or `--app` flag.
+The following example command creates a new volume named "myapp_data" with 1GB of storage in the yyz (Toronto) region, for the application whose `fly.toml` file is in the working directory. To specify a different app, use the `-a` or `--app` flag.
 
 ```cmd
 fly volumes create myapp_data --region yyz --size 1
@@ -63,10 +63,9 @@ Volumes are, by default, created with encryption-at-rest enabled for additional 
 
 Volumes are bound to both apps and regions. A volume is directly associated with only one app and exists in only one region. No other app can see this volume and only an instance of the app running in the yyz region can access it.
 
-Most people use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting does limit the number of volumes your app can have in a region.
+Most developers use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting does limit the number of volumes your app can have in a region.
 
-When you create a volume on a legacy (Nomad) Fly App, its region is added to the app's region pool to allow app instances to be started with it.
-
+When you create a volume on a Nomad (V1) App, its region is added to the app's region pool to allow app instances to be started with it.
 
 There can be multiple volumes of the same volume name in a region. Each volume has a unique ID to distinguish itself from others to allow for this. This allows multiple instances of an app to run in one region. Creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
 
@@ -74,7 +73,7 @@ Volumes are independent of one another; Fly.io does not automatically replicate 
 
 ## List an App's Volumes
 
-You can [get a list of all volumes created for an app](https://fly.io/docs/flyctl/volumes-list/) using the sub-command `list`. 
+Get a list of all the volumes created for an app using `fly volumes list`. Refer to [`fly volumes list`](https://fly.io/docs/flyctl/volumes-list/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
 ```cmd
 fly volumes list
@@ -86,7 +85,7 @@ vol_od56vjpp95mvny30    created myapp_data    1GB     lhr     79f0    true      
 vol_kgj54500d3qry2wz    created myapp_data    1GB     yyz     acc6    true                            9 minutes ago
 ```
 
-The unique ID can be used in commands that reference a specific volume, such as the `show` or `delete` sub-command. For example, the `show` command can display the details for a particular volume:
+The unique volume ID can be used in commands that reference a specific volume, such as the `show` or `delete` sub-commands. For example, the `fly volumes show` command can display the details for a particular volume:
 
 ```cmd
 fly vol show vol_kgj54500d3qry2wz
@@ -103,15 +102,17 @@ Created at: 04 Mar 23 03:32 UTC
 ```
 ## Extend a Volume
 
-[Volumes can be extended](https://fly.io/docs/flyctl/volumes-extend/), but cannot be made smaller. To make a volume larger, find its ID with `fly volumes list`, then use:
+Extend a volume using `fly volumes extend`. Volumes can be extended, or made larger, but can't be made smaller. Refer to [`fly volumes extend`](https://fly.io/docs/flyctl/volumes-extend/) in the [flyctl reference](/docs/flyctl) for usage and options. 
+
+To extend a volume, find its ID with `fly volumes list`, then use `fly volumes extend <volume-id> -s <new-size>`:
 
 ```cmd
-fly volumes extend <volume-id> -s <new-size>
+fly volumes extend vol_od56vjp5pzmvny30 -s 2
 ```
 
-where `<new-size>` is the desired size in GB. 
+where `<new-size>` is the extended size in GB. 
 
-The Machine attached to the target volume must be restarted to allow the file system to be resized. **On legacy Nomad-orchestrated Apps, the instance is automatically restarted, so this step isn't needed.**
+You'll need to restart the Machine attached to the target volume to allow the file system to be resized. On Nomad (V1) Apps, the instance is automatically restarted, so this step isn't needed.
 
 Get the `id` of the Machine that has the volume mounted (find it under `ATTACHED VM`).
 
@@ -123,11 +124,10 @@ ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       
 vol_od56vjp5pzmvny30    created data    2GB     yyz     acc6    true            4d891de2f66587  36 minutes ago
 ```
 
-
-Restart the Machine:
+Restart the Machine using `fly machine restart <machine-id>`:
 
 ```cmd
-fly machine restart <machine-id>
+fly machine restart 4d891de2f66587
 ```
 
 You can check that the new volume size is reflected in the Machine's file system by running `df` via `fly ssh console`. If there's more than one Machine on the app, `fly ssh console -s` allows you to select the correct one:
@@ -147,13 +147,13 @@ tmpfs             113224      0    113224   0% /sys/fs/cgroup
 /dev/vdb         2043856   3072   1930400   1% /storage
 ```
 
-Here, the volume is mounted under `/storage` in the Machine's root file system and has been resized to 2GB.
+Here, the volume is mounted under `/storage` in the Machine's root file system and has been resized to 2GB. The `df` command shows disk space in 1K blocks by default. You can use the `-h` flag to return a more human-readable format.
 
 ## Snapshots and Restores
 
-We take daily block-level snapshots of volumes. Snapshots are kept for five days. These may not have your latest data. You should implement your own backup plan for important data.
+Find the snapshots belonging to your target volume using the `fly volumes snapshots list` command. We take daily block-level snapshots of volumes. Snapshots are kept for five days. These may not have your latest data. You should implement your own backup plan for important data. Refer to [`fly volumes snapshots list`](https://fly.io/docs/flyctl/volumes-snapshots-list/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
-[Find the snapshots belonging to your target volume](https://fly.io/docs/flyctl/volumes-snapshots-list/) with `fly volumes snapshots list <volume-id>`:
+To list a volume's snapshots, find its ID with `fly volumes list`, then use `fly volumes snapshots list <volume-id>`:
 
 ```cmd
 fly volumes snapshots list vol_wod56vjyd6pvny30
@@ -169,13 +169,9 @@ vs_pZlGZvq3gkAlAcaZ	17655830	4 days ago
 vs_A9k6age3bQov6twj	17631880	5 days ago
 ```
 
-Restoring from the snapshot to a new volume is a matter of:
-
-```cmd
-fly volumes create <volume-name> --snapshot-id <snapshot-id> -s <volume-size> [-a <app-name>]
-```
-
 A volume snapshot can be restored into a volume that's the same size as, or larger than, the source volume, but not a smaller one. If you don't specify a size with the `-s` flag, `fly volumes create` will request a 3GB volume. 
+
+To restore from the snapshot to a new volume, use `fly volumes create <volume-name> --snapshot-id <snapshot-id> -s <volume-size> [-a <app-name>]`:
 
 ```cmd
 fly volumes create pg_data --snapshot-id vs_0Gvz2kBKJ28Mph4y -a cat-pg
@@ -194,15 +190,15 @@ Created at: 02 Aug 22 21:27 UTC
 
 The `flyctl` output shows the details of the new volume, including its size.
 
-## Delete a Volume
+## Destroy a Volume
 
-The `delete` sub-command allows you to delete a specific volume.
+Delete a volume using the `fly volumes destroy` command. Refer to in the [flyctl reference](/docs/flyctl) for usage and options.
 
 ```cmd
-fly volumes delete vol_2n0l9vlnklpr635d -a myapp
+fly volumes destroy vol_2n0l9vlnklpr635d -a myapp
 ```
 ```out
-Deleting a volume is not reversible.
-? Are you sure you want to delete this volume? Yes
-Deleted volume vol_2n0l9vlnklpr635d from myapp
+Warning! Individual volumes are pinned to individual hosts. You should create two or more volumes per application. Deleting this volume will leave you with 1 volume(s) for this application, and it is not reversible.  Learn more at https://fly.io/docs/reference/volumes/
+? Are you sure you want to destroy this volume? Yes
+Destroyed volume vol_2n0l9vlnklpr635d from myapp
 ```

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -7,18 +7,15 @@ nav: firecracker
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
+Apps can store ephemeral data on the root file systems of their Machines, but a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state—to preserve configuration, session or user data—and then be restarted with that information in place.
 
-**This is a reference doc for Fly Volumes. For the use of volumes with Fly Apps or Fly Machines, see the [Apps](/docs/apps/) and [Machines](/docs/machines/) docs respectively.**
-
-Volumes are local persistent storage for [Fly Machines](/docs/machines/). They allow an app to save its state, preserving configuration, session or user data, and be restarted with that information in place.
-
-A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware.
+A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
 <div class="callout">
-**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, at some point you'll have downtime.
+**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime whenever you deploy your app, because only one Machine can be attached to a volume at a time. 
 </div>
 
-Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
+There are exceptions to the rule of running at least two Fly Volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime while you redeply your app, then you can run a single Machine with an attached volume.
 
 **Things to consider before settling on volume storage:**
 
@@ -28,7 +25,7 @@ Fly Volumes are a lot like the disk inside your laptop, with the speed and simpl
 * If your app needs a volume to function, and the NVMe drive hosting your volume fails, that instance of your app goes down. There's no way around that. 
 * If you only have a single copy of your data on a single Fly Volume, and that drive fails, data is lost. Fly.io takes daily snapshots, retained for 5 days, but these are meant as a backstop, not your primary backup method.
 
-Explore further options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+If volumes won't work for your use case, you can explore further options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
 ## Fly Volumes and flyctl
 
@@ -38,7 +35,7 @@ Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command.
 
 ## Fly Volumes and Fly Apps
 
-[Read more about using Fly Volumes with the Fly Apps platform](/docs/apps/volume-storage/).
+Learn how to more about [launch an app with a volume](/docs/apps/volume-storage/).
 
 ## Create a Volume
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -31,15 +31,21 @@ If volumes won't work for your use case, you can explore other options for data 
 
 ## Fly Volumes and Fly Apps
 
-Learn how to [use volume storage with apps](/docs/apps/volume-storage/).
+Learn how to [add and use volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+
+Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` app configuration file.
 
 ## Fly Volumes and flyctl
 
-Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command. 
+Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command.
 
-## Create a Volume
+## Working with volumes
 
-Every Fly Volume belongs to a [Fly App](/docs/reference/apps/).
+This section is a reference for working with volumes. If you want the steps to create a new app with a volume, or to add a a volume to an app, then refer to [Add and Use Volume Storage](/docs/apps/volume-storage/).
+
+### Create a Volume
+
+Every Fly Volume belongs to a [Fly App](/docs/reference/apps/). 
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -71,7 +77,7 @@ There can be multiple volumes of the same volume name in a region. Each volume h
 
 Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app.
 
-## List an App's Volumes
+### List Volumes
 
 Get a list of all the volumes created for an app using `fly volumes list`. Refer to [`fly volumes list`](https://fly.io/docs/flyctl/volumes-list/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -100,7 +106,16 @@ fly vol show vol_kgj54500d3qry2wz
  Encrypted: true
 Created at: 04 Mar 23 03:32 UTC
 ```
-## Extend a Volume
+
+### Mount a Volume
+
+The [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml` is where you list the volumes and their destination directories.
+
+### Access a Volume
+
+You can access and write to a volume on a Machine just like a regular directory. The `destination` entry under `[mounts]` in `fly.toml` is the path for the mounted volume.
+
+### Extend a Volume
 
 Extend a volume using `fly volumes extend`. Volumes can be extended, or made larger, but can't be made smaller. Refer to [`fly volumes extend`](https://fly.io/docs/flyctl/volumes-extend/) in the [flyctl reference](/docs/flyctl) for usage and options. 
 
@@ -149,7 +164,7 @@ tmpfs             113224      0    113224   0% /sys/fs/cgroup
 
 Here, the volume is mounted under `/storage` in the Machine's root file system and has been resized to 2GB. The `df` command shows disk space in 1K blocks by default. You can use the `-h` flag to return a more human-readable format.
 
-## Snapshots and Restores
+### Restore from a Snapshot
 
 Find the snapshots belonging to your target volume using the `fly volumes snapshots list` command. We take daily block-level snapshots of volumes. Snapshots are kept for five days. These may not have your latest data. You should implement your own backup plan for important data. Refer to [`fly volumes snapshots list`](https://fly.io/docs/flyctl/volumes-snapshots-list/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -190,7 +205,7 @@ Created at: 02 Aug 22 21:27 UTC
 
 The `flyctl` output shows the details of the new volume, including its size.
 
-## Destroy a Volume
+### Destroy a Volume
 
 Delete a volume using the `fly volumes destroy` command. Refer to in the [flyctl reference](/docs/flyctl) for usage and options.
 


### PR DESCRIPTION
**Work in Progress**
- The goal of the structure changes is to move content around so that the "Databases & Storage" page is an overview of all storage options, "Volumes reference" is where you find all the details, and "Add Volume Storage" comes after you've chosen storage and read the Volume reference (hopefully).
- Consolidate and make descriptions consistent
- These community posts gave us some direction on what was needed: https://community.fly.io/t/documentation-heavily-outdated-for-volumes/12288 and https://community.fly.io/t/some-issues-with-volumes-on-apps-v2/11994

### [Databases and Storage](https://fly.io/docs/database-storage-guides/) page
Preview: https://andrea-docs-preview.fly.dev/docs/database-storage-guides/
- moved section on `choosing your approach to storage` here
- minor edits

### [Volumes](https://fly.io/docs/reference/volumes/) reference page
Preview: https://andrea-docs-preview.fly.dev/docs/reference/volumes/
- remove bolded "this is a reference doc", to be replaced by other links. Machines section doesn't have volume info in it in any case. BUt maybe we need extra links back the app section?
- add exceptions to the rule of volumes per [https://community.fly.io/t/multiple-fly-volumes-confusion/12329](https://community.fly.io/t/multiple-fly-volumes-confusion/12329) and [https://community.fly.io/t/so-its-not-possible-to-use-sqlite-on-fly-without-litefs/12306](https://community.fly.io/t/so-its-not-possible-to-use-sqlite-on-fly-without-litefs/12306)
- make each flyctl command section consistent, all sections edited/updated
- changed delete a volume to destroy a volume
- UPDATE: added sections for Access a Volume and Mount a Volume
- UPDATE: put the reference content under another heading: Working with Volumes and a link to Add and Use Volumes for the step-by-step. This should avoid the scenario where users try to "follow" this reference.

### [Add Volume Storage](https://fly.io/docs/apps/volume-storage/) (changed to Use Volume Storage) page
Preview: https://andrea-docs-preview.fly.dev/docs/apps/volume-storage/
- added status command output to the `Deploy the app` step

TBD in new PR:
- added section on using cloning to add a volume to an existing app (still testing, since it doesn't work yet without this PR: https://github.com/superfly/flyctl/pull/2190 and the text needs to be augmented with more details and outputs)

