### PR TITLE
Volume reference re-org

### DIFF
--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -10,15 +10,15 @@ order: 30
 
 Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place. You can access and write to a volume on a Machine just like a regular directory.
 
-**The first rule of Fly Volumes is: Always run at least two volumes per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) details about how volumes are implemented.
+**The first rule of Fly Volumes is: Always run at least two volumes per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves; your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) for details about how volumes work.
 
 ## Launch a new app with a Fly Volume
 
-Follow these steps to create a new app, add the volume configuration to `fly.toml`, and then deploy the app. 
+Launch a new app with one Machine and an attached volume, and then clone the Machine to scale out.
 
 ### Launch the app, but don't deploy it yet
 
-The app has to exist for the volume to be created. The volume has to exist before you can mount it to a Machine. The first deployment of your app will create a Machine. So the shortest path to a Machine with a mounted volume begins by launching the app, and saying `N` to "deploy now?":
+The app has to exist for the volume to be created. The volume has to exist before you can mount it to a Machine. The shortest path to a Machine with a mounted volume begins by launching the app, and saying `N` to "deploy now?":
 
 ```cmd
 fly launch 
@@ -33,7 +33,7 @@ Your app is ready! Deploy with `flyctl deploy`
 
 ### Configure the app to mount the new volume
 
-Add a `[mounts]` section in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the volume during the deploy process. For example, the following configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+Add a `[mounts]` section in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the Machine and the volume during the deploy process. The following configuration exposes data from a volume named `myapp_data` under the `/data` directory of the application.
 
 ```toml
 [mounts]
@@ -143,7 +143,7 @@ fly volume myapp_data -r lhr
 ```
 
 <div class="callout">
-You need to create as many volumes as you have Machines per process in your app. Newer apps deployed using the `fly launch` command might have two Machines in the `app` process by default.
+You need to create as many volumes as you have Machines per process in your app. New apps deployed using the `fly launch` command might have two Machines in the `app` process by default.
 </div>
 
 If you configure [mounts] in `fly.toml` and then run `fly deploy` without first creating enough volumes, then you'll get an error similar to this one:
@@ -173,7 +173,7 @@ vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            
 
 ## Add a volume to a Machine clone
 
-If you're not using the `fly.toml` with `fly deploy` workflow for your Machines, you can add a volume by cloning a Machine with no volume and attaching a new volume to it. You can also clone a Machine with a volume already attached, which gives you a new Machine with a new, empty, volume attached.
+If you're not using the `fly.toml` with `fly deploy` workflow for some Machines, you can still add a volume by cloning a Machine with no volume and attaching a new volume to it. You can also clone a Machine with a volume already attached, which gives you a new Machine with a new, empty, volume attached.
 
 ### Create the volume
 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -173,7 +173,7 @@ vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            
 
 ## Add a volume to a Machine clone
 
-You can add a volume to an existing Machine by cloning a Machine with no volume and attaching a new volume to it. When you clone a Machine with a volume already attached, you'll also get a new Machine with a new, empty, volume attached.
+If you're not using the `fly.toml` with `fly deploy` workflow for your Machines, you can add a volume by cloning a Machine with no volume and attaching a new volume to it. You can also clone a Machine with a volume already attached, which gives you a new Machine with a new, empty, volume attached.
 
 ### Create the volume
 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -10,7 +10,7 @@ order: 30
 
 Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place. You can access and write to a volume on a Machine just like a regular directory.
 
-**The first rule of Fly Volumes is: always run at least two of them per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) details about how volumes are implemented.
+**The first rule of Fly Volumes is: Always run at least two volumes per application.** The way to do this is to run at least two Machines per app. Also note that volumes don't sync up by themselves. Your app needs to take care of that. Refer to [Fly Volumes](/docs/reference/volumes/) details about how volumes are implemented.
 
 ## Launch a new app with a Fly Volume
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -11,6 +11,23 @@ Apps can store only ephemeral data on the root file systems of their Machines, b
 
 A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
+If you already know you want to use volumes, learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+
+## Volume Considerations
+
+* **A volume belongs to one app:**: Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
+* **A volume exists in one region**: A volume exists in only one region. Only an instance of the app running in the same region can access it.
+* **A volume can attach to one machine**: You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
+* **Develop your app to handle replication**: Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, then your app has to make that happen.
+* **Use availability features**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. There are features you can use to mitigate hardware failure, like 
+* **Create and store backups**: If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
+
+If volumes won't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+
+## Volumes and Regions
+
+You can run multiple instances of an app in one region by creating volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run. Every volume has a unique ID to allow for multiple volumes with the same name. 
+
 ## Volumes and High availability
 
 <div class="callout">
@@ -20,21 +37,6 @@ A Fly Volume is a slice of an NVMe drive on the physical server your Fly App run
 There are a few cases where you can run a single Machine with an attached volume. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not yet worried about downtime.
 
 Many developers use volumes for databases, so when you create a volume, each of your app's volumes is placed in a separate hardware zone by default. When each volume is in a separate hardware zone, the number of volumes your app can have in a region is limited. You can configure this setting with the `--require-unique-zone` option when you run [`fly volumes create`](/docs/flyctl/volumes-create/).
-
-## Volume Considerations
-
-* Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
-* You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
-* **Your app needs to handle replication**: Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, then your app has to make that happen.
-* **Use availability features**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. Use the 
-* If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
-
-If volumes won't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
-
-## Volumes and Regions
-
-
-
 
 ## Volumes and Fly Apps
 
@@ -76,13 +78,9 @@ fly volumes create myapp_data --region yyz --size 1
 Created at: 04 Mar 23 03:32 UTC
 ```
 
