### PR TITLE
Update volume docs with more ways to add volumes

### DIFF
--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -118,7 +118,7 @@ At this point there are two identically configured Machines on the app, each wit
 
 ### On a V1 (Nomad) app
 
-Create an additional volume in the desired region, then [use `fly scale count`](/docs/legacy-scaling/) to add a VM to use it.
+Create an additional volume in the desired region, then [use `fly scale count`](/docs/apps/legacy-scaling/) to add a VM to use it.
 
 ## Add volumes to an existing app
 
@@ -219,8 +219,8 @@ Repeat the process for each machine that you want to add a volume to.
 
 ## Remove a volume from an app
 
-You can't currently unmount a volume from an existing Machine. If you need to remove volumes from your app, you can [scale it](/docs/apps/scale-count/) down to zero Machines, [destroy all the volumes](/docs/reference/volumes#delete-a-volume), remove the `mounts` section from `fly.toml`, and redeploy. **Only destroy a volume whose data you no longer need access to.**
+You can't currently unmount a volume from an existing Machine. If you need to remove volumes from your app, you can [scale it](/docs/apps/scale-count/) down to zero Machines, [destroy all the volumes](/docs/reference/volumes#destroy-a-volume), remove the `mounts` section from `fly.toml`, and redeploy. **Only destroy a volume whose data you no longer need access to.**
 
 ### On a V1 (Nomad) app
 
