### PR TITLE
Remove duplicate references to the canary strategy

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -184,9 +184,7 @@ The available strategies are:
 
 #### For Nomad (Legacy) Apps Only
 
-Legacy Fly Apps orchestrated by Nomad can also be deployed with `canary` or `bluegreen` strategies.
-
-**canary**: The default for apps without persistent volumes. `canary` will boot a single, new VM with the new release, verify its health, then proceed with a `rolling` restart strategy.
+Legacy Fly Apps orchestrated by Nomad can also be deployed with the `bluegreen` strategy.
 
 **bluegreen**: For every running VM, a new one is booted alongside it in the same region. Once all of the new VMs pass health checks, traffic gets migrated to new VMs. If your app is scaled to 2 or more VMs, this strategy can reduce deploy time by running tasks in parallel.
 


### PR DESCRIPTION
Canary is now available in v2, so only bluegreen should be listed as an exception for Nomad.