### PR TITLE
Clarifying engineering levels vs. company-wide levels

### DIFF
--- a/hiring/company-levels.html.md
+++ b/hiring/company-levels.html.md
@@ -1,0 +1,20 @@
+---
+title: Our Levels
+layout: docs
+sitemap: false
+toc: false
+---
+
+We break out seniority into four levels, L1 to L4 (staff). 
+
+* **L1's** tend to be early-career or people trying out a new specialty. L1's get more management support than folks at other levels. L1's focus on continuously absorbing new information about our users and how to be effective at Fly.io, and aim to be increasingly autonomous as they gain more experience here.
+  
+* **L2's** will generally be responsible for running a project start-to-finish. An L2 is mostly self-directed about implementation, works with L3s on the plan, and collaborates with their manager and other teammates on their project's direction. An L2 has personal responsibility for the "how" of what they're working on, but shares responsibility for the "what" and "why". An L2 makes consistent progress on their work by continuously minimizing scope, incorporating feedback, trying different approaches and solutions, and deciding what will deliver the most value for users.
+  
+* **L3's** have an even-bigger scope. We delegate to L3s entire functional areas and trust them to make smart decisions, not just about how we build things, but about what things to build. L3s are tuned in to our customers and independent sources of authority about their corner of Fly.io. L3s might be hands-on with the day-to-day work of the team, but they're also a resource for their teammates: they're helping L2s figure out what the next best thing to focus on is, and helping L1s figure out the right sequence of work to get a project done.
+  
+* **L4's** are our staff level. An L4 is a leader across multiple different parts of our platform, product, or function. They influence work on lots of teams, not just one. They're independently responsible for making big new things happen; an L3 leads a team, an L4 might create new teams. 
+
+You can go from L1 to L2, or from L2 to L3, etc. In fact, the most important job that managers at Fly.io have is leveling people up. [We prefer small teams and bottom-up product decisions](https://fly.io/docs/hiring/working/#we-prefer-small-teams-and-bottom-up-decisions), which incentivizes us to get people as autonomous as we can.
+
+Going down a level is more problematic, and as a rule of thumb we don't do it. So we're particularly careful about leveling people in the door.

--- a/hiring/working.html.md
+++ b/hiring/working.html.md
@@ -42,7 +42,7 @@ We&#39;re a product for developers, by developers. We have a [thriving community
 ## Leveling
 
 Levels at Fly.io are relatively informal. We're pretty flat, as companies
-go. Small teams, like we just said. Our current engineering leveling looks
+go. Small teams, like we just said. Our current [engineering leveling](/docs/hiring/levels/) looks
 roughly like:
 
 * Level 1: Early-career or intern-level demonstrated aptitude. An L1 might need

--- a/partials/_devjobs_nav.html.erb
+++ b/partials/_devjobs_nav.html.erb
@@ -9,7 +9,7 @@
         <%= nav_link "Our Roles", "/docs/hiring/roles" %>
       </li>
       <li>
-        <%= nav_link "Our Levels", "/docs/hiring/levels" %>
+        <%= nav_link "Our Engineering Levels", "/docs/hiring/levels" %>
       </li>
       <li>
         <%= nav_link "Our Hiring Process", "/docs/hiring/hiring" %>


### PR DESCRIPTION
The https://fly.io/docs/hiring/levels/ page has Engineering-specific language in it, and we hire for more than just engineering roles!

I've added a company levels page (using the same basic language as the Engineering page, just a little more genericized) which we can link to as necessary for outside-of-Engineering roles.

I've also added the word "Engineering" to the sidebar nav link for levels, and a link to those engineering levels from the main hiring page (in case folks want to read more depth).