### PR TITLE
Edits to Getting Started for Fly Launch terminology

### DIFF
--- a/apps/index.html.md.erb
+++ b/apps/index.html.md.erb
@@ -1,12 +1,12 @@
 ---
-title: "Fly Apps"
+title: "Fly Launch"
 layout: docs
 toc: false
 nav: firecracker
 ---
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-In this section we'll talk about how to create and manage a [Fly App](/docs/reference/apps/).
+Learn how to use all the Fly Launch features that help you manage and run your apps.
 
 <ul class="outline-list">
     <li>

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -17,15 +17,8 @@ If you'd rather jump right in, try [Speedrun](/docs/speedrun/) to launch your ow
 
 Once that's done, check out our in-depth docs:
 
-* [Language & Frameworks guides](/docs/languages-and-frameworks/) to learn about how we support your favorite language or framework
-* [Fly Launch](/docs/apps) to use the features that help you manage and run your apps
-* [Databases & Storage](/docs/database-storage-guides/) to understand the persistent storage options
-* [Reference](/docs/reference) to explore the details of how the Fly Platform works
-
-
 * **[Languages & Frameworks Guides](/docs/languages-and-frameworks/)**: comprehensive and starter guides for your favorite languages and frameworks.
 * **[Fly Launch](/docs/apps)**: you've tried the `fly launch` command, now learn how to use all the Fly Launch features that help you manage and run your apps.
-* **[Databases & Storage](/docs/database-storage-guides/)**: options for persistent data storage on the FLy Platform
+* **[Databases & Storage](/docs/database-storage-guides/)**: options for persistent data storage on the FLy Platform.
 * **[Fly Machines](/docs/machines/)**: go deeper with our VMs, and use them to run your projects and tasks.
-* **[Reference](/docs/reference)**: the details of how the Fly Platform works
-
+* **[Reference](/docs/reference)**: the details of how the Fly Platform products and features work.

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -17,8 +17,8 @@ If you'd rather jump right in, try [Speedrun](/docs/speedrun/) to launch your ow
 
 Once that's done, check out our in-depth docs:
 
-* **[Languages & Frameworks Guides](/docs/languages-and-frameworks/)**: comprehensive and starter guides for your favorite languages and frameworks.
-* **[Fly Launch](/docs/apps)**: you've tried the `fly launch` command, now learn how to use all the Fly Launch features that help you manage and run your apps.
-* **[Databases & Storage](/docs/database-storage-guides/)**: options for persistent data storage on the FLy Platform.
-* **[Fly Machines](/docs/machines/)**: go deeper with our VMs, and use them to run your projects and tasks.
-* **[Reference](/docs/reference)**: the details of how the Fly Platform products and features work.
+* **[Language & Framework Guides](/docs/languages-and-frameworks/)**: Comprehensive and starter guides for your favorite languages and frameworks.
+* **[Fly Launch](/docs/apps)**: You've tried the `fly launch` command. Now learn how to use all the Fly Launch features that help you manage and run your apps.
+* **[Databases & Storage](/docs/database-storage-guides/)**: Options for persistent data storage on the Fly Platform
+* **[Fly Machines](/docs/machines/)**: Go deeper with our VMs, and use them to run your projects and tasks.
+* **[Reference](/docs/reference)**: The details of how the Fly Platform works.

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "Getting started"
 layout: docs
 sitemap: false
 nav: firecracker
@@ -11,10 +11,13 @@ nav: firecracker
 
 This section of the Fly.io docs is all about getting you up and running quickly.
 
-If you’re new to Fly.io, our [Hands-on](/docs/hands-on/) will take you through creating an account, installing `flyctl`, the Fly.io command-line tool, and launching a simple demo app.
+Follow [Hands-on](/docs/hands-on/) which takes you through creating an account, installing `flyctl`, the Fly.io command-line tool, and launching a simple demo app.
 
-Once that's done, you can dive straight in and check out our [Language & Frameworks Guides](/docs/languages-and-frameworks/) for a demonstration matching your project.
+If you'd rather jump right in, try [Speedrun] to launch your own app fast.
 
-Or get into the details you'll need to work with Fly Apps through their entire lifecycle in the [Fly Apps](/docs/apps/) section.
+Once that's done, check out our in-depth docs:
 