-Remove the `mounts` section from `fly.toml` and redeploy. This will create a new Machine without a volume. [Destroy any unused volumes](/docs/reference/volumes#delete-a-volume), **only if you no longer need their data**.
+Remove the `mounts` section from `fly.toml` and redeploy. This will create a new Machine without a volume. [Destroy any unused volumes](/docs/reference/volumes#destroy-a-volume), **only if you no longer need their data**.

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -14,7 +14,7 @@ Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volume
 
 ## Add volumes to an existing app
 
-You can add a volume, or volumes, to an exsiting app by adding `[mounts]` to the app's `fly.toml` file and creating the volumes using flyctl.
+You can add a volume, or volumes, to an existing app by adding `[mounts]` to the app's `fly.toml` file and creating the volumes using flyctl.
 
 ### Configure the app to mount the new volume
 
@@ -65,7 +65,7 @@ vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            
 
 ## Add a volume to a Machine clone
 
-Another way to add a volume to an exsiting app is to clone a Machine with no volume and attach a new volume to it. When you clone a machine with a volume already attached, you'll also get a new machine with a new, empty, volume attached.
+Another way to add a volume to an existing app is to clone a Machine with no volume and attach a new volume to it. When you clone a machine with a volume already attached, you'll also get a new machine with a new, empty, volume attached.
 
 ### Configure the app to mount the new volume
 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Add and Use Volume Storage
+title: Add Volume Storage
 layout: docs
 nav: firecracker
 titlecase: false
@@ -8,13 +8,120 @@ order: 30
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state—to preserve configuration, session or user data—and then be restarted with that information in place.
+Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place. You can access and write to a volume on a Machine just like a regular directory.
 
 **The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) for exceptions to the rule and details about how volumes are implemented.
 
-## Launch an app with a Fly Volume
+## Add volumes to an existing app
 
-Follow these steps to create a new app, add the volume you want to create to `fly.toml`, and then deploy the app. 
+You can add a volume, or volumes, to an exsiting app by adding `[mounts]` to the app's `fly.toml` file and creating the volumes using flyctl.
+
+### Configure the app to mount the new volume
+
+Add a `[mounts]` section in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+
+```toml
+[mounts]
+source="myapp_data"
+destination="/data"
+```
+
+### Create the volume
+
+Create the volume (or volumes) in the same region as your app.
+
+```cmd
+fly volume myapp_data -r lhr
+```
+
+<div class="callout">
+You need to create as many volumes as you have Machines per process in your app. Newer apps deployed using the `fly launch` command might have two Machines in the `app` process by default.
+</div>
+
+If you configure [mounts] in `fly.toml` and then run `fly deploy` without first creating enough volumes, then you'll get an error similar to this one:
+
+```out
+Error: Process group 'app' needs volumes with name 'myapp_data' to fullfill mounts defined in fly.toml; 
+Run fly volume create myapp_data -r REGION for the following regions and counts: lhr=1.`
+```
+
+The error indicates that the app needs one more volume in the `lhr` region.
+
+### Deploy the app
+
+```cmd
+fly deploy 
+```
+
+Run `fly volumes list` to verify that your volumes now have `ATTACHED VM` populated.
+
+```cmd
+fly volumes list
+```
+```out
+ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
+vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
+```
+
+## Add a volume to a Machine clone
+
+Another way to add a volume to an exsiting app is to clone a Machine with no volume and attach a new volume to it. When you clone a machine with a volume already attached, you'll also get a new machine with a new, empty, volume attached.
+
+### Configure the app to mount the new volume
+
+Add a `[mounts]` section in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+
+```toml
+[mounts]
+source="myapp_data"
+destination="/data"
+```
+
+### Create the volume
+
+Create the volume in the same region as your app.
+
+```cmd
+fly volume myapp_data -r lhr
+```
+
+### Clone the Machine
+
+Clone one of your app's Machines (with no volume) and attach the volume you just created:
+
+```
+fly machine clone <machine-id> --attach-volume <vol-id>:<destination-mount-path>
+```
+
+`destination-mount-path` is the directory where the volume should be mounted on the running app.
+
+For example:
+
+```cmd
+fly machine clone 148eddeef09789 --attach-volume vol_8l524yj0ko347zmp:/data
+```
+
+### Destroy the Machine used to create the clone
+
+```cmd
+fly machine destroy 148eddeef09789
+```
+
+Run `fly volumes list` to verify that the volume you just created has the newly-cloned Machine's ID listed under `ATTACHED VM`.
+
+```cmd
+fly volumes list
+```
+```out
+ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
+vol_8l524yj0ko347zmp    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
+```
+
+Repeat the process for each machine that you want to add a volume to.
+
+## Launch a new app with a Fly Volume
+
+Follow these steps to create a new app, add the volume configuration to `fly.toml`, and then deploy the app. 
 
 ### Launch the app, but don't deploy it yet
 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -10,114 +10,7 @@ order: 30
 
 Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place. You can access and write to a volume on a Machine just like a regular directory.
 
-**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) for exceptions to the rule and details about how volumes are implemented.
-
-## Add volumes to an existing app
-
-You can add a volume, or volumes, to an existing app by adding `[mounts]` to the app's `fly.toml` file and creating the volumes using flyctl.
-
-### Configure the app to mount the new volume
-
-Add a `[mounts]` section in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
-
-```toml
-[mounts]
-source="myapp_data"
-destination="/data"
-```
-
-### Create the volume
-
-Create the volume (or volumes) in the same region as your app.
-
-```cmd
-fly volume myapp_data -r lhr
-```
-
-<div class="callout">
-You need to create as many volumes as you have Machines per process in your app. Newer apps deployed using the `fly launch` command might have two Machines in the `app` process by default.
-</div>
-
-If you configure [mounts] in `fly.toml` and then run `fly deploy` without first creating enough volumes, then you'll get an error similar to this one:
-
-```out
-Error: Process group 'app' needs volumes with name 'myapp_data' to fullfill mounts defined in fly.toml; 
-Run fly volume create myapp_data -r REGION for the following regions and counts: lhr=1.`
-```
-
-The error indicates that the app needs one more volume in the `lhr` region.
-
-### Deploy the app
-
-```cmd
-fly deploy 
-```
-
-Run `fly volumes list` to verify that your volumes now have `ATTACHED VM` populated.
-
-```cmd
-fly volumes list
-```
-```out
-ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
-vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
-```
-
-## Add a volume to a Machine clone
-
-Another way to add a volume to an existing app is to clone a Machine with no volume and attach a new volume to it. When you clone a machine with a volume already attached, you'll also get a new machine with a new, empty, volume attached.
-
-### Configure the app to mount the new volume
-
-Add a `[mounts]` section in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
-
-```toml
-[mounts]
-source="myapp_data"
-destination="/data"
-```
-
-### Create the volume
-
-Create the volume in the same region as your app.
-
-```cmd
-fly volume myapp_data -r lhr
-```
-
-### Clone the Machine
-
-Clone one of your app's Machines (with no volume) and attach the volume you just created:
-
-```
-fly machine clone <machine-id> --attach-volume <vol-id>:<destination-mount-path>
-```
-
-`destination-mount-path` is the directory where the volume should be mounted on the running app.
-
-For example:
-
-```cmd
-fly machine clone 148eddeef09789 --attach-volume vol_8l524yj0ko347zmp:/data
-```
-
-### Destroy the Machine used to create the clone
-
-```cmd
-fly machine destroy 148eddeef09789
-```
-
-Run `fly volumes list` to verify that the volume you just created has the newly-cloned Machine's ID listed under `ATTACHED VM`.
-
-```cmd
-fly volumes list
-```
-```out
-ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
-vol_8l524yj0ko347zmp    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
-```
-
-Repeat the process for each machine that you want to add a volume to.
+**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) details about how volumes are implemented.
 
 ## Launch a new app with a Fly Volume
 
