### PR TITLE
Remove LiteFS banner; replace with project status disclaimer

### DIFF
--- a/litefs/backup.html.md.erb
+++ b/litefs/backup.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: Backing up your LiteFS cluster
+layout: docs
+sitemap: false
+nav: litefs
+toc: true
+---
+
+While LiteFS replicates data between nodes and supports failover, it does not
+currently have a disaster recovery system in place in the event you lose your
+entire cluster. These are some strategies you can use to reduce your risk of
+data loss in the event of a bug or disk corruption.
+
+## Periodic backup via export
+
+The simplest approach is to export your database via the [litefs
+export](/docs/litefs/export) command and then upload that file to long-term
+storage such as S3. The `export` commmand is safe to use on a live database 
+and can even be run remotely by specifying the `-url` flag.
+
+Once the database is downloaded, it can be compressed & uploaded to S3.
+
+```sh
+# Download current snapshot the "my.db" database to a local file.
+litefs export -name my.db /path/to/backup
+
+# Compress the file.
+gzip /path/to/backup
+
+# Upload the file to S3.
+aws s3 aws s3 cp /path/to/backup.gz s3://mybucket/backup.gz
+```
+
+It's also recommended to perform a rolling backup based on either hour, day or
+month depending on cost requirements.
+
+```sh
+# 1-day, rolling hourly backup
+aws s3 cp /path/to/backup.gz s3://mybucket/backup-`date +%H`.gz
+
+# 1-month, rolling daily backup
+aws s3 cp /path/to/backup.gz s3://mybucket/backup-`date +%d`.gz
+
+# 1-month, rolling hourly backup
+aws s3 cp /path/to/backup.gz s3://mybucket/backup-`date +%d%H`.gz
+```
+
+This backup can be run on any of your nodes as even the replicas should have
+minimal lag behind the primary. If you run this on multiple nodes (such as all
+your candidates), make sure they are backing up to different storage locations
+so they do not overwrite one another.

--- a/litefs/config.html.md.erb
+++ b/litefs/config.html.md.erb
@@ -6,9 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
-
 Most of the configuration options for LiteFS are set via a `litefs.yml` config
 file. You can find a fully-commented version of [`litefs.yml`](https://github.com/superfly/litefs/blob/main/cmd/litefs/etc/litefs.yml)
 in the LiteFS repository.

--- a/litefs/export.html.md.erb
+++ b/litefs/export.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 ## Overview
 
 The `export` command will download a SQLite database from a LiteFS cluster. If 

--- a/litefs/getting-started.html.md.erb
+++ b/litefs/getting-started.html.md.erb
@@ -7,9 +7,6 @@ toc: true
 redirect_from: /docs/litefs/example/
 ---
 
-<%= partial "partials/disclaimer" %>
-
-
 ## Overview
 
 This guide will walk you through the steps of getting a LiteFS cluster up and

--- a/litefs/how-it-works.html.md.erb
+++ b/litefs/how-it-works.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 LiteFS is a distributed file system specifically built for replicating SQLite
 databases. This allows each application node to have a full, local copy of the
 database and respond to requests with minimal latency. LiteFS is built for high

--- a/litefs/import.html.md.erb
+++ b/litefs/import.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 ## Overview
 
 The `import` command will upload a SQLite database to a LiteFS cluster. If the

--- a/litefs/index.html.md.erb
+++ b/litefs/index.html.md.erb
@@ -5,13 +5,20 @@ sitemap: false
 nav: litefs
 ---
 
-<%= partial "partials/disclaimer" %>
-
 LiteFS is a distributed file system that transparently replicates SQLite
 databases. This lets you run your application like it's running against a local
 on-disk SQLite database but behind the scenes the database is replicated to all
 the nodes in your cluster. This lets you run your database right next to your
 application on the edge.
+
+## Project status
+
+LiteFS is stable and running in production environments. The project is still
+pre-1.0 so APIs may change and features could be removed. Please remember that
+all software has bugs so we recommend you [set up regular off-site
+backups][backup] in case of malfunction or disk corruption.
+
+[backup]: /docs/litefs/backup/
 
 
 ## Exploring our guides

--- a/litefs/migrations.html.md.erb
+++ b/litefs/migrations.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 ## Overview
 
 LiteFS is a single-writer system so only the primary node can write to the

--- a/litefs/mount.html.md.erb
+++ b/litefs/mount.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 ## Overview
 
 The `mount` command will mount a LiteFS directory via FUSE and begin communicating

--- a/litefs/partials/_disclaimer.html.md
+++ b/litefs/partials/_disclaimer.html.md
@@ -1,3 +1,0 @@
-<aside class="callout">
-  LiteFS is currently in beta and is not recommended for production use yet.
-</aside>

--- a/litefs/position.html.md.erb
+++ b/litefs/position.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 Each database created in LiteFS maintains a position in their replication log.
 The position is a combination of a monotonically incrementing transaction ID
 (TXID) and a rolling checksum of the database contents.

--- a/litefs/primary.html.md.erb
+++ b/litefs/primary.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 The LiteFS directory (typically `/litefs`) provides a `.primary` file that
 applications can read to determine the current primary node. This file only
 exists if the node is currently a replica _and_ it is connected to the primary

--- a/litefs/proxy.html.md.erb
+++ b/litefs/proxy.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 ## Overview
 
 LiteFS uses a single primary node for writing data and that primary node

--- a/litefs/run.html.md.erb
+++ b/litefs/run.html.md.erb
@@ -6,8 +6,6 @@ nav: litefs
 toc: true
 ---
 
-<%= partial "partials/disclaimer" %>
-
 ## Overview
 
 The `run` command will execute the program listed after the double dash. It

--- a/partials/_litefs_nav.html.erb
+++ b/partials/_litefs_nav.html.erb
@@ -23,6 +23,9 @@
         <%= nav_link "Running database migrations", "/docs/litefs/migrations" %>
       </li>
       <li>
+        <%= nav_link "Backing up your cluster", "/docs/litefs/backup" %>
+      </li>
+      <li>
         <%= nav_link "Determining the primary", "/docs/litefs/primary" %>
       </li>
       <li>


### PR DESCRIPTION
Previously, there was a banner on every page noting that LiteFS was beta and not ready for production. That is probably overly cautious advice at this point. LiteFS is stable and is in production deployments.

Instead, a "project status" section has been added to the home page of the LiteFS docs to note its pre-1.0 status and also recommend that people use a cluster backup strategy. That's good advice for any database, honestly.

/cc @kentcdodds 