### PR TITLE
Example: Ping an App via an internal address

### DIFF
--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -100,7 +100,7 @@ Examples of retrieving this information are in the [fly-examples/privatenet](htt
 
 ### Example: Ping an app via an `.internal` address
 
-A quick to tutorial to show private networks in action. If you've arrived on private networking, we'll assume you've at least installed the CLI and are at least a little familiar with deploying apps on Fly.
+The following example shows private networks in action. You'll need to install [flyctl](/docs/hands-on/install-flyctl/) and be at least a little familiar with deploying apps on Fly.io.
 
 For this example we'll use the [hello-fly](https://github.com/fly-apps/hello-fly) repository.
 

--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -142,7 +142,7 @@ kill_timeout = "5s"
 
 #### Install dig and/or curl in your Dockerfile
 
-To test the internal network we need tool for that. By default dig and curl won't be installed on a machine. Just add `dnsutils` (for dig) and `curl` to your Dockerfile so you can access them later. Here's the line to add to your the Dockerfile:
+Next, install some tools to test the internal network. By default, dig and curl won't be installed on a Machine. Just add `dnsutils` (for dig) and `curl` to your Dockerfile so you can access them later. Here's the line to add to your Dockerfile:
 
 ```docker
 RUN apt-get update -y && \

--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -102,7 +102,7 @@ Examples of retrieving this information are in the [fly-examples/privatenet](htt
 
 The following example shows private networks in action. You'll need to install [flyctl](/docs/hands-on/install-flyctl/) and be at least a little familiar with deploying apps on Fly.io.
 
-For this example we'll use the [hello-fly](https://github.com/fly-apps/hello-fly) repository.
+For this example, you'll use the [hello-fly](https://github.com/fly-apps/hello-fly) repository. First, clone the `hello-fly` repo, and then run `fly launch`:
 
 ```cmd
 # clone the repository

--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -98,7 +98,7 @@ Finally, You can discover all the apps in the organization by requesting the TXT
 Examples of retrieving this information are in the [fly-examples/privatenet](https://github.com/fly-apps/privatenet) repository.
 
 
-### Example: Ping an app via an `.internal` addresss
+### Example: Ping an app via an `.internal` address
 
 A quick to tutorial to show private networks in action. If you've arrived on private networking, we'll assume you've at least installed the CLI and are at least a little familiar with deploying apps on Fly.
 

--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -118,7 +118,7 @@ fly launch
 ? Would you like to deploy now? (y/N)
 N
 
-# deploying now is fine, but we'll want to modify
+# deploying now is fine, but you'll want to modify
 # the fly.toml and redeploy again
 ```
 

--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -152,7 +152,7 @@ RUN apt-get update -y && \
 
 #### Deploy the app
 
-If you haven't already, run `fly deploy` and make sure the app is running. If you're using the [hello-fly](https://github.com/fly-apps/hello-fly) example then `service.port`'s were set in your fly.toml. You can  visit https://[[ your app name]].fly.dev and see a "Welcome to Fly" message.
+If you haven't already, run `fly deploy` and make sure the app is running. If you're using the [hello-fly](https://github.com/fly-apps/hello-fly) example, then `service.port`'s were set in your fly.toml. You can visit https://[[ your app name]].fly.dev and see a "Welcome to Fly.io" message.
 
 #### Ping an internal address
 


### PR DESCRIPTION
a step-by-step example using fly internal addresses.

![screencapture-localhost-4567-docs-reference-private-networking-2023-05-17-18_17_57](https://github.com/superfly/docs/assets/3220620/1b6de7ec-47ec-44d3-8b7c-6b4ef71d9b40)


