### PR TITLE
Fix "Migrate from Heroku" guide on secrets importing

### DIFF
--- a/rails/getting-started/migrate-from-heroku.html.md
+++ b/rails/getting-started/migrate-from-heroku.html.md
@@ -98,7 +98,7 @@ To see all of your Heroku env vars and secrets, run:
 heroku config -s | grep -v -e "RAILS_MASTER_KEY" -e "DATABASE_URL" -e "REDIS_URL" -e "REDIS_TLS_URL" | fly secrets import
 ```
 
-This command exports the following Heroku secrets: `RAILS_MASTER_KEY`, `DATABASE_URL` `REDIS_URL`, and `REDIS_TLS_URL`, and imports them into Fly.
+This command exports the Heroku secrets, excluding `RAILS_MASTER_KEY`, `DATABASE_URL` `REDIS_URL`, and `REDIS_TLS_URL`, and imports them into Fly.
 
 Verify your Heroku secrets are in Fly.
 


### PR DESCRIPTION
`grep` is **excluding** those commands, not keeping them, as the doc is saying.