### PR TITLE
Update terraform download link

### DIFF
--- a/machines/guides-examples/terraform-machines.html.md.erb
+++ b/machines/guides-examples/terraform-machines.html.md.erb
@@ -23,7 +23,7 @@ In this guide we'll use Terraform to deploy a [very simple demo app](https://git
 
 ## Prerequisites
 
-Go ahead and [download](https://learn.hashicorp.com/tutorials/terraform/install-cli) Terraform if you haven't yet.
+Go ahead and [download](https://developer.hashicorp.com/terraform/downloads) Terraform if you haven't yet.
 
 ## Set API key
 


### PR DESCRIPTION
The old link redirects into an AWS workflow in the Terraform docs. New link goes to generic downloads page.