-Volumes are bound to both apps and regions. A volume is directly associated with only one app and exists in only one region. No other app can see this volume and only an instance of the app running in the yyz region can access it.
-
-Most developers use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting limits the number of volumes your app can have in a region.
-
-There can be multiple volumes with the same volume name in a region and each volume has a unique ID to allow for this. You can run multiple instances of an app in one region by creating volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
-
+<div class="callout">
 Volumes are, by default, created with encryption-at-rest enabled for additional protection of the data on the volume. Use `--no-encryption` to instead create an unencrypted volume for improved performance at deployment and runtime.
+</div>
 
 When you create a volume on a Nomad (V1) App, its region is added to the app's region pool to allow app instances to be started with it.
 
@@ -175,9 +173,9 @@ Here, the volume is mounted under `/storage` in the Machine's root file system a
 
 ### Restore from a Snapshot
 
-Find the snapshots belonging to your target volume using the `fly volumes snapshots list` command. We take daily block-level snapshots of volumes. Snapshots are kept for five days. These may not have your latest data. You should implement your own backup plan for important data. Refer to [`fly volumes snapshots list`](https://fly.io/docs/flyctl/volumes-snapshots-list/) in the [flyctl reference](/docs/flyctl) for usage and options.
+List the snapshots that belong to your target volume using the `fly volumes snapshots list` command. We take daily block-level snapshots of volumes. Snapshots are kept for five days. These may not have your latest data. You should implement your own backup plan for important data. Refer to [`fly volumes snapshots list`](https://fly.io/docs/flyctl/volumes-snapshots-list/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
-To list a volume's snapshots, find its ID with `fly volumes list`, then use `fly volumes snapshots list <volume-id>`:
+To list a volume's snapshots, find the volume ID with `fly volumes list`, then use `fly volumes snapshots list <volume-id>`:
 
 ```cmd
 fly volumes snapshots list vol_wod56vjyd6pvny30
@@ -193,7 +191,7 @@ vs_pZlGZvq3gkAlAcaZ	17655830	4 days ago
 vs_A9k6age3bQov6twj	17631880	5 days ago
 ```
 
-A volume snapshot can be restored into a volume that's the same size as, or larger than, the source volume, but not a smaller one. If you don't specify a size with the `-s` flag, `fly volumes create` will request a 3GB volume. 
+A volume snapshot can be restored into a volume that's the same size as, or larger than, the source volume, but not into a smaller one. If you don't specify a size with the `-s` flag, then `fly volumes create` requests a 3GB volume.
 
 To restore from the snapshot to a new volume, use `fly volumes create <volume-name> --snapshot-id <snapshot-id> -s <volume-size> [-a <app-name>]`:
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -7,22 +7,22 @@ nav: firecracker
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Apps can store only ephemeral data on the root file systems of their Machines, because a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place.
+Apps can store only ephemeral data on the root file systems of their Machines, because a Machine's file system is rebuilt from scratch each time you deploy your app, or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). You can use volumes to store your database files or backups, to save your app's state, configuration, and session or user data, or for any information that needs to persist after deploy or restart.
 
 A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
-If you already know you want to use volumes, learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+If you already know how volumes work and you're ready to get started, then learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
 
 ## Volume Considerations
 
-* **A volume belongs to one app:**: Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
+* **A volume belongs to one app**: Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
 * **A volume exists in one region**: A volume exists in only one region. Only an instance of the app running in the same region can access it.
-* **A volume can attach to one machine**: You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
+* **A volume can attach to one Machine**: You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
 * **Develop your app to handle replication**: Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, then your app has to make that happen.
-* **Use availability features**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. There are features you can use to mitigate hardware failure, like 
+* **Create high availability in your primary region**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. You can run multiple Machines with volumes in your app's primary region to mitigate hardware failures.
 * **Create and store backups**: If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
 
-If volumes won't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+If volumes just don't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
 ## Volumes and Regions
 
@@ -30,13 +30,13 @@ You can run multiple instances of an app in one region by creating volumes with 
 
 ## Volumes and High availability
 
-<div class="callout">
+<div class="warning">
 **Always run at least two volumes per app.** We usually recommend running at least two Machines per app to increase availability, and if you're using volumes, then each machine should have an attached volume. If you only have one Machine and volume, you'll have downtime if there's a host or network failure, and whenever you deploy your app.
 </div>
 
 There are a few cases where you can run a single Machine with an attached volume. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not yet worried about downtime.
 
-Many developers use volumes for databases, so when you create a volume, each of your app's volumes is placed in a separate hardware zone by default. When each volume is in a separate hardware zone, the number of volumes your app can have in a region is limited. You can configure this setting with the `--require-unique-zone` option when you run [`fly volumes create`](/docs/flyctl/volumes-create/).
+Many developers use volumes for databases, so each volume you create for your app is placed in a separate hardware zone by default. Note that having each volume in a separate hardware zone limits the number of volumes your app can have in a region. You can configure this setting with the `--require-unique-zone` option when you run [`fly volumes create`](/docs/flyctl/volumes-create/).
 
 ## Volumes and Fly Apps
 
@@ -44,17 +44,9 @@ Learn how to [add volume storage for your app](/docs/apps/volume-storage/), step
 
 Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` app configuration file.
 
-<!-- 
-## Fly Volumes and flyctl
-
-Manage volumes using the [`fly volumes`](/docs/flyctl/volumes/) command.
-
-<div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
--->
-
 ## Working with volumes using flyctl
 
-This section is a reference for working with volumes using the [`fly volumes`](/docs/flyctl/volumes/) command. Refer to [Add Volume Storage](/docs/apps/volume-storage/) to add a volume to an existing app or launch a new app with a volume.
+This section is a reference for working with volumes using the [`fly volumes`](/docs/flyctl/volumes/) command. To add a volume to an existing app or launch a new app with a volume refer to [Add Volume Storage](/docs/apps/volume-storage/).
 
 <div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
 
@@ -116,7 +108,7 @@ Created at: 04 Mar 23 03:32 UTC
 
 ### Access a volume
 
-You can access and write to a volume on a Machine just like a regular directory. For Fly Apps, the `destination` under `[mounts]` in `fly.toml` is the path for the mounted volume. When you [clone a Machine and add a volume](/docs/apps/volume-storage/#add-a-volume-to-a-machine-clone), you specify the mount path in the `fly machine clone` command.
+You can access and write to a volume on a Machine just like a regular directory. For Fly Apps, the `destination` under `[mounts]` in `fly.toml` is the path for the mounted volumes. For Machines that are managed separately from the Fly App, you specify the mount path in the `fly machine clone` command, when you [clone a Machine and add a volume](/docs/apps/volume-storage/#add-a-volume-to-a-machine-clone).
 
 ### Extend a Volume
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -7,11 +7,11 @@ nav: firecracker
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Apps can store only ephemeral data on the root file systems of their Machines, because a Machine's file system is rebuilt from scratch each time you deploy your app, or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). You can use volumes to store your database files or backups, to save your app's state, configuration, and session or user data, or for any information that needs to persist after deploy or restart.
+Apps can store only ephemeral data on the root file systems of their Machines, because a Machine's file system is rebuilt from scratch each time you deploy your app, or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). You can use volumes to store your database files, to save your app's state, such as configuration and session or user data, or for any information that needs to persist after deploy or restart.
 
 A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
-If you already know how volumes work and you're ready to get started, then learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+If you already know how volumes work, and you're ready to get started, then learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
 
 ## Volume Considerations
 
@@ -22,7 +22,7 @@ If you already know how volumes work and you're ready to get started, then learn
 * **Create high availability in your primary region**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. You can run multiple Machines with volumes in your app's primary region to mitigate hardware failures.
 * **Create and store backups**: If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
 
-If volumes just don't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+If volumes don't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
 ## Volumes and Regions
 
@@ -48,7 +48,7 @@ Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-sec
 
 This section is a reference for working with volumes using the [`fly volumes`](/docs/flyctl/volumes/) command. To add a volume to an existing app or launch a new app with a volume refer to [Add Volume Storage](/docs/apps/volume-storage/).
 
-<div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
+<div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol`.</div>
 
 ### Create a Volume
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -7,23 +7,23 @@ nav: firecracker
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Apps can store ephemeral data on the root file systems of their Machines, but a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state—to preserve configuration, session or user data—and then be restarted with that information in place.
+Apps can store only ephemeral data on the root file systems of their Machines, becasue a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place.
 
 A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
 <div class="callout">
-**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime if there's a host or network failure, and whenever you deploy your app, because only one Machine can be attached to a volume at a time.
+**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime if there's a host or network failure, and whenever you deploy your app, because a volume can be attached to only one Machine.
 </div>
 
-There are exceptions to the rule of running at least two Fly volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime while you deploy it, then you can run a single Machine with an attached volume.
+There are exceptions to the rule of running at least two Fly volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime yet, then you can run a single Machine with an attached volume.
 
 **Things to consider before settling on volume storage:**
 
-* You'll need to run as many volumes as there are Machines.
-* There's a one-to-one mapping between Machines and volumes. You can't share a volume between apps, nor can two Machines mount the same volume at the same time. A single Machine can only mount one volume at a time.
+* Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
+* You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
 * Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, your app has to make that happen.
-* If your app needs a volume to function, and the NVMe drive hosting your volume fails, that instance of your app goes down. There's no way around that. 
-* If you only have a single copy of your data on a single Fly Volume, and that drive fails, data is lost. Fly.io takes daily snapshots and retains them for 5 days, but these are meant as a backstop, not your primary backup method.
+* If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. 
+* If you only have a single copy of your data on a single Fly Volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but these are meant as a backstop, not your primary backup method.
 
 If volumes won't work for your use case, you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
@@ -45,7 +45,7 @@ This section is a reference for working with volumes. Refer to [Add Volume Stora
 
 ### Create a Volume
 
-Every Fly Volume belongs to a [Fly App](/docs/reference/apps/). Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app.
+ Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app.
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -67,9 +67,9 @@ Created at: 04 Mar 23 03:32 UTC
 
 Volumes are bound to both apps and regions. A volume is directly associated with only one app and exists in only one region. No other app can see this volume and only an instance of the app running in the yyz region can access it.
 
-Most developers use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting does limit the number of volumes your app can have in a region.
+Most developers use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting limits the number of volumes your app can have in a region.
 
-There can be multiple volumes of the same volume name in a region. Each volume has a unique ID to distinguish itself from others to allow for this. This allows multiple instances of an app to run in one region. Creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
+There can be multiple volumes with the same volume name in a region, but each volume has a unique ID. You can  run multiple instances of an app one region byt creating volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
 
 Volumes are, by default, created with encryption-at-rest enabled for additional protection of the data on the volume. Use `--no-encryption` to instead create an unencrypted volume for improved performance at deployment and runtime.
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -7,45 +7,56 @@ nav: firecracker
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Apps can store only ephemeral data on the root file systems of their Machines, becasue a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place.
+Apps can store only ephemeral data on the root file systems of their Machines, because a Machine's file system is rebuilt from scratch each time the app is deployed or the Machine is restarted. Volumes are local persistent storage for [Fly Machines](/docs/machines/). Volumes allow an app to save its state&mdash;to preserve configuration, session or user data&mdash;and then be restarted with that information in place.
 
 A Fly Volume is a slice of an NVMe drive on the physical server your Fly App runs on. It is tied to that hardware. Fly Volumes are a lot like the disk inside your laptop, with the speed and simplicity advantage of being attached to your motherboard and accessible from a mount point in your file system. And the disadvantages that come with being tied to that hardware, too.
 
+## Volumes and High availability
+
 <div class="callout">
-**The first rule of Fly Volumes is: Always run at least two of them per application.** If you don't, you'll have downtime if there's a host or network failure, and whenever you deploy your app, because a volume can be attached to only one Machine.
+**Always run at least two volumes per app.** We usually recommend running at least two Machines per app to increase availability, and if you're using volumes, then each machine should have an attached volume. If you only have one Machine and volume, you'll have downtime if there's a host or network failure, and whenever you deploy your app.
 </div>
 
-There are exceptions to the rule of running at least two Fly volumes. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not worried about downtime yet, then you can run a single Machine with an attached volume.
+There are a few cases where you can run a single Machine with an attached volume. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not yet worried about downtime.
 
-**Things to consider before settling on volume storage:**
+Many developers use volumes for databases, so when you create a volume, each of your app's volumes is placed in a separate hardware zone by default. When each volume is in a separate hardware zone, the number of volumes your app can have in a region is limited. You can configure this setting with the `--require-unique-zone` option when you run [`fly volumes create`](/docs/flyctl/volumes-create/).
+
+## Volume Considerations
 
 * Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
 * You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
-* Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, your app has to make that happen.
-* If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. 
-* If you only have a single copy of your data on a single Fly Volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but these are meant as a backstop, not your primary backup method.
+* **Your app needs to handle replication**: Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, then your app has to make that happen.
+* **Use availability features**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. Use the 
+* If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
 
-If volumes won't work for your use case, you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+If volumes won't work for your use case, then you can explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
-## Fly Volumes and Fly Apps
+## Volumes and Regions
+
+
+
+
+## Volumes and Fly Apps
 
 Learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
 
 Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` app configuration file.
 
+<!-- 
 ## Fly Volumes and flyctl
 
 Manage volumes using the [`fly volumes`](/docs/flyctl/volumes/) command.
 
 <div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
+-->
 
-## Working with volumes
+## Working with volumes using flyctl
 
-This section is a reference for working with volumes. Refer to [Add Volume Storage](/docs/apps/volume-storage/) to add a volume to an existing app or launch a new app with a volume.
+This section is a reference for working with volumes using the [`fly volumes`](/docs/flyctl/volumes/) command. Refer to [Add Volume Storage](/docs/apps/volume-storage/) to add a volume to an existing app or launch a new app with a volume.
+
+<div class="callout">`fly volumes` is aliased to `fly volume` and `fly vol` for convenience.</div>
 
 ### Create a Volume
-
- Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app.
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
@@ -69,7 +80,7 @@ Volumes are bound to both apps and regions. A volume is directly associated with
 
 Most developers use volumes for databases, so for high availability, we default to putting each of your app's volumes on different hardware (equivalent to using `--require-unique-zone=true` with `fly volumes create`). This setting limits the number of volumes your app can have in a region.
 
-There can be multiple volumes with the same volume name in a region, but each volume has a unique ID. You can  run multiple instances of an app one region byt creating volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
+There can be multiple volumes with the same volume name in a region and each volume has a unique ID to allow for this. You can run multiple instances of an app in one region by creating volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run.
 
 Volumes are, by default, created with encryption-at-rest enabled for additional protection of the data on the volume. Use `--no-encryption` to instead create an unencrypted volume for improved performance at deployment and runtime.
 


### PR DESCRIPTION
An attempt to organize and augment the information about volumes by adding details, using headings, and summarizing and adding to the considerations. Will need a technical review. 

- Moved content out from the Create a volume section into the overview and into separate sections about regions and high availability.
- Added bolded "summary" statements to the bullets in the Considerations section to make them easier to scan visually.
- Created parallel considerations to explain the one-to-one mapping between volumes, regions, apps, and Machines.
- Etc.