@@ -226,6 +119,103 @@ At this point there are two identically configured Machines on the app, each wit
 ### On a V1 (Nomad) app
 
 Create an additional volume in the desired region, then [use `fly scale count`](/docs/legacy-scaling/) to add a VM to use it.
+
+## Add volumes to an existing app
+
+You can add a volume, or volumes, to an existing app by adding `[mounts]` to the app's `fly.toml` file and creating the volumes using flyctl.
+
+### Configure the app to mount the new volume
+
+Add a `[mounts]` section in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+
+```toml
+[mounts]
+source="myapp_data"
+destination="/data"
+```
+
+### Create the volume
+
+Create the volume (or volumes) in the same region as your app.
+
+```cmd
+fly volume myapp_data -r lhr
+```
+
+<div class="callout">
+You need to create as many volumes as you have Machines per process in your app. Newer apps deployed using the `fly launch` command might have two Machines in the `app` process by default.
+</div>
+
+If you configure [mounts] in `fly.toml` and then run `fly deploy` without first creating enough volumes, then you'll get an error similar to this one:
+
+```out
+Error: Process group 'app' needs volumes with name 'myapp_data' to fullfill mounts defined in fly.toml; 
+Run fly volume create myapp_data -r REGION for the following regions and counts: lhr=1.`
+```
+
+The error indicates that the app needs one more volume in the `lhr` region.
+
+### Deploy the app
+
+```cmd
+fly deploy 
+```
+
+Run `fly volumes list` to verify that your volumes now have `ATTACHED VM` populated.
+
+```cmd
+fly volumes list
+```
+```out
+ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
+vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
+```
+
+## Add a volume to a Machine clone
+
+You can add a volume to an existing Machine by cloning a Machine with no volume and attaching a new volume to it. When you clone a Machine with a volume already attached, you'll also get a new Machine with a new, empty, volume attached.
+
+### Create the volume
+
+Create the volume in the same region as your app.
+
+```cmd
+fly volume myapp_data -r lhr
+```
+
+### Clone the Machine
+
+Clone one of your app's Machines (with no volume) and attach the volume you just created:
+
+```
+fly machine clone <machine-id> --attach-volume <vol-id>:<destination-mount-path>
+```
+
+`destination-mount-path` is the directory where the volume should be mounted on the file system.
+
+For example:
+
+```cmd
+fly machine clone 148eddeef09789 --attach-volume vol_8l524yj0ko347zmp:/data
+```
+
+### Destroy the Machine used to create the clone
+
+```cmd
+fly machine destroy 148eddeef09789
+```
+
+Run `fly volumes list` to verify that the volume you just created has the newly-cloned Machine's ID listed under `ATTACHED VM`.
+
+```cmd
+fly volumes list
+```
+```out
+ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
+vol_8l524yj0ko347zmp    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
+```
+
+Repeat the process for each machine that you want to add a volume to.
 
 ## Remove a volume from an app
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -29,7 +29,7 @@ If volumes won't work for your use case, you can explore other options for data 
 
 ## Fly Volumes and Fly Apps
 
-Learn how to [add and use volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+Learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
 
 Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` app configuration file.
 
@@ -41,7 +41,7 @@ Manage volumes using the [`fly volumes`](/docs/flyctl/volumes/) command.
 
 ## Working with volumes
 
-This section is a reference for working with volumes. If you want the steps to launch a new app with a volume, or to add a volume to an existing app, then refer to [Add and Use Volume Storage](/docs/apps/volume-storage/).
+This section is a reference for working with volumes. Refer to [Add Volume Storage](/docs/apps/volume-storage/) to add a volume to an existing app or launch a new app with a volume.
 
 ### Create a Volume
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -205,7 +205,7 @@ The `flyctl` output shows the details of the new volume, including its size.
 
 ### Destroy a Volume
 
