### PR TITLE
Swap note for standard V2 migration banner in Apps Ref

### DIFF
--- a/reference/apps.html.md.erb
+++ b/reference/apps.html.md.erb
@@ -4,16 +4,8 @@ layout: docs
 toc: false
 nav: firecracker
 ---
-<div class="callout">
 
-New organizations use [V2 of the Fly Apps platform](/docs/reference/apps/#apps-v2), running on [Fly Machines](/docs/machines/).
-
-You can check if your org defaults to Apps V2 deployments with `fly orgs apps-v2 show <org-slug>`. Get your organization slug using `fly orgs list`. 
-
-Flip the switch to start deploying your new apps to Apps V2 with `fly orgs apps-v2 default-on <org-slug>`.
-
-You can also [migrate your existing V1 apps to Apps V2](/docs/apps/migrate-to-v2/).
-</div>
+<%= partial "/docs/partials/v2_transition_banner" %>
 
 On Fly.io, an App is an abstraction for a group of virtual machines running your code, along with the configuration, provisioned resources, and data we need to keep track of to run and route to your VMs. 
 


### PR DESCRIPTION
Replace the callout with the standard v2 migration partial.