### PR TITLE
Add blog to Django docs

### DIFF
--- a/django/index.html.md.erb
+++ b/django/index.html.md.erb
@@ -2,6 +2,7 @@
 title: Django on Fly.io
 layout: framework_docs
 toc: false
+blog_path: /django-beats
 ---
 
 Fly.io is a great place to run your Django application. `fly launch` can detect, configure and deploy Django apps.


### PR DESCRIPTION
Add [Django Beats Blog](https://fly.io/django-beats/) to Django Docs.