### PR TITLE
Add experimental `exec` override to docs

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -618,3 +618,7 @@ This overrides the `CMD` set by the Dockerfile. It should be specified as an arr
 ### `entrypoint`
 
 This overrides the `ENTRYPOINT` set by the Dockerfile. It should be specified as an array of strings, as seen in the example above.
+
+### `exec`
+
+This overrides the `EXEC` set by the Dockerfile. It should be specified as an array of strings, as seen in the example above.


### PR DESCRIPTION
Adds the `exec` section to the Experimental section of the Configuration docs.

[The other 2 flags used in the code snippet are documented already, but this one is currently missing.]

https://fly.io/docs/reference/configuration/#the-experimental-section

(Previously #828 but accidentally closed it when I deleted my fork.)