### PR TITLE
Add query params to wait endpoint example to make request clearer

### DIFF
--- a/reference/machines/wait_req.html.md
+++ b/reference/machines/wait_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait" 
+    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
 
 ```
 **Status: 200**


### PR DESCRIPTION
It's not super obvious how to pass in state as a query param to the wait endpoint, and especially since [this was reported in the forum](https://community.fly.io/t/machines-api-for-waiting-a-machine-for-state-is-not-clear/12516), thought it'd be an easy fix 