### PR TITLE
Fix services.concurrency configuration example

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -308,7 +308,7 @@ The services concurrency sub-section configures how to measure load for an appli
 This section is a simple list of key/values, so the section is denoted with single square brackets like so:
 
 ```toml
-  [services.concurrency]
+  [[services.concurrency]]
     type = "connections"
     hard_limit = 25
     soft_limit = 20


### PR DESCRIPTION
services.concurrency seems to have one pair of brackets.
