### PR TITLE
Fix link to setting up machines section in working with machines

### DIFF
--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -19,7 +19,7 @@ This guide assumes that you have `flyctl` and `curl` installed, and have authent
 
 The easiest (and recommended) way to connect to the machines api is to use `api.machines.dev`, an easy to use and more performant alternative to doing all the wireguard shenanigans.
 
-Simply skip down to [setting up the environment](###Setting up the environment), and make sure to set `$FLY_API_HOSTNAME` to `api.machines.dev`
+Simply skip down to [setting up the environment](#setting-up-the-environment), and make sure to set `$FLY_API_HOSTNAME` to `api.machines.dev`
 
 ### Connecting via WireGuard
 


### PR DESCRIPTION
While reading the machines docs, I found a broken link! Fixed here. 