-We also have some [web-based launchers](https://fly.io/launch/), including [Turboku](https://fly.io/launch/heroku); a way to dip your toes in by cloning a Heroku app to Fly.io. Read about it in the [New Turboku launch post](https://fly.io/blog/new-turboku/).
+* [Language & Frameworks guides](/docs/languages-and-frameworks/) to learn about how we support your langauge or framework
+* [Fly Launch] to learn about the features that help you manage and run your apps on the Fly Platform
+* [Databases & Storage]
+* [Reference]

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -13,11 +13,19 @@ This section of the Fly.io docs is all about getting you up and running quickly.
 
 Follow [Hands-on](/docs/hands-on/) which takes you through creating an account, installing `flyctl`, the Fly.io command-line tool, and launching a simple demo app.
 
-If you'd rather jump right in, try [Speedrun] to launch your own app fast.
+If you'd rather jump right in, try [Speedrun](/docs/speedrun/) to launch your own app fast.
 
 Once that's done, check out our in-depth docs:
 
-* [Language & Frameworks guides](/docs/languages-and-frameworks/) to learn about how we support your langauge or framework
-* [Fly Launch] to learn about the features that help you manage and run your apps on the Fly Platform
-* [Databases & Storage]
-* [Reference]
+* [Language & Frameworks guides](/docs/languages-and-frameworks/) to learn about how we support your favorite language or framework
+* [Fly Launch](/docs/apps) to use the features that help you manage and run your apps
+* [Databases & Storage](/docs/database-storage-guides/) to understand the persistent storage options
+* [Reference](/docs/reference) to explore the details of how the Fly Platform works
+
+
+* **[Languages & Frameworks Guides](/docs/languages-and-frameworks/)**: comprehensive and starter guides for your favorite languages and frameworks.
+* **[Fly Launch](/docs/apps)**: you've tried the `fly launch` command, now learn how to use all the Fly Launch features that help you manage and run your apps.
+* **[Databases & Storage](/docs/database-storage-guides/)**: options for persistent data storage on the FLy Platform
+* **[Fly Machines](/docs/machines/)**: go deeper with our VMs, and use them to run your projects and tasks.
+* **[Reference](/docs/reference)**: the details of how the Fly Platform works
+

--- a/hands-on/index.html.md.erb
+++ b/hands-on/index.html.md.erb
@@ -12,6 +12,6 @@ redirect_from:
   <img src="/static/images/hands-on.webp" srcset="/static/images/hands-on@2x.webp 2x" alt="">
 </figure>
 
-In this work-through you'll use Fly Launch to deploy a simple hellofly app to the Fly Platform. The hellofly app comes from a Docker image, but the first step is installing all the tools you need to work with Fly Launch. Which is one tool: flyctl.
+In this work-through you'll use Fly Launch to deploy a simple "hello fly" app to the Fly Platform. The first step is installing all the tools you need to work with Fly Launch. Which is one tool: flyctl.
 
 [Next: Install flyctl](/docs/hands-on/install-flyctl/)

--- a/hands-on/index.html.md.erb
+++ b/hands-on/index.html.md.erb
@@ -12,6 +12,6 @@ redirect_from:
   <img src="/static/images/hands-on.webp" srcset="/static/images/hands-on@2x.webp 2x" alt="">
 </figure>
 
-In this work-through we're going to deploy an application to Fly.io. In this example, the application will come from a Docker image, but first, we want to install all the tools you need to work with Fly.io. Which is one tool: flyctl.
+In this work-through you'll use Fly Launch to deploy a simple hellofly app to the Fly Platform. The hellofly app comes from a Docker image, but the first step is installing all the tools you need to work with Fly Launch. Which is one tool: flyctl.
 
 [Next: Install flyctl](/docs/hands-on/install-flyctl/)

--- a/hands-on/launch-app.html.md.erb
+++ b/hands-on/launch-app.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Launch an App on Fly
+title: Launch the App
 layout: docs
 sitemap: false
 nav: hands_on
@@ -10,11 +10,13 @@ redirect_from:
 
 ---
 
-Fly.io enables you to deploy almost any kind of app using a Docker image. To learn more about the different ways to get your app ready to deploy, refer to [Launch a New App on Fly.io](/docs/apps/launch/).
+Fly Launch enables you to deploy almost any kind of app using a Docker image. To learn more about the different ways to get your app ready to deploy, refer to [Fly Launch](/docs/apps/launch/).
 
-For this example, you can use our pre-built Docker image, `flyio/hellofly:latest`, to try out creating and deploying an app. 
+For this example, you can use our pre-built Docker image, `flyio/hellofly:latest`, to create and deploy an app. 
 
-Each Fly.io application needs a `fly.toml` file to tell the system how to deploy it. The `fly.toml` file can be automatically generated with the `fly launch` command, which will ask a few questions to set everything up. Let's run through it now:
+Each Fly Launch application uses a `fly.toml` file to tell the system how to deploy it. The `fly.toml` file can be automatically generated with the `fly launch` command, which will ask a few questions to set everything up.
+
+Run:
 
 ```cmd
 fly launch --image flyio/hellofly:latest
@@ -44,19 +46,17 @@ Next, you'll be prompted to select a region to deploy in.
 At this point, flyctl creates a shell of an app for you and writes a starter configuration to a `fly.toml` file. 
 
 <div class="callout">
-
-If you've just signed up, then you'll also be prompted for credit card payment information, which is required for charges outside the free allowances on Fly.io. See [How We Use Credit Cards](/docs/about/credit-cards/) and [Pricing](/docs/about/pricing) for more details.
-
+If you've just signed up, then you'll also be prompted for credit card payment information, which is required for charges outside the free allowances on Fly.io. Refer to [How We Use Credit Cards](/docs/about/credit-cards/) and [Pricing](/docs/about/pricing) for more details.
 </div>
 
-The CLI will ask if you need a Postgres or Redis database. You can enter "No" for this example.
+flyctl will ask if you need a Postgres or Redis database. You can enter "No" for this example.
 
 ```output
 ? Would you like to set up a Postgresql database now? No
 ? Would you like to set up an Upstash Redis database now? No
 ```
 
-Finally, the CLI will ask you if you would like to deploy.
+Finally, flyctl will ask you if you would like to deploy.
 
 <div class="callout">
 If you're deploying an app that doesn't use `internal_port = 8080`, then enter "No", and edit the `fly.toml` file.
@@ -84,7 +84,7 @@ primary_region = "ord"
   ...
 ```
 
-flyctl always checks to see if `fly.toml` exists in the current directory, and then checks the `app` value at the start of the file. Many commands use this app name to determine which Fly App to apply to by default. You can also see how the app will be built (from a pre-built Docker image, in this case), that internal port setting, and further configuration to be applied to the application when it deploys.
+When you run a command, flyctl always checks to see if `fly.toml` exists in the current directory, and then checks the `app` value at the start of the file. Many commands use this app name to determine which Fly App to apply to by default. You can also see how the app will be built (from a pre-built Docker image, in this case), that internal port setting, and further configuration to be applied to the application when it deploys.
 
 If you stopped to customize your `fly.toml`, you'll want to deploy your app now. At the command line, just run:
 
@@ -92,6 +92,6 @@ If you stopped to customize your `fly.toml`, you'll want to deploy your app now.
 fly deploy
 ```
 
-The `fly deploy` command gets the app name `hellofly` from `fly.toml`. Then flyctl will start the process of deploying your application to the Fly.io platform and return you to the command line when it's done.
+The `fly deploy` command gets the app name from the `fly.toml` file. Then flyctl will start the process of deploying your application to the Fly Platform and return you to the command line when it's done.
 
 [Next: Check your app's status](/docs/hands-on/check-app-status/)

--- a/hands-on/launch-app.html.md.erb
+++ b/hands-on/launch-app.html.md.erb
@@ -10,7 +10,7 @@ redirect_from:
 
 ---
 
-Fly Launch enables you to deploy almost any kind of app using a Docker image. To learn more about the different ways to get your app ready to deploy, refer to [Fly Launch](/docs/apps/launch/).
+Fly Launch helps you quickly deploy almost any kind of app using a Docker image. To learn more about the different ways to get your app ready to deploy, refer to [Fly Launch](/docs/apps/launch/).
 
 For this example, you can use our pre-built Docker image, `flyio/hellofly:latest`, to create and deploy an app. 
 
@@ -46,7 +46,7 @@ Next, you'll be prompted to select a region to deploy in.
 At this point, flyctl creates a shell of an app for you and writes a starter configuration to a `fly.toml` file. 
 
 <div class="callout">
-If you've just signed up, then you'll also be prompted for credit card payment information, which is required for charges outside the free allowances on Fly.io. Refer to [How We Use Credit Cards](/docs/about/credit-cards/) and [Pricing](/docs/about/pricing) for more details.
+If you've just signed up, then you'll also be prompted for credit card payment information. Refer to [How We Use Credit Cards](/docs/about/credit-cards/) and [Pricing](/docs/about/pricing) for more details.
 </div>
 
 flyctl will ask if you need a Postgres or Redis database. You can enter "No" for this example.
@@ -84,7 +84,7 @@ primary_region = "ord"
   ...
 ```
 
-When you run a command, flyctl always checks to see if `fly.toml` exists in the current directory, and then checks the `app` value at the start of the file. Many commands use this app name to determine which Fly App to apply to by default. You can also see how the app will be built (from a pre-built Docker image, in this case), that internal port setting, and further configuration to be applied to the application when it deploys.
+When you run a command, flyctl always checks to see if `fly.toml` exists in the current directory, and then checks the `app` value at the start of the file. Many commands use this app name to determine which Fly App to apply to by default. You can also see how the app will be built (from a pre-built Docker image, in this case), that internal port setting, and further configuration to be applied to the app when it deploys.
 
 If you stopped to customize your `fly.toml`, you'll want to deploy your app now. At the command line, just run:
 

--- a/hands-on/next.html.md.erb
+++ b/hands-on/next.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Further Reading, Resources and References
+title: Learn more
 layout: docs
 sitemap: false
 nav: hands_on
@@ -8,41 +8,22 @@ toc: false
 
 What's next? Well, this is only the start of your travels with Fly.io.
 
-## Developers
+* **Languages & Frameworks Guides**: comprehensive and starter guides for your favorite languages and frameworks.
+* **Fly Launch**: you've tried the `fly launch` command, now learn about all the features for your app that come with Fly Launch.
+* **Databases & Storage**: options for persistent data storage on Fly.io.
+* **Fly Machines**: go deeper with our VMs, and use them to run your projects and tasks.
 
-If you're all about the code, then these guides will get you deploying from your source:
+When you are ready to move real traffic to your app, check out the ways you can increase availability, capacity and performance with Fly.io:
 
-* [Learn how to build and deploy the hellofly application from Go source](/docs/languages-and-frameworks/golang/)
-* [Deploy a Rails App with Fly.io](/docs/rails/)
-* [Deploy an Elixir App with Fly.io](/docs/elixir/)
-* [Deploy a Laravel App with Fly.io](/docs/laravel/)
-* [Deploy a Django App with Fly.io](/docs/django/)
-* [Deploy a Deno App with Fly.io](/docs/languages-and-frameworks/deno/)
-* [Deploy a Node App with Fly.io](/docs/languages-and-frameworks/node/)
-* [Deploy a Ruby App with Fly.io](/docs/languages-and-frameworks/ruby/)
-
-Add storage to persist your Fly App's data:
-
-* [Databases & Storage](/docs/database-storage-guides/)
-
-And if you want to automate your deployments (who doesn't), check out:
-
-* [Continuous Deployment with Fly.io and GitHub Actions](/docs/app-guides/continuous-deployment-with-github-actions/)
-
-Make your apps or sites your own with custom domains. This guide will show you the straightforward route to putting your own name on your Fly Apps:
-
-* [Set up Custom Domains for your App](/docs/app-guides/custom-domains-with-fly/)
-
-When you are ready to move traffic to your app, check out the ways you can increase availability, capacity and performance with Fly.io:
-
+* Read up on our [App Availability and Resiliency](/docs/reference/app-availability/) features
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine Count](/docs/apps/scale-count/) 
 * [Autostart and Autostop Machines](/docs/apps/autostart-stop/) in response to traffic
 
-## More to read
-
-Your one-stop reference for everything Fly.io is the [documentation](/docs).
+## Community
 
 Get active on our [Community Forum](https://community.fly.io/) to help and be helped, and be the first to hear about our latest features.
 
-Check out our articles on the [Fly.io Blog](/blog), [Phoenix Files](/phoenix-files), [Ruby Dispatch](/ruby-dispatch), and [Laravel Bytes](/laravel-bytes).
+## Articles
+
+Check out our articles on the [Fly.io Blog](/blog), [Phoenix Files](/phoenix-files), [Ruby Dispatch](/ruby-dispatch), [Laravel Bytes](/laravel-bytes), and [Django Beats](/django-beats/).

--- a/hands-on/next.html.md.erb
+++ b/hands-on/next.html.md.erb
@@ -8,11 +8,11 @@ toc: false
 
 What's next? Well, this is only the start of your travels with Fly.io.
 
-* **[Languages & Frameworks Guides](/docs/languages-and-frameworks/)**: comprehensive and starter guides for your favorite languages and frameworks.
-* **[Fly Launch](/docs/apps)**: you've tried the `fly launch` command, now learn how to use all the Fly Launch features that help you manage and run your apps.
-* **[Databases & Storage](/docs/database-storage-guides/)**: options for persistent data storage on the FLy Platform
-* **[Fly Machines](/docs/machines/)**: go deeper with our VMs, and use them to run your projects and tasks.
-* **[Reference](/docs/reference)**: the details of how the Fly Platform works
+* **[Language & Framework Guides](/docs/languages-and-frameworks/)**: Comprehensive and starter guides for your favorite languages and frameworks.
+* **[Fly Launch](/docs/apps)**: You've tried the `fly launch` command. Now learn how to use all the Fly Launch features that help you manage and run your apps.
+* **[Databases & Storage](/docs/database-storage-guides/)**: Options for persistent data storage on the Fly Platform
+* **[Fly Machines](/docs/machines/)**: Go deeper with our VMs, and use them to run your projects and tasks.
+* **[Reference](/docs/reference)**: The details of how the Fly Platform works.
 
 When you are ready to move real traffic to your app, check out the ways you can increase availability, capacity and performance with Fly.io:
 

--- a/hands-on/next.html.md.erb
+++ b/hands-on/next.html.md.erb
@@ -8,10 +8,11 @@ toc: false
 
 What's next? Well, this is only the start of your travels with Fly.io.
 
-* **Languages & Frameworks Guides**: comprehensive and starter guides for your favorite languages and frameworks.
-* **Fly Launch**: you've tried the `fly launch` command, now learn about all the features for your app that come with Fly Launch.
-* **Databases & Storage**: options for persistent data storage on Fly.io.
-* **Fly Machines**: go deeper with our VMs, and use them to run your projects and tasks.
+* **[Languages & Frameworks Guides](/docs/languages-and-frameworks/)**: comprehensive and starter guides for your favorite languages and frameworks.
+* **[Fly Launch](/docs/apps)**: you've tried the `fly launch` command, now learn how to use all the Fly Launch features that help you manage and run your apps.
+* **[Databases & Storage](/docs/database-storage-guides/)**: options for persistent data storage on the FLy Platform
+* **[Fly Machines](/docs/machines/)**: go deeper with our VMs, and use them to run your projects and tasks.
+* **[Reference](/docs/reference)**: the details of how the Fly Platform works
 
 When you are ready to move real traffic to your app, check out the ways you can increase availability, capacity and performance with Fly.io:
 

--- a/hands-on/open-app.html.md.erb
+++ b/hands-on/open-app.html.md.erb
@@ -7,7 +7,9 @@ toc: false
 redirect_from: /docs/hands-on/connecting-to-an-app/
 ---
 
-The quickest way to connect to your deployed app is with the `fly open` command. This will open a browser on the http version of the site. That will automatically be upgraded to a https secured connection (when using the fly.dev domain) to connect to it securely. Add `/name` to `fly open` and it'll be appended to the apps path and you'll get an extra greeting from the hellofly application.
+The quickest way to connect to your deployed app is with the `fly open` command, which opens a browser on the http version of the site. That http connection will automatically be upgraded to an https secured connection (when using the fly.dev domain) to connect to it securely. 
+
+For fun, add `/<your-name>` to `fly open` and your name will be appended to the app's path to add an extra greeting from the hellofly application.
 
 ```cmd
 fly open /fred
@@ -18,7 +20,6 @@ Opening http://hellofly.fly.dev/fred
 
 <img src="/docs/hands-on/images/helloflyandfred.webp" alt="Hello from Fly Screenshot" class="rounded-xl shadow-lg">
 
-You have successfully deployed and visited your first Fly App.
+You've successfully launched your first Fly App.
 
-
-[Next: Further Reading](/docs/hands-on/next/)
+[Next: Learn more about what you can do with Fly.io](/docs/hands-on/next/)

--- a/index.html.md
+++ b/index.html.md
@@ -1,35 +1,36 @@
 ---
-title: "Fly.io Docs"
+title: "Fly.io developer documentation"
 layout: docs
 sitemap: false
 nav: firecracker
 ---
 
-<figure>
-  <img src="/static/images/docs-intro.webp" srcset="/static/images/docs-intro@2x.webp 2x" alt="">
-</figure>
-
+Deploy your project in a few minutes with [Fly Launch](/docs/apps/). Then do more with [Fly Machines](/docs/machines/).
 
 ## Run your entire stack near your users
 
-Deploy your project in a few minutes on the [Fly Apps](/docs/apps/) Platform. Manage your worker [processes](/docs/apps/processes/) alongside your web server. Back it with a [Fly Postgres](/docs/postgres/) app, or bring your own exotic database. Whatever supporting infrastructure you need! It's all just VMs. 
+Deploy in any [region](/docs/reference/regions/). Manage your worker [processes](/docs/apps/processes/) alongside your web server. Back it with a [Fly Postgres](/docs/postgres/) app, or bring your own exotic database. Whatever supporting infrastructure you need! It's all just VMs.
 
 [Try our Speedrun](/docs/speedrun/)
 
-[Learn more about Fly Apps](/docs/apps/)
+[Learn more about Fly Launch](/docs/apps/)
 
-## Grow at your own pace
+## Scale at your own pace
 
 [flyctl](/docs/flyctl/) helps you herd VMs, but puts the power in your hands.
 
 Scale locally, or put your app next to your users in ten more cities. Either way, it's [one command](/docs/apps/scale-count/). Add CPU oomph or RAM, again with [one command](/docs/apps/scale-machine/). Pay for what you use, and have your VMs stop when they're idle, so you don't use more than you need. 
 
-## Color outside the lines
+<figure>
+  <img src="/static/images/docs-intro.webp" srcset="/static/images/docs-intro@2x.webp 2x" alt="">
+</figure>
 
-The Fly Apps platform-as-a-service is there to make your apps easy to launch and manage. When you outgrow its opinions, micromanage your app VMs with `fly machines` commands, or drop down a level of abstraction to the [Machines](/docs/machines/working-with-machines/) API. Launch [tiny, fast-booting VMs](/docs/machines/) from your app! The perfect way to run user code, or try that sketchy Typescript snippet ChatGPT suggested.
+## Control individual VMs 
+
+The Fly Launch platform-as-a-service is there to make your apps easy to launch and manage. When you outgrow its opinions, micromanage your app VMs with `fly machines` commands, or drop down a level of abstraction to the [Machines](/docs/machines/working-with-machines/) API. Launch [tiny, fast-booting VMs](/docs/machines/) from your app! The perfect way to run user code, or try that sketchy Typescript snippet ChatGPT suggested.
 
 [Learn more about Fly Machines](/docs/machines/)
 
-## Draw your own lines
+## Build your own cloud
 
 Go ahead and build your own cloud on top of Fly Machines! Did we mention it's all just VMs? Fly.io features don't care what shape your project takes. A powerful CLI, remote Docker builds, private networking, persistent storage, logging, metrics, secrets management, load balancing, certs, autoscaling, dynamic request routing...it's all available, whatever scale and complexity you're working with.

--- a/index.html.md
+++ b/index.html.md
@@ -25,7 +25,7 @@ Scale locally, or put your app next to your users in ten more cities. Either way
   <img src="/static/images/docs-intro.webp" srcset="/static/images/docs-intro@2x.webp 2x" alt="">
 </figure>
 
-## Control individual VMs 
+## Control individual VMs
 
 The Fly Launch platform-as-a-service is there to make your apps easy to launch and manage. When you outgrow its opinions, micromanage your app VMs with `fly machines` commands, or drop down a level of abstraction to the [Machines](/docs/machines/working-with-machines/) API. Launch [tiny, fast-booting VMs](/docs/machines/) from your app! The perfect way to run user code, or try that sketchy Typescript snippet ChatGPT suggested.
 

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -47,7 +47,7 @@
 </ul>
 <ul class="outline-list">
   <li>
-    <%= nav_link "Fly Apps", "/docs/apps/" %>
+    <%= nav_link "Fly Launch", "/docs/apps/" %>
     <ul role="region" aria-label="Fly Apps">
       <li>
         <%= nav_link "Launch a New App", "/docs/apps/launch/" %>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -3,7 +3,7 @@
     <%= nav_link "Getting Started", "/docs/getting-started" %>
     <ul role="region" aria-label="Getting Started">
       <li>
-        <%= nav_link "Speedrun: Deploying an App", "/docs/speedrun/" %>
+        <%= nav_link "Speedrun: Launch on Fly.io", "/docs/speedrun/" %>
       </li>
       <li>
         <%= nav_link "Hands-on with Fly.io", "/docs/hands-on/" %>

--- a/partials/_hands_on_nav.html.erb
+++ b/partials/_hands_on_nav.html.erb
@@ -6,22 +6,22 @@
         <%= nav_link "1. Install flyctl", "/docs/hands-on/install-flyctl/" %>
       </li>
       <li>
-        <%= nav_link "2. Sign Up", "/docs/hands-on/sign-up/" %>
+        <%= nav_link "2. Sign up", "/docs/hands-on/sign-up/" %>
       </li>
       <li>
-        <%= nav_link "3. Sign In", "/docs/hands-on/sign-in/" %>
+        <%= nav_link "3. Sign in", "/docs/hands-on/sign-in/" %>
       </li>
       <li>
-        <%= nav_link "4. Launch App", "/docs/hands-on/launch-app/" %>
+        <%= nav_link "4. Launch app", "/docs/hands-on/launch-app/" %>
       </li>
       <li>
-        <%= nav_link "5. Check App Status", "/docs/hands-on/check-app-status/" %>
+        <%= nav_link "5. Check app status", "/docs/hands-on/check-app-status/" %>
       </li>
       <li>
-        <%= nav_link "6. Visit App", "/docs/hands-on/open-app/" %>
+        <%= nav_link "6. Visit app", "/docs/hands-on/open-app/" %>
       </li>
       <li>
-        <%= nav_link "7. Further Reading", "/docs/hands-on/next/" %>
+        <%= nav_link "7. Learn more", "/docs/hands-on/next/" %>
       </li>
     </ul>
   </li>

--- a/speedrun.html.md.erb
+++ b/speedrun.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Speedrun! Deploying to Fly.io!
+title: "Speedrun: Launch on Fly.io"
 layout: docs
 sitemap: false
 nav: firecracker
@@ -24,7 +24,7 @@ For many languages and frameworks, you can deploy your app from zero, with the f
 
 You're not limited to these kinds of projects, though! `fly launch` also knows what to do [with a Dockerfile](/docs/languages-and-frameworks/dockerfile/), so you can use the tech _you_ love.
 
-See [Fly Launch](/docs/reference/fly-launch/) for more on what `fly launch` does.
+Refer to [Launch a new app](/docs/reference/fly-launch/) to learn more about what `fly launch` does.
 
 ## Next steps
 
@@ -32,7 +32,7 @@ See [Fly Launch](/docs/reference/fly-launch/) for more on what `fly launch` does
 2. Run `fly open` - open your browser and direct it to your app.
 
 
-If things don't go as smoothly as you'd like, visit our [community forum](https://community.fly.io) and get help!
+If things don't go as smoothly as you'd like, visit our [community forum](https://community.fly.io) and get help.
 
 Would you like to know more?
 

--- a/speedrun.html.md.erb
+++ b/speedrun.html.md.erb
@@ -24,7 +24,7 @@ For many languages and frameworks, you can deploy your app from zero, with the f
 
 You're not limited to these kinds of projects, though! `fly launch` also knows what to do [with a Dockerfile](/docs/languages-and-frameworks/dockerfile/), so you can use the tech _you_ love.
 
-Refer to [Launch a new app](/docs/reference/fly-launch/) to learn more about what `fly launch` does.
+Refer to [Launch a new app](/docs/apps/launch/) to learn more about what `fly launch` does.
 
 ## Next steps
 


### PR DESCRIPTION
This PR:
Updates mainly two of the Gettting started sections to use Fly Launch, plus some other minor edits:
- Speedrun
- Hands-on

Updates the main Docs index page.
- some changes are just style
- but also to put this sentence at the top of the page: "Deploy your project in a few minutes with [Fly Launch](http://127.0.0.1:4567/docs/apps/). Then do more with [Fly Machines](http://127.0.0.1:4567/docs/machines/)."

Updates the title of "Fly Apps" section in Nav and the index page to "Fly Launch".

## Preview links (not up-to-date)
Links to changed pages:
https://aa-docs.fly.dev/docs/
https://aa-docs.fly.dev/docs/getting-started/
https://aa-docs.fly.dev/docs/speedrun/
https://aa-docs.fly.dev/docs/hands-on/ (and some sub-pages)
