### PR TITLE
Updates to Application Configuration docs

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -53,6 +53,13 @@ When shutting down a Fly app instance, by default, after sending a signal, Fly g
 kill_timeout = 120
 ```
 
+## Console command
+
+If you want to use the `fly console` command 
+```toml
+console_command = 
+```
+
 ## The `build` section
 
 The optional build section contains key/values concerned with how the application should be built. You can read more about builders in [Builders and Fly](/docs/reference/builders/)
@@ -158,8 +165,6 @@ The available strategies are:
 
 **rolling**: The default for apps with persistent volumes. One by one, each running VM is taken down and replaced by a new release VM. This is the default strategy for apps with volumes.
 
-
-
 **immediate**: Replace all VMs with new releases immediately without waiting for health checks to pass. This is useful in emergency situations where you're confident about release health and can't wait for health checks.
 
 
@@ -206,13 +211,15 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
+  min_machines_running = 0
   [http_service.concurrency]
     type = "requests"
     soft_limit = 200
     hard_limit = 250
 ```
 
-* `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
+* `processes`: For apps with multiple processes. The process group that this service belongs to. Define process groups in the [processes](#the-processes-section) section.
+* `internal_port`: The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `force_https`: A boolean which determines whether to enforce HTTP to HTTPS redirects.
 * `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop machines every few minutes. The default it `true`.
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
@@ -251,12 +258,15 @@ The `services` section itself is a table of tables in TOML, so the section is de
   protocol = "tcp"
   auto_stop_machines = true
   auto_start_machines = true
+  min_machines_running = 0
 ```
 
+* `processes`: For apps with multiple processes. The process group that this service belongs to. Define process groups in the [processes](#the-processes-section) section.
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `protocol` : The protocol that this service will use to communicate. Typically `tcp` for most applications, but can also be `udp`.
 * `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop machines every few minutes. The default it `true`.
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
+* `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines = true`.
 
 <div class="callout">
 We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
@@ -371,7 +381,7 @@ Times are in milliseconds unless units are specified.
 
 * `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your application to start up. For example if your app takes 2 seconds to start up, give it some runway by setting this to at least 3 seconds.
 * `interval`: The time between connectivity checks. If it's long and your grace_period shorter than your app's startup time, health check will take long adding you your deployment time.
-* `restart_limit`: The number of consecutive TCP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed TCP health checks.
+* `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive TCP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed TCP health checks.
 * `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
 
 ### `services.http_checks`
@@ -397,11 +407,11 @@ Times are in milliseconds unless units are specified.
 
 * `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your app to start up. For example if your app takes 2 seconds to start up, give it some runway by setting to at least 3 seconds.
 * `interval`: The time between connectivity checks. There should be a balance between the interval and the grace period. If it's long and your grace_period shorter than your app's startup time, health check will take too long adding you your deployment time.
+* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive HTTP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed HTTP health checks.
 * `method`: The HTTP method to be used for the check.
 * `path`: The path of the URL to be requested.
-* `protocol`: The protocol to be used (`http` or `https`)
-* `restart_limit`: The number of consecutive HTTP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed HTTP health checks.
-* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `protocol`: The protocol to be used (`http` or `https`).
 * `tls_skip_verify`: When `true` (and using HTTPS protocol) skip verifying the certificates sent by the server.
 * `services.http_checks.headers`: This is a sub-section of `services.http_checks`. It uses the key/value pairs as a specification of header and header values that will get passed with the http_check call.
 
@@ -424,6 +434,8 @@ The `source` is a volume name that this app should mount. Any volume with this n
 ### `destination`
 
 The `destination` is directory where the `source` volume should be mounted on the running app.
