### PR TITLE
Add min machines running to auto start/stop feature docs

### DIFF
--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Automatically Stop and Start App V2 Fly Machines
+title: Automatically Stop and Start Machines
 objective: 
 layout: docs
 nav: firecracker
@@ -7,15 +7,16 @@ order: 65
 ---
 
 <div class="callout">
-This feature only works for V2 apps. For information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
+This feature only works for V2 apps running on Fly Machines. You might also be interested in learning about [scaling the nuber of machines](/docs/apps/scale-count/) for the V2 Apps Platform. For information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
 </div>
 
-Fly Machines are fast to start and stop, and you don't pay for their CPU and RAM when they're in the `stopped` state. For Fly Apps with a service configured, Fly Proxy can start and stop existing Machines based on incoming requests, so that your app can accommodate bursts in demand without keeping extra Machines running constantly.
+Fly Machines are fast to start and stop, and you don't pay for their CPU and RAM when they're in the `stopped` state. For Fly Apps with a service configured, Fly Proxy can start and stop existing Machines based on incoming requests, so that your app can accommodate bursts in demand without keeping extra Machines running constantly. And if your app needs to have one or more Machines always running in your primary region, then you can set a minimum number of machines to keep running.
 
 This Fly Proxy feature also plays well with apps whose Machines [exit from within](#stop-a-machine-by-terminating-its-main-process) when idle.
 
-You can configure automatic starts and automatic stops independently with the `auto_stop_machines` and `auto_start_machines` settings, and tune them with concurrency limits, within the [[[services]]](/docs/reference/configuration/#the-services-sections) or [[http_service]](/docs/reference/configuration/#the-http_service-section) sections of `fly.toml`.
+You can configure automatic starts and automatic stops with the `auto_stop_machines` and `auto_start_machines` settings, and set the minimum number of machines to keep running with the `min_machines_running` setting, within the [[[services]]](/docs/reference/configuration/#the-services-sections) or [[http_service]](/docs/reference/configuration/#the-http_service-section) sections of `fly.toml`. Concurrency limits for services affect [how automatic starts and stops work](#how-it-works).
 
+Default settings in `fly.toml` for V2 apps:
 ```toml
 ...
 [[services]]
@@ -23,6 +24,7 @@ You can configure automatic starts and automatic stops independently with the `a
   protocol = "tcp"
   auto_stop_machines = true
   auto_start_machines = true
+  min_machines_running = 0
 ...
 ```
 
@@ -33,42 +35,47 @@ You can configure automatic starts and automatic stops independently with the `a
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
+  min_machines_running = 0
 ...
 ```
 
 ## Default and recommended values
 
-New V2 apps created using the `fly launch` command are configured to automatically start and automatically stop Fly Machines by default:
+New V2 apps created using the `fly launch` command are configured by default to automatically start and automatically stop Fly Machines, and have the minimum machines running set to zero:
 
 ```toml
 auto_stop_machines = true
 auto_start_machines = true
+min_machines_running = 0
 ```
 
-Existing V2 apps—or any V2 apps that don't have these settings in `fly.toml`—will automatically start but not automatically stop Machines by default:
-
-```toml
-auto_stop_machines = false
-auto_start_machines = true
-```
+<div class="callout">
+Existing V2 apps—or any V2 apps that don't have these settings in `fly.toml`—will automatically start but not automatically stop Machines and have the minimum machines running set to 0 by default.
+</div>
 
 In most cases, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having Machines that either never start or never stop. 
 
-If `auto_start_machines = true` and `auto_stop_machines = false`, Fly Proxy will automatically start your Machines but will never stop them. If you have a reason to only stop Machines manually, then these settings are just fine.
+If `auto_start_machines = true` and `auto_stop_machines = false`, then Fly Proxy will automatically start your Machines but will never stop them. This means you'll have to stop Machines manually.
 
-If `auto_start_machines = false` and `auto_stop_machines = true`, Fly Proxy will automatically stop your Machines when there's low traffic, but won't be able to start them again. If all or most of your Machines are stopped, then requests will start failing.
+If `auto_start_machines = false` and `auto_stop_machines = true`, then Fly Proxy will automatically stop your Machines when there's low traffic, but won't be able to start them again. If all or most of your Machines are stopped, then requests will start failing.
+
+You can set `min_machines_running` to `1` or higher if your use case calls for having at least one instance of your app running all the time. This setting is for the total number of Machines, not Machines per region. For example, if `min_machines_running = 1`, then your app will scale down until there is only one Machine running in your primary region.
 
 ## How It Works
 
-The Fly Proxy runs a process to automatically stop and start Fly Machines every few minutes.
+The Fly Proxy runs a process to automatically stop and start existing Fly Machines every few minutes.
 
-When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capacity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
+<div class="callout">
+The automtic start and stop feature only works on existing Machines and never creates or destroys Machines for you. The maximum number of running Machines is the number of Machines you've cerated for your app using `fly scale count` or `fly machine clone`. Learn more about [scaling the number of Machines](/docs/apps/scale-count/). 
+</div>
+
+When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the concurrency [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capacity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
 
 Fly Proxy considers all of the app's Machines that are currently running in a given region, such as `fra`, and determines excess capacity as follows:
 
 * If there's more than one Machine in the region:
   * the proxy determines how many Machines are over their `soft_limit` setting and then calculates excess capacity: `excess capacity = num of machines - (num machines over soft limit + 1)`
-  * if excess capacity is 1 or greater, then the proxy stops one machine
+  * if excess capacity is 1 or greater, then the proxy stops one Machine
 * If there's only one Machine in the region:
   * the proxy checks if the Machine has any traffic
   * if the Machine has no traffic (a load of 0), then the proxy stops the Machine
@@ -85,9 +92,9 @@ Fly Proxy determines when to start a Machine as follows:
 
 If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your Fly Machines as demand decreases and increases. This could reduce costs, because you'll never have to run excess Machines to handle peak load; you'll only run, and be charged for, the number of Machines that are needed at any given time.
 
-The difference between this feature and what is typical in autoscaling, is that it doesn't create new Machines up to a specified maximum. It will automatically start only existing Machines. For example, if you want to have a maximum of 10 Machines available to service requests, then you need to create 10 Machines for your app.
+The difference between this feature and what is typical in autoscaling, is that it doesn't create new Machines up to a specified maximum. It automatically starts only existing Machines. For example, if you want to have a maximum of 10 Machines available to service requests, then you need to create 10 Machines for your app.
 
-If you need your app to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines` is set to `true` and there’s no traffic to your app, eventually all of your app's Machines could be stopped.
+If you need your all of you app's Machines to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines = true`, `min_machines_running = 0`, and there’s no traffic to your app, eventually all of your app's Machines could be stopped. If you only need one or a few instances of your app to keep running in your primary region all the time, then you can set `min_machines_running` to `1` or higher.
 
 ## Stop a Machine by terminating its main process
 

--- a/apps/autostart-stop.html.md.erb
+++ b/apps/autostart-stop.html.md.erb
@@ -7,7 +7,7 @@ order: 65
 ---
 
 <div class="callout">
-This feature only works for V2 apps running on Fly Machines. You might also be interested in learning about [scaling the nuber of machines](/docs/apps/scale-count/) for the V2 Apps Platform. For information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
+This feature only works for V2 apps running on Fly Machines. You might also be interested in learning about [scaling the number of machines](/docs/apps/scale-count/) for the V2 Apps Platform. For information about scaling V1 apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
 </div>
 
 Fly Machines are fast to start and stop, and you don't pay for their CPU and RAM when they're in the `stopped` state. For Fly Apps with a service configured, Fly Proxy can start and stop existing Machines based on incoming requests, so that your app can accommodate bursts in demand without keeping extra Machines running constantly. And if your app needs to have one or more Machines always running in your primary region, then you can set a minimum number of machines to keep running.
@@ -66,7 +66,7 @@ You can set `min_machines_running` to `1` or higher if your use case calls for h
 The Fly Proxy runs a process to automatically stop and start existing Fly Machines every few minutes.
 
 <div class="callout">
-The automtic start and stop feature only works on existing Machines and never creates or destroys Machines for you. The maximum number of running Machines is the number of Machines you've cerated for your app using `fly scale count` or `fly machine clone`. Learn more about [scaling the number of Machines](/docs/apps/scale-count/). 
+The automatic start and stop feature only works on existing Machines and never creates or destroys Machines for you. The maximum number of running Machines is the number of Machines you've created for your app using `fly scale count` or `fly machine clone`. Learn more about [scaling the number of Machines](/docs/apps/scale-count/). 
 </div>
 
 When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the concurrency [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capacity, it will stop exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
@@ -94,7 +94,7 @@ If your app has highly variable request workloads, then you can set `auto_stop_m
 
 The difference between this feature and what is typical in autoscaling, is that it doesn't create new Machines up to a specified maximum. It automatically starts only existing Machines. For example, if you want to have a maximum of 10 Machines available to service requests, then you need to create 10 Machines for your app.
 
-If you need your all of you app's Machines to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines = true`, `min_machines_running = 0`, and there’s no traffic to your app, eventually all of your app's Machines could be stopped. If you only need one or a few instances of your app to keep running in your primary region all the time, then you can set `min_machines_running` to `1` or higher.
+If you need all of you app's Machines to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines = true`, `min_machines_running = 0`, and there’s no traffic to your app, eventually all of your app's Machines could be stopped. If you only need one or a few instances of your app to keep running in your primary region all the time, then you can set `min_machines_running` to `1` or higher.
 
 ## Stop a Machine by terminating its main process
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -216,6 +216,7 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 * `force_https`: A boolean which determines whether to enforce HTTP to HTTPS redirects.
 * `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop machines every few minutes. The default it `true`.
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
+* `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines = true`.
 
 <div class="callout">
 We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.


### PR DESCRIPTION
This PR:
- adds the `min_machines_running` setting to the auto start and stop docs (source: https://community.fly.io/t/setting-a-minimum-number-of-instances-to-keep-running-when-using-auto-start-stop/12861)
- adds a note to emphasize this feature is for existing Machines only
- includes some other clarifications and word improvements
- updates the fly config reference for fly.toml