### PR TITLE
Working with machines improvements

### DIFF
--- a/machines/guides-examples/terraform-machines.html.md.erb
+++ b/machines/guides-examples/terraform-machines.html.md.erb
@@ -80,13 +80,13 @@ resource "fly_app" "exampleApp" {
 }
 
 resource "fly_ip" "exampleIp" {
-  app        = "flyiac" #Replace this with your own app name
+  app        = fly_app.exampleApp.name
   type       = "v4"
   depends_on = [fly_app.exampleApp]
 }
 
 resource "fly_ip" "exampleIpv6" {
-  app        = "flyiac" #Replace this with your own app name
+  app        = fly_app.exampleApp.name
   type       = "v6"
   depends_on = [fly_app.exampleApp]
 }
@@ -113,7 +113,7 @@ This example creates machines running in `ewr` (Secaucus, NJ) and `lax` (Los Ang
 ```terraform
 resource "fly_machine" "exampleMachine" {
   for_each = toset(["ewr", "lax"])
-  app    = "flyiac" #Replace this with your own app name
+  app    = fly_app.exampleApp.name
   region = each.value
   name   = "flyiac-${each.value}"
   image  = "flyio/iac-tutorial:latest"

--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -55,6 +55,8 @@ $ export FLY_API_HOSTNAME="api.machines.dev" # set to _api.internal:4280 when us
 $ export FLY_API_TOKEN=$(fly auth token)
 ```
 
+For local development, you can see the token used by `flyctl` with `flyctl auth token`. You can also create a new auth token in the [personal access token section of the fly.io dashboard](https://fly.io/user/personal_access_tokens).
+
 In order to access this API on a fly VM, make the token available as a secret:
 
 ```cmd

--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -19,7 +19,7 @@ This guide assumes that you have `flyctl` and `curl` installed, and have authent
 
 The easiest (and recommended) way to connect to the machines api is to use `api.machines.dev`, an easy to use and more performant alternative to doing all the wireguard shenanigans.
 
-Simply skip down to [setting up the environment](#setting-up-the-environment), and make sure to set `$FLY_API_HOSTNAME` to `api.machines.dev`
+Simply skip down to [setting up the environment](#setting-up-the-environment), and make sure to set `$FLY_API_HOSTNAME` to `api.machines.dev`, and `$FLY_API_PROTOCOL` to `https`.
 
 ### Connecting via WireGuard
 
@@ -28,6 +28,8 @@ This method requires more setup but gives you direct access to machines over the
 First, follow the [instructions](/docs/reference/private-networking/#private-network-vpn) to set up a permanent WireGuard connection to your Fly network. We recommend WireGuard because you can directly test your machines from your local machine.
 
 Once you're connected, Fly internal DNS should expose the Machines API endpoint at: `http://_api.internal:4280`
+
+The internal API is only available via `http` (not `https`), so you will need to set `FLY_API_PROTOCOL` to `http` (instead of the default `https`) for the commands below.
 
 ### Connecting via `flyctl proxy`
 
@@ -47,12 +49,12 @@ If you successfully reach the API, it should respond with a `404 page not found`
 
 ### Setting up the environment
 
-If you are using a Wireguard VPN or a `flyctl` proxy,
-set these environment variables to make the following commands easier to use.
+Set these environment variables to make the following commands easier to use.
 
 ```bash
 $ export FLY_API_HOSTNAME="api.machines.dev" # set to _api.internal:4280 when using Wireguard or `127.0.0.1:4280` when using 'flyctl proxy'
 $ export FLY_API_TOKEN=$(fly auth token)
+$ export FLY_API_PROTOCOL=https # set to http if you are using Wireguard or 'flyctl proxy'
 ```
 
 For local development, you can see the token used by `flyctl` with `flyctl auth token`. You can also create a new auth token in the [personal access token section of the fly.io dashboard](https://fly.io/user/personal_access_tokens).

--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -19,7 +19,7 @@ This guide assumes that you have `flyctl` and `curl` installed, and have authent
 
 The easiest (and recommended) way to connect to the machines api is to use `api.machines.dev`, an easy to use and more performant alternative to doing all the wireguard shenanigans.
 
-Simply skip down to [setting up the environment](#setting-up-the-environment), and make sure to set `$FLY_API_HOSTNAME` to `api.machines.dev`, and `$FLY_API_PROTOCOL` to `https`.
+Simply skip down to [setting up the environment](#setting-up-the-environment), and make sure to set `$FLY_API_HOSTNAME` to `https://api.machines.dev`.
 
 ### Connecting via WireGuard
 
@@ -28,8 +28,6 @@ This method requires more setup but gives you direct access to machines over the
 First, follow the [instructions](/docs/reference/private-networking/#private-network-vpn) to set up a permanent WireGuard connection to your Fly network. We recommend WireGuard because you can directly test your machines from your local machine.
 
 Once you're connected, Fly internal DNS should expose the Machines API endpoint at: `http://_api.internal:4280`
-
-The internal API is only available via `http` (not `https`), so you will need to set `FLY_API_PROTOCOL` to `http` (instead of the default `https`) for the commands below.
 
 ### Connecting via `flyctl proxy`
 
@@ -52,9 +50,8 @@ If you successfully reach the API, it should respond with a `404 page not found`
 Set these environment variables to make the following commands easier to use.
 
 ```bash
-$ export FLY_API_HOSTNAME="api.machines.dev" # set to _api.internal:4280 when using Wireguard or `127.0.0.1:4280` when using 'flyctl proxy'
+$ export FLY_API_HOSTNAME="https://api.machines.dev" # set to http://_api.internal:4280 when using Wireguard or `http://127.0.0.1:4280` when using 'flyctl proxy'
 $ export FLY_API_TOKEN=$(fly auth token)
-$ export FLY_API_PROTOCOL=https # set to http if you are using Wireguard or 'flyctl proxy'
 ```
 
 For local development, you can see the token used by `flyctl` with `flyctl auth token`. You can also create a new auth token in the [personal access token section of the fly.io dashboard](https://fly.io/user/personal_access_tokens).
@@ -68,7 +65,7 @@ flyctl secrets set FLY_API_TOKEN=$(fly auth token)
 A convenient way to set the `FLY_API_HOSTNAME` is to add it to your `Dockerfile`:
 
 ```
-ENV FLY_API_HOSTNAME="api.machines.dev"
+ENV FLY_API_HOSTNAME="https://api.machines.dev"
 ```
 
 

--- a/reference/machines/create_app.html.md
+++ b/reference/machines/create_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
       "app\_name": "user-functions",
       "org\_slug": "personal",

--- a/reference/machines/create_app.html.md
+++ b/reference/machines/create_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
       "app\_name": "user-functions",
       "org\_slug": "personal",

--- a/reference/machines/create_app.html.md
+++ b/reference/machines/create_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
       "app\_name": "user-functions",
       "org\_slug": "personal",

--- a/reference/machines/create_app_req.html.md
+++ b/reference/machines/create_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
       "app\_name": "user-functions",
       "org\_slug": "personal"

--- a/reference/machines/create_app_req.html.md
+++ b/reference/machines/create_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
       "app\_name": "user-functions",
       "org\_slug": "personal"

--- a/reference/machines/create_app_req.html.md
+++ b/reference/machines/create_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
       "app\_name": "user-functions",
       "org\_slug": "personal"

--- a/reference/machines/delete.html.md
+++ b/reference/machines/delete.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/delete.html.md
+++ b/reference/machines/delete.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/delete.html.md
+++ b/reference/machines/delete.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/delete_app.html.md
+++ b/reference/machines/delete_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 404**

--- a/reference/machines/delete_app.html.md
+++ b/reference/machines/delete_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 404**

--- a/reference/machines/delete_app.html.md
+++ b/reference/machines/delete_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 404**

--- a/reference/machines/delete_app_req.html.md
+++ b/reference/machines/delete_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 202**

--- a/reference/machines/delete_app_req.html.md
+++ b/reference/machines/delete_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 202**

--- a/reference/machines/delete_app_req.html.md
+++ b/reference/machines/delete_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 202**

--- a/reference/machines/delete_req.html.md
+++ b/reference/machines/delete_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
 ```
 
 Optionally append `?force=true` to the URI to kill a running machine.

--- a/reference/machines/delete_req.html.md
+++ b/reference/machines/delete_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
 ```
 
 Optionally append `?force=true` to the URI to kill a running machine.

--- a/reference/machines/delete_req.html.md
+++ b/reference/machines/delete_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
 ```
 
 Optionally append `?force=true` to the URI to kill a running machine.

--- a/reference/machines/get.html.md
+++ b/reference/machines/get.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/get.html.md
+++ b/reference/machines/get.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/get.html.md
+++ b/reference/machines/get.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app.html.md
+++ b/reference/machines/get_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app.html.md
+++ b/reference/machines/get_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app.html.md
+++ b/reference/machines/get_app.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app_req.html.md
+++ b/reference/machines/get_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app_req.html.md
+++ b/reference/machines/get_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app_req.html.md
+++ b/reference/machines/get_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_req.html.md
+++ b/reference/machines/get_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_req.html.md
+++ b/reference/machines/get_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_req.html.md
+++ b/reference/machines/get_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
 
 ```
 **Status: 200**

--- a/reference/machines/launch.html.md
+++ b/reference/machines/launch.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch.html.md
+++ b/reference/machines/launch.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch.html.md
+++ b/reference/machines/launch.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch_req.html.md
+++ b/reference/machines/launch_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch_req.html.md
+++ b/reference/machines/launch_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch_req.html.md
+++ b/reference/machines/launch_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch_syd_req.html.md
+++ b/reference/machines/launch_syd_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "machine-syd",
       "config": {

--- a/reference/machines/launch_syd_req.html.md
+++ b/reference/machines/launch_syd_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "machine-syd",
       "config": {

--- a/reference/machines/launch_syd_req.html.md
+++ b/reference/machines/launch_syd_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
   -d '{
       "name": "machine-syd",
       "config": {

--- a/reference/machines/lease.html.md
+++ b/reference/machines/lease.html.md
@@ -3,11 +3,11 @@ Add the `fly-machine-lease-nonce` header to all subsequent API calls.
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
+    "https://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
 ```
 #### Release the lease
 ```
 curl -i -X DELETE \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
+    "https://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
 ```

--- a/reference/machines/lease.html.md
+++ b/reference/machines/lease.html.md
@@ -3,11 +3,11 @@ Add the `fly-machine-lease-nonce` header to all subsequent API calls.
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "https://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
+    "${FLY\_API\_PROTOCOL}://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
 ```
 #### Release the lease
 ```
 curl -i -X DELETE \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "https://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
+    "${FLY\_API\_PROTOCOL}://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
 ```

--- a/reference/machines/lease.html.md
+++ b/reference/machines/lease.html.md
@@ -3,11 +3,11 @@ Add the `fly-machine-lease-nonce` header to all subsequent API calls.
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "${FLY\_API\_PROTOCOL}://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
+    "${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
 ```
 #### Release the lease
 ```
 curl -i -X DELETE \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "${FLY\_API\_PROTOCOL}://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
+    "${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
 ```

--- a/reference/machines/lease_req.html.md
+++ b/reference/machines/lease_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \
-    "https://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
+    "${FLY\_API\_PROTOCOL}://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
     -d '{
         "ttl": 500
     }'

--- a/reference/machines/lease_req.html.md
+++ b/reference/machines/lease_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \
-    "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
+    "https://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
     -d '{
         "ttl": 500
     }'

--- a/reference/machines/lease_req.html.md
+++ b/reference/machines/lease_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \
-    "${FLY\_API\_PROTOCOL}://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
+    "${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
     -d '{
         "ttl": 500
     }'

--- a/reference/machines/list.html.md
+++ b/reference/machines/list.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/list.html.md
+++ b/reference/machines/list.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/list.html.md
+++ b/reference/machines/list.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/list_req.html.md
+++ b/reference/machines/list_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/list_req.html.md
+++ b/reference/machines/list_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/list_req.html.md
+++ b/reference/machines/list_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/start.html.md
+++ b/reference/machines/start.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/start.html.md
+++ b/reference/machines/start.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/start.html.md
+++ b/reference/machines/start.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/start_req.html.md
+++ b/reference/machines/start_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/start_req.html.md
+++ b/reference/machines/start_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/start_req.html.md
+++ b/reference/machines/start_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop.html.md
+++ b/reference/machines/stop.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop.html.md
+++ b/reference/machines/stop.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop.html.md
+++ b/reference/machines/stop.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop_req.html.md
+++ b/reference/machines/stop_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop_req.html.md
+++ b/reference/machines/stop_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop_req.html.md
+++ b/reference/machines/stop_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/update.html.md
+++ b/reference/machines/update.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
   -d '{
       "region": "ord",
       "config": {

--- a/reference/machines/update.html.md
+++ b/reference/machines/update.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
   -d '{
       "region": "ord",
       "config": {

--- a/reference/machines/update.html.md
+++ b/reference/machines/update.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
   -d '{
       "region": "ord",
       "config": {

--- a/reference/machines/update_req.html.md
+++ b/reference/machines/update_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
   -d '{
       "config": {
         "image": "flyio/fastify-functions",

--- a/reference/machines/update_req.html.md
+++ b/reference/machines/update_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
   -d '{
       "config": {
         "image": "flyio/fastify-functions",

--- a/reference/machines/update_req.html.md
+++ b/reference/machines/update_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
   -d '{
       "config": {
         "image": "flyio/fastify-functions",

--- a/reference/machines/wait.html.md
+++ b/reference/machines/wait.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
 
 ```
 **Status: 200**

--- a/reference/machines/wait.html.md
+++ b/reference/machines/wait.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
 
 ```
 **Status: 200**

--- a/reference/machines/wait.html.md
+++ b/reference/machines/wait.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
 
 ```
 **Status: 200**

--- a/reference/machines/wait_req.html.md
+++ b/reference/machines/wait_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
+    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
 
 ```
 **Status: 200**

--- a/reference/machines/wait_req.html.md
+++ b/reference/machines/wait_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_PROTOCOL}://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
+    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
 
 ```
 **Status: 200**

--- a/reference/machines/wait_req.html.md
+++ b/reference/machines/wait_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "http://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
+    "https://${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
 
 ```
 **Status: 200**


### PR DESCRIPTION
I made some improvements while working from the working with machines docs:

* Most importantly: don't send fly API token in header over http when using `api.machines.dev` (instead use https)
* Make the Terraform examples 1% easier to copy-and-paste by using `fly_app`'s `name` attribute instead of making the user update the name in multiple places
* Added a line explaining where to get the auth token when setting up env for machines API