+
+### `processes`
 
 Optionally, you can specify a list of [processes](#the-processes-section) to limit volume mounts by process group. You can even specify two different `[[mounts]]` sections to mount different source volumes to VMs in different process groups. Note the need to use double brackets if there are multiple `[[mounts]]` defined.
 
@@ -468,7 +480,7 @@ Again, times are in milliseconds unless units are specified.
 
 ## The `processes` section
 
-The `processes` section allows you to define process groups to be run on separate VMs within a single app.
+The `processes` section allows you to define process groups to be run on separate VMs within a single app. Learn more about [running multiple process groups in an app](/docs/apps/processes/).
 
 **Each machine can run a different command on start**, allowing you to re-use your code base for different tasks (web server, queue worker, etc).
 
@@ -525,20 +537,20 @@ The "guest path" --- the path inside your container where the files to serve are
 
 ### Caveats
 
-This feature should not be compared directly with a CDN, for the following reasons.
+This feature should not be compared directly with a CDN, for the following reasons:
 
-This feature does not exempt you from having to run a web service in your VM.
+* This feature does not exempt you from having to run a web service in your VM.
 
-Statics will not find `index.html` at the root. The full path must be requested.
+* Statics will not find `index.html` at the root. The full path must be requested.
 
-You can't set `Cache-Control` or any other headers on assets. If you need those, you'll need to deliver them from your application and set the relevant headers.
+* You can't set `Cache-Control` or any other headers on assets. If you need those, you'll need to deliver them from your application and set the relevant headers.
 
-Assets are not delivered, by default, from all edge Fly.io regions. Rather, assets are delivered from the regions the application is deployed in.
+* Assets are not delivered, by default, from all edge Fly.io regions. Rather, assets are delivered from the regions the application is deployed in.
 
-`statics` does not honor symlinks. So, if `/app/public` in your container is actually a symlink to something like `/app-39403/public`, you'll want to use the absolute original path in your statics configuration.
+* `statics` does not honor symlinks. So, if `/app/public` in your container is actually a symlink to something like `/app-39403/public`, you'll want to use the absolute original path in your statics configuration.
 
 
-## The `experimental` section (Legacy Nomad Apps Only)
+## The `experimental` section (V1 Nomad Apps Only)
 
 This section is for flags and feature settings which have yet to be promoted into the main configuration.
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -211,7 +211,7 @@ Secrets take precedence over env variables with the same name.
 
 ## The `http_service` section
 
-[**Apps V2**](/docs/reference/apps/#apps-v2) **only:** For apps that only need HTTP and HTTPS services, you can replace the full-blown `[[services]]` section with this simpler alternative. 
+[**Apps V2**](/docs/reference/apps/#apps-v2) **only:** For apps that only need HTTP and HTTPS services, you can replace the `[[services]]` section with this simpler alternative. 
 
 An `[http_service]` section defines a service that listens on ports 80 and 443. Port 80 will have an HTTP handler. Port 443 will have a TLS and HTTP handler. You can configure additional services on different ports by adding `[[services]]` sections.
 
@@ -241,6 +241,8 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having machines that either never start or never stop. Learn more about [automatically starting and stopping V2 app Fly machines](/docs/apps/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
+### `http_service.concurrency`
+
 The `[http_service.concurrency]` section has the same settings as `[services.concurrency]`, which are:
 
 * `type` specifies what metric is used to determine when to scale up and down, or when a given instance should receive more or less traffic (load balancing). The two supported values are `connections` and `requests`.
@@ -251,6 +253,10 @@ The `[http_service.concurrency]` section has the same settings as `[services.con
 
 * `hard_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that application instance. The system will bring up another instance if the auto scaling policy supports doing so.
 * `soft_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that application instance and only send it to that application instance if all other instances are also at or above their soft_limit. The system will likely bring up another instance if the auto scaling policy for the application support doing so.
+
+### `http_service.http_options`
+
+
 
 ## The `services` sections
 
@@ -563,7 +569,7 @@ This feature should not be compared directly with a CDN, for the following reaso
 * `statics` does not honor symlinks. So, if `/app/public` in your container is actually a symlink to something like `/app-39403/public`, you'll want to use the absolute original path in your statics configuration.
 
 
-## The `experimental` section (V1 Nomad Apps Only)
+## The `experimental` section
 
 This section is for flags and feature settings which have yet to be promoted into the main configuration.
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -55,9 +55,12 @@ kill_timeout = 120
 
 ## Console command
 
-If you want to use the `fly console` command 
+The command to run when you run the [`fly console` command](/docs/flyctl/console/). Configure the `console_command` field with the command that opens your framework's console, and then `fly console` will run that command automatically in a new, dedicated Machine. The new Machine is configured with the image and environment from your app’s latest release, but your app isn’t started, and no traffic will be routed to it. The Machine gets destroyed when you exit the console.
+
+Here's an example of a console command for Django:
+
 ```toml
-console_command = 
+console_command = "/code/manage.py shell"
 ```
 
 ## The `build` section
@@ -95,6 +98,15 @@ The image builder is used when you want to immediately deploy an existing public
 `dockerfile` accepts a relative path to a Dockerfile, or a URL. By default, `flyctl` looks for `Dockerfile` in the application root.
 
 **Gotchas:** 1) This option will not change the Docker context path, which is set to the project root directory by default. If you want the `Dockerfile` to use its containing directory as the context root, use `fly deploy <directory>`. 2) When specifying a local Dockerfile, make sure it's not excluded from the Docker build context in your `.dockerignore`.
+
+### Specify a Docker ignore file
+
+```toml
+[build]
+  ignorefile = "/path/.dockerignore"
+```
+
+`ignorefile` accepts a relative path to a `.dockerignore` file. By default, `flyctl` looks for the `.dockerignore` file in the working directory.
 
 ### Specify a multistage Docker build target
 
@@ -475,6 +487,7 @@ Fields are very similar to `[[services.checks]]`:
 * `method`: The HTTP method to be used for the check.
 * `path`: The path of the URL to be requested.
 * `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `processes`: For apps with multiple processes. The process group to apply the health checks to. Define process groups in the [processes](#the-processes-section) section.
 
 Again, times are in milliseconds unless units are specified.
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -158,7 +158,7 @@ The temporary VM inherits the size from the largest machine in the default proce
 
 A non-zero exit status from this command will stop the deployment. `fly deploy` will display logs from the command. Logs are available via `fly logs` as well.
 
-To ensure the command runs in a specific region - say `dfw` - set `PRIMARY_REGION = 'dfw'` in your application environment in `fly.toml` or with `fly deploy -e PRIMARY_REGION=dfw`. Setting `PRIMARY_REGION` is important if when running [database replicas in multiple regions](/docs/postgres/high-availability-and-global-replication).
+To ensure the command runs in a specific region, such as `dfw`, set `PRIMARY_REGION = 'dfw'` in your application environment in `fly.toml` or with `fly deploy -e PRIMARY_REGION=dfw`. Setting `PRIMARY_REGION` is important if you're running [database replicas in multiple regions](/docs/postgres/high-availability-and-global-replication).
 
 The environment variable `RELEASE_COMMAND=1` is set within the temporary release VM. You can use this to define behavior in your Dockerfile's `ENTRYPOINT`  that's conditional on being run on a release VM.
 
@@ -233,7 +233,7 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 * `processes`: For apps with multiple processes. The process group that this service belongs to. Define process groups in the [processes](#the-processes-section) section.
 * `internal_port`: The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `force_https`: A boolean which determines whether to enforce HTTP to HTTPS redirects.
-* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop machines every few minutes. The default it `true`.
+* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop machines every few minutes. The default is `true`.
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 * `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines = true`.
 
@@ -247,22 +247,24 @@ The `[http_service.concurrency]` section has the same settings as `[services.con
 
 * `type` specifies what metric is used to determine when to scale up and down, or when a given instance should receive more or less traffic (load balancing). The two supported values are `connections` and `requests`.
 
-**connections**: Load balance and scale based on number of concurrent tcp connections. This is the default when unspecified. This is also the default when fly.toml is created with `fly launch`.
+**connections**: Load balance and scale based on the number of concurrent tcp connections. This is the default when unspecified. This is also the default when fly.toml is created with `fly launch`.
 
 **requests**: Load balance and scale based on the number of http requests. This is recommended for web services, since multiple requests can be sent over a single tcp connection.
 
 * `hard_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that application instance. The system will bring up another instance if the auto scaling policy supports doing so.
-* `soft_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that application instance and only send it to that application instance if all other instances are also at or above their soft_limit. The system will likely bring up another instance if the auto scaling policy for the application support doing so.
+* `soft_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that application instance and only send it to that application instance if all other instances are also at or above their soft_limit. The system will likely bring up another instance if the auto scaling policy for the application supports doing so.
 
 ### `http_service.http_options.response.headers`
 
-Add or remove HTTP response headers. In the following example, `example-header` would be removed from the final response that Fly Proxy sends, and `example-header-1` and `example-multi-value` and their values would be added to the response headers.
+Add or remove HTTP response headers. 
+
+In the following example, `Example-Header` will be removed from the final response that Fly Proxy sends, while `Example-Header-1` and `Example-Multi-Value` and their values will be added to the response header.
 
 ```toml
   [http_service.http_options.response.headers]
-    example-header = false
-    example-header-1 = "value"
-    example-multi-value = ["value1", "value2"]
+    Example-Header = false
+    Example-Header-1 = "value"
+    Example-Multi-Value = ["value1", "value2"]
 ```
 
 ## The `services` sections
@@ -289,7 +291,7 @@ The `services` section itself is a table of tables in TOML, so the section is de
 * `processes`: For apps with multiple processes. The process group that this service belongs to. Define process groups in the [processes](#the-processes-section) section.
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `protocol` : The protocol that this service will use to communicate. Typically `tcp` for most applications, but can also be `udp`.
-* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop machines every few minutes. The default it `true`.
+* `auto_stop_machines`: Whether to automatically stop an application's machines when there's excess capacity, per region. If there's only one machine in a region, then the machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop machines every few minutes. The default is `true`.
 * `auto_start_machines`: Whether to automatically start an application's machines when a new request is made to the application and there's no excess capacity, per region. If there's only one machine in a region, then it's started whenever a request is made to the application. The default is `true`.
 * `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines = true`.
 
@@ -312,7 +314,7 @@ This section is a simple list of key/values, so the section is denoted with sing
 
 `type` specifies what metric is used to determine when a given instance has reached a concurrency limit. The two supported values are `connections` and `requests`.
 
-**connections**: Load balance based on number of concurrent tcp connections. This is the default when unspecified. This is also the default when fly.toml is created with `fly launch`.
+**connections**: Load balance based on the number of concurrent tcp connections. This is the default when unspecified. This is also the default when fly.toml is created with `fly launch`.
 
 **requests**: Load balance based on the number of http requests. This is recommended for web services, since multiple requests can be sent over a single tcp connection.
 
@@ -370,13 +372,13 @@ Instead of using multiple port definitions, you can specify a range of ports. Fo
 
 Add or remove HTTP response headers. 
 
-In the following example, `Example-Header` is removed from the final response that Fly Proxy sends, while `Example-Header-1` and `Example-Multi-Value` and their values are added to the response header.
+In the following example, `Example-Header` will be removed from the final response that Fly Proxy sends, while `Example-Header-1` and `Example-Multi-Value` and their values will be added to the response header.
 
 ```toml
   [services.ports.http_options.response.headers]
-    example-header = false
-    example-header-1 = "value"
-    example-multi-value = ["value1", "value2"]
+    Example-Header = false
+    Example-Header-1 = "value"
+    Example-Multi-Value = ["value1", "value2"]
 ```
 
 #### `services.ports.tls_options`
@@ -418,7 +420,7 @@ When a service is running, Fly Proxy can check up on it by connecting to a port.
 Times are in milliseconds unless units are specified.
 
 * `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your application to start up. For example if your app takes 2 seconds to start up, give it some runway by setting this to at least 3 seconds.
-* `interval`: The time between connectivity checks. If it's long and your grace_period shorter than your app's startup time, health check will take long adding you your deployment time.
+* `interval`: The time between connectivity checks. If the interval is long, and the `grace_period` is shorter than your app's startup time, then the health check will take longer and will add to your deployment time.
 * `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive TCP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed TCP health checks.
 * `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
 
@@ -443,7 +445,7 @@ Roughly translated, this section says every ten seconds, perform a HTTP GET on t
 
 Times are in milliseconds unless units are specified.
 
-* `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your app to start up. For example if your app takes 2 seconds to start up, give it some runway by setting to at least 3 seconds.
+* `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your app to start up. For example, if your app takes 2 seconds to start up, give it some runway by setting `grace_period` to at least 3 seconds.
 * `interval`: The time between connectivity checks. There should be a balance between the interval and the grace period. If it's long and your grace_period shorter than your app's startup time, health check will take too long adding you your deployment time.
 * `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
 * `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive HTTP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed HTTP health checks.
@@ -471,7 +473,7 @@ The `source` is a volume name that this app should mount. Any volume with this n
 
 ### `destination`
 
-The `destination` is directory where the `source` volume should be mounted on the running app.
+The `destination` is the directory where the `source` volume should be mounted on the running app.
 
 ### `processes`
 
@@ -508,8 +510,8 @@ Fields are very similar to `[[services.checks]]`:
 
 * `port`: Internal port to connect to. Needs to be available on `0.0.0.0`.
 * `type`: Either `tcp` or `http`.
-* `grace_period`: The time to wait after a VM starts before checking its health. Make sure you give your app enough time to start up. For example if your app takes 2 seconds to start up, give it some runway by setting this to at least 3 seconds.  
-* `interval`: The time between connectivity checks. If it's long and your grace_period shorter than your app's startup time, health will take long adding you your deployment time.
+* `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your app to start up. For example, if your app takes 2 seconds to start up, give it some runway by setting `grace_period` to at least 3 seconds.  
+* `interval`: The time between connectivity checks. If the interval is long, and the `grace_period` is shorter than your app's startup time, then the health check will take longer and will add to your deployment time.
 * `method`: The HTTP method to be used for the check.
 * `path`: The path of the URL to be requested.
 * `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -175,9 +175,11 @@ The environment variable `RELEASE_COMMAND=1` is set within the temporary release
 
 The available strategies are:
 
-**rolling**: The default for apps with persistent volumes. One by one, each running VM is taken down and replaced by a new release VM. This is the default strategy for apps with volumes.
+**rolling**: The default strategy for apps with or without volumes. One by one, each running VM is taken down and replaced by a new release VM.
 
 **immediate**: Replace all VMs with new releases immediately without waiting for health checks to pass. This is useful in emergency situations where you're confident about release health and can't wait for health checks.
+
+**canary**: Boots a single, new VM with the new release, verifies its health, and then proceeds with a `rolling` restart strategy.
 
 
 #### For Nomad (Legacy) Apps Only

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -158,7 +158,7 @@ The temporary VM inherits the size from the largest machine in the default proce
 
 A non-zero exit status from this command will stop the deployment. `fly deploy` will display logs from the command. Logs are available via `fly logs` as well.
 
-To ensure the command runs in a specific region - say `dfw` - set `PRIMARY_REGION = 'dfw'` on in your application environment in `fly.toml` or with `fly deploy -e PRIMARY_REGION=dfw`. Setting `PRIMARY_REGION` is important if when running [database replicas in multiple regions](/docs/postgres/high-availability-and-global-replication).
+To ensure the command runs in a specific region - say `dfw` - set `PRIMARY_REGION = 'dfw'` in your application environment in `fly.toml` or with `fly deploy -e PRIMARY_REGION=dfw`. Setting `PRIMARY_REGION` is important if when running [database replicas in multiple regions](/docs/postgres/high-availability-and-global-replication).
 
 The environment variable `RELEASE_COMMAND=1` is set within the temporary release VM. You can use this to define behavior in your Dockerfile's `ENTRYPOINT`  that's conditional on being run on a release VM.
 
@@ -254,9 +254,16 @@ The `[http_service.concurrency]` section has the same settings as `[services.con
 * `hard_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that application instance. The system will bring up another instance if the auto scaling policy supports doing so.
 * `soft_limit` : When an application instance is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that application instance and only send it to that application instance if all other instances are also at or above their soft_limit. The system will likely bring up another instance if the auto scaling policy for the application support doing so.
 
-### `http_service.http_options`
+### `http_service.http_options.response.headers`
 
+Add or remove HTTP response headers. In the following example, `example-header` would be removed from the final response that Fly Proxy sends, and `example-header-1` and `example-multi-value` and their values would be added to the response headers.
 
+```toml
+  [http_service.http_options.response.headers]
+    example-header = false
+    example-header-1 = "value"
+    example-multi-value = ["value1", "value2"]
+```
 
 ## The `services` sections
 
@@ -357,6 +364,19 @@ Instead of using multiple port definitions, you can specify a range of ports. Fo
   handlers = ["tls"]
   start_port = 8080
   end_port = 8085
+```
+
+#### `services.ports.http_options.response.headers`
+
+Add or remove HTTP response headers. 
+
+In the following example, `Example-Header` is removed from the final response that Fly Proxy sends, while `Example-Header-1` and `Example-Multi-Value` and their values are added to the response header.
+
+```toml
+  [services.ports.http_options.response.headers]
+    example-header = false
+    example-header-1 = "value"
+    example-multi-value = ["value1", "value2"]
 ```
 
 #### `services.ports.tls_options`


### PR DESCRIPTION
This PR:
- sprinkles more "processes" stuff throughout, where it was missing
- adds the `console_command` field
- fixes up `min_machines_running`
- adds the `ignorefile` field to the build section
- adds `http_options.response.headers` to `http_service` and `services`
- other minor edits

Preview: https://aa-docs.fly.dev/docs/reference/configuration/