### PR TITLE
Update Fly Log Shipper Queue documentation

### DIFF
--- a/going-to-production/monitoring/exporting-logs.html.md
+++ b/going-to-production/monitoring/exporting-logs.html.md
@@ -95,3 +95,12 @@ Fly.io ships logs through a [NATS](https://nats.io) stream. This is available to
 The Vector configuration to grab those logs within the Log Shipper is [seen here](https://github.com/superfly/fly-log-shipper/blob/main/vector-configs/vector.toml).
 
 You can contribute to (or, you know, fork) this repository to add providers (sinks) of your own!
+
+## Avoiding Duplicate Log Messages In High Availability Apps
+
+If you would like to run multiple VM's for high availability, the [NATS](https://docs.nats.io/) endpoint supports [subscription queues](https://docs.nats.io/nats-concepts/core-nats/queue) to ensure messages are only sent to one subscriber of the named queue. The `QUEUE` secret can be set to configure an arbitrary queue name if you want to run multiple log processes for HA and avoid duplicate messages being shipped.
+
+```toml
+[env]
+  QUEUE = "org-logs"
+```


### PR DESCRIPTION
Update documentation to show users how to avoid duplicate logs in High Availability apps to avoid confusion

Sources:

https://community.fly.io/t/fly-log-shipper-duplicate-logs-on-apps-v2/13505

https://github.com/superfly/fly-log-shipper