### PR TITLE
Use absolute paths for SSH commands

### DIFF
--- a/elixir/getting-started/existing.html.md.erb
+++ b/elixir/getting-started/existing.html.md.erb
@@ -63,7 +63,7 @@ fly ssh issue --agent
 With SSH configured, let's open a console.
 
 ```cmd
-fly ssh console --pty -C "app/bin/hello_elixir remote"
+fly ssh console --pty -C "/app/bin/hello_elixir remote"
 ```
 ```output
 Connecting to hello_elixir.internal... complete

--- a/elixir/the-basics/iex-into-running-app.html.md
+++ b/elixir/the-basics/iex-into-running-app.html.md
@@ -23,7 +23,7 @@ fly ssh issue --agent
 With SSH configured, let's open a console.
 
 ```cmd
-fly ssh console --pty -C "app/bin/hello_elixir remote"
+fly ssh console --pty -C "/app/bin/hello_elixir remote"
 ```
 ```output
 Connecting to hello_elixir.internal... complete

--- a/rails/the-basics/deployments.html.md
+++ b/rails/the-basics/deployments.html.md
@@ -53,7 +53,7 @@ task :release => 'db:migrate'
 To disable automatic migrations for deploys, remove the dependency from the `:release` task. Then, to manually run migrations after a deployment, run:
 
 ```cmd
-fly ssh console -C "rails/bin/rails db:migrate"
+fly ssh console -C "/rails/bin/rails db:migrate"
 ```
 
 ## Run ad-hoc tasks after deploying

--- a/rails/the-basics/run-tasks-and-consoles.html.md
+++ b/rails/the-basics/run-tasks-and-consoles.html.md
@@ -10,7 +10,7 @@ order: 3
 To access an interactive Rails console, run:
 
 ```cmd
-fly ssh console --pty -C "rails/bin/rails console"
+fly ssh console --pty -C "/rails/bin/rails console"
 ```
 ```output
 Loading production environment (Rails 7.0.4.2)
@@ -65,13 +65,13 @@ Accept the changes to your Dockerfile, and then rerun `fly deploy`.
 Once this is complete, you can execute other commands on Fly, for example:
 
 ```cmd
-fly ssh console -C "rails/bin/rails db:migrate"
+fly ssh console -C "/rails/bin/rails db:migrate"
 ```
 
 To list all the available tasks, run:
 
 ```cmd
-fly ssh console -C "rails/bin/rails help"
+fly ssh console -C "/rails/bin/rails help"
 ```
 
 ## Custom Rake tasks
@@ -88,11 +88,11 @@ namespace :fly do
   end
 
   task :console do
-    sh 'fly ssh console --pty -C "rails/bin/rails console"'
+    sh 'fly ssh console --pty -C "/rails/bin/rails console"'
   end
 
   task :dbconsole do
-    sh 'fly ssh console --pty -C "rails/bin/rails dbconsole"'
+    sh 'fly ssh console --pty -C "/rails/bin/rails dbconsole"'
   end
 end
 ```


### PR DESCRIPTION
It looks like we're going to change the SSH working directory to the Docker image's `WORKDIR` by default, so the docs shouldn't assume that it will be `/`.

Provided that our scanner-generated `Dockerfile`s set the `WORKDIR` properly, we may want to further update some of these commands when that patch rolls out (e.g. simplifying `/rails/bin/rails` to `bin/rails`). But for now I just want to make sure that they keep working!