### PR TITLE
Fix link typo

### DIFF
--- a/machines/guides-examples/machines-app-using-flyctl.html.md.erb
+++ b/machines/guides-examples/machines-app-using-flyctl.html.md.erb
@@ -15,7 +15,7 @@ flyctl provides commands for managing individual Machines from the CLI, on a lev
 
 ⚠️ **Stale doc!** This document illustrates some ways to work with Fly Machines individually using flyctl, and was written before [Fly Apps V2](/docs/reference/apps/#apps-v2) made it possible to manage Machines as a group, using a `fly.toml` config file and `fly deploy`. For most web apps, the [**Fly Apps docs**](/docs/apps/) are a better place to start!
 
-The [`fly machine` command docs](/docs/flyctl/machines/) are another good resource.
+The [`fly machine` command docs](/docs/flyctl/machine/) are another good resource.
 
 ## Elements of a Machines Web App
 


### PR DESCRIPTION
link to `fly machine` command docs had a typo