### PR TITLE
Suggest pwsh instead of powershell

### DIFF
--- a/hands-on/install-flyctl.html.md.erb
+++ b/hands-on/install-flyctl.html.md.erb
@@ -58,7 +58,7 @@ curl -L https://fly.io/install.sh | sh
 Run the Powershell install script:
 
 ```cmd
-powershell -Command "iwr https://fly.io/install.ps1 -useb | iex"
+pwsh -Command "iwr https://fly.io/install.ps1 -useb | iex"
 ```
 
 Next:


### PR DESCRIPTION
`powershell.exe` is fixed at PowerShell 5.1 for backwards compatibility reasons, newer versions use `pwsh.exe`.

Older versions have [issues](https://github.com/superfly/flyctl/pull/2307), we should suggest users to use a newer PowerShell instead.