-Destroy a volume using the `fly volumes destroy` command. Refer to in the [flyctl reference](/docs/flyctl) for usage and options.
+Destroy a volume using the `fly volumes destroy` command. Refer to [`fly volumes destroy`](https://fly.io/docs/flyctl/volumes-destroy/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
 ```cmd
 fly volumes destroy vol_2n0l9vlnklpr635d -a myapp

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -12,10 +12,10 @@ Apps can store ephemeral data on the root file systems of their Machines, but a 
 A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
 <div class="callout">
-**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime whenever you deploy your app, because only one Machine can be attached to a volume at a time. 
+**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime if there's a host or network failure, and whenever you deploy your app, because only one Machine can be attached to a volume at a time.
 </div>
 
-There are exceptions to the rule of running at least two Fly Volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime while you deploy it, then you can run a single Machine with an attached volume.
+There are exceptions to the rule of running at least two Fly volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime while you deploy it, then you can run a single Machine with an attached volume.
 
 **Things to consider before settling on volume storage:**
 
@@ -105,13 +105,9 @@ fly vol show vol_kgj54500d3qry2wz
 Created at: 04 Mar 23 03:32 UTC
 ```
 
-### Mount a Volume
+### Access a volume
 
-The [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml` is where you list the volumes and their destination directories. Unless you're [launching a new app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume), you also need to [create the volumes](#create-a-volume).
-
-### Access a Volume
-
-You can access and write to a volume on a Machine just like a regular directory. The `destination` entry under `[mounts]` in `fly.toml` is the path for the mounted volume.
+You can access and write to a volume on a Machine just like a regular directory. For Fly Apps, the `destination` under `[mounts]` in `fly.toml` is the path for the mounted volume. When you [clone a Machine and add a volume](/docs/apps/volume-storage/#add-a-volume-to-a-machine-clone), you specify the mount path in the `fly machine clone` command.
 
 ### Extend a Volume
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -27,8 +27,6 @@ There are exceptions to the rule of running at least two Fly Volumes. For exampl
 
 If volumes won't work for your use case, you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
-<div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
-
 ## Fly Volumes and Fly Apps
 
 Learn how to [add and use volume storage for your app](/docs/apps/volume-storage/), step-by-step.
@@ -37,15 +35,17 @@ Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-sec
 
 ## Fly Volumes and flyctl
 
-Volumes are managed using the [`fly volumes`](/docs/flyctl/volumes/) command.
+Manage volumes using the [`fly volumes`](/docs/flyctl/volumes/) command.
+
+<div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
 
 ## Working with volumes
 
-This section is a reference for working with volumes. If you want the steps to launch a new app with a volume then refer to [Add and Use Volume Storage](/docs/apps/volume-storage/).
+This section is a reference for working with volumes. If you want the steps to launch a new app with a volume, or to add a volume to an existing app, then refer to [Add and Use Volume Storage](/docs/apps/volume-storage/).
 
 ### Create a Volume
 
-Every Fly Volume belongs to a [Fly App](/docs/reference/apps/).
+Every Fly Volume belongs to a [Fly App](/docs/reference/apps/). Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app.
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -65,17 +65,15 @@ fly volumes create myapp_data --region yyz --size 1
 Created at: 04 Mar 23 03:32 UTC
 ```
 
-Volumes are, by default, created with encryption-at-rest enabled for additional protection of the data on the volume. Use `--no-encryption` to instead create an unencrypted volume for improved performance at deployment and runtime.
-
 Volumes are bound to both apps and regions. A volume is directly associated with only one app and exists in only one region. No other app can see this volume and only an instance of the app running in the yyz region can access it.
 
 Most developers use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting does limit the number of volumes your app can have in a region.
 
-When you create a volume on a Nomad (V1) App, its region is added to the app's region pool to allow app instances to be started with it.
-
 There can be multiple volumes of the same volume name in a region. Each volume has a unique ID to distinguish itself from others to allow for this. This allows multiple instances of an app to run in one region. Creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
 
-Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app.
+Volumes are, by default, created with encryption-at-rest enabled for additional protection of the data on the volume. Use `--no-encryption` to instead create an unencrypted volume for improved performance at deployment and runtime.
+
+When you create a volume on a Nomad (V1) App, its region is added to the app's region pool to allow app instances to be started with it.
 
 ### List Volumes
 
@@ -109,7 +107,7 @@ Created at: 04 Mar 23 03:32 UTC
 
 ### Mount a Volume
 
-The [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml` is where you list the volumes and their destination directories.
+The [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml` is where you list the volumes and their destination directories. Unless you're [launching a new app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume), you also need to [create the volumes](#create-a-volume).
 
 ### Access a Volume
 


### PR DESCRIPTION
Add 2 ways to add volumes to existing apps (apps that have already been deployed). 

- clone and use --attach-volume, specifying the mount point
- set up volumes and run `fly deploy`

Other minor edits. Like renaming Add and Use Volume Storage back to just Add Volume Storage. We need to add more info about usage or maybe link to the specific framework guides that talk about volumes?