### PR TITLE
Postgres docs: change text about VM RAM to a warning

### DIFF
--- a/postgres/managing/scaling.html.md.erb
+++ b/postgres/managing/scaling.html.md.erb
@@ -9,7 +9,11 @@ order: 50
 
 See [Monitoring](/docs/postgres/managing/monitoring/) for how to check the current sizes of the VMs in your Postgres cluster.
 
-**Before scaling a Postgres VM:** Consider the [Postgres configuration parameters](/docs/postgres/managing/configuration-tuning.html) of your cluster, and adjust the resources accordingly. If you're scaling your VMs up, scale before adjusting the Postgres config to match. If you're scaling down, adjust the cluster's Postgres parameters to match the reduced resources before scaling the VM. **In particular, too high a `shared-buffers` value with too little VM RAM can cause a Postgres VM to fail its health checks.**
+<div class="warning icon">
+**Before scaling a Postgres VM:** Consider the [Postgres configuration parameters](/docs/postgres/managing/configuration-tuning.html) of your cluster, and adjust the resources accordingly. In particular, if the `shared-buffers` value is proportionally too high for the VM RAM, then a Postgres VM might fail its health checks.
+<br><br>
+If you're scaling your VMs up, then scale the VMs first before adjusting the Postgres config to match. If you're scaling down, then adjust the cluster's Postgres parameters to match the reduced resources before scaling the VMs.
+</div>
 
 Scale VM resources for each Machine in the cluster with the [`flyctl machine update`](https://fly.io/docs/flyctl/machine-update/) command. Here's an example of scaling RAM to 1GB on a machine:
 
@@ -25,4 +29,4 @@ If you have more than one instance in the primary region cluster, scale these VM
 
 ## Postgres resource parameters
 
-When you created your Fly Postgres cluster, certain Postgres configuration parameters were set to sensible values for the resources being provisioned. This means you may want, or need, to change them if you scale your VM resources. Read [Configuration Tuning](/docs/postgres/managing/configuration-tuning.html) before scaling down!
+When you created your Fly Postgres cluster, certain Postgres configuration parameters were set to sensible values for the resources being provisioned. This means you may want, or need, to change them if you scale your VM resources. Read [Configuration Tuning](/docs/postgres/managing/configuration-tuning.html) before scaling down.


### PR DESCRIPTION
This PR styles the note about Postgres VM RAM and tuning config parameters into a warning. Also some minor re-wording.