### PR TITLE
Update docs for all new app are v2 apps

### DIFF
--- a/partials/_v2_transition_banner.html.erb
+++ b/partials/_v2_transition_banner.html.erb
@@ -1,5 +1,7 @@
 <div class="border border-blue-600 bg-blue-50 rounded-l p-4 my-4 text-base text-navy">
-New organizations now deploy to <u>[V2](/docs/reference/apps/#apps-v2)</u> of the <u>[Fly Apps platform](/docs/reference/apps/)</u>, running on <u>[Fly Machines](/docs/machines/)</u>. Docs put Apps V2 in the foreground, but include information specific to the legacy <u>[Fly Apps V1](/docs/reference/apps/#legacy-apps-fly-apps-v1)</u> where appropriate.
+All new apps now deploy to <u>[V2](/docs/reference/apps/#apps-v2)</u> of the <u>[Fly Apps platform](/docs/reference/apps/)</u>, running on <u>[Fly Machines](/docs/machines/)</u>. Most docs focus on Apps V2, but we still include information specific to the legacy <u>[Fly Apps V1](/docs/reference/apps/#legacy-apps-fly-apps-v1)</u> where appropriate.
 <br><br>
-Start deploying your new apps to Apps V2 with `fly orgs apps-v2 default-on <org-slug>`. You can also <u>[migrate your V1 apps](/docs/apps/migrate-to-v2/)</u>!
+We'll be migrating all V1 apps in phases. Learn more about <u>[how and why we're getting off Nomad](https://community.fly.io/t/get-in-losers-were-getting-off-nomad/12914)</u>.
+<br><br>
+You can also migrate your V1 app yourself <u>[using our migration tool](https://community.fly.io/t/fly-migrate-to-v2-apps-with-volumes-support/12316)</u> or <u>[manually](https://fly.io/docs/apps/migrate-to-v2/)</u>.
 </div>


### PR DESCRIPTION
This PR:
- updates the migration banner partial used on many pages to say that all new apps are V2 apps and to link to  community posts
- TBD still looking for other related changes

Preview:
![Screenshot 2023-05-23 at 12 25 18 PM](https://github.com/superfly/docs/assets/13827355/d3fb348a-11cb-4f77-af5a-468f8ca84f36)
