### PR TITLE
Mention platform region command when creating a volume

### DIFF
--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -137,7 +137,7 @@ destination="/data"
 
 ### Create the volume
 
-Create the volume (or volumes) in the same region as your app.
+Create the volume (or volumes) in the same region as your app. Use `fly platform regions` to see a list of available regions.
 
 ```cmd
 fly volumes create myapp_data -r lhr

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -54,7 +54,7 @@ This section is a reference for working with volumes using the [`fly volumes`](/
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
-The following example command creates a new volume named "myapp_data" with 1GB of storage in the yyz (Toronto) region, for the application whose `fly.toml` file is in the working directory. To specify a different app, use the `-a` or `--app` flag.
+The following example command creates a new volume named "myapp_data" with 1GB of storage in the yyz (Toronto) region, for the application whose `fly.toml` file is in the working directory. To see a list of regions, use `fly platform regions`. To specify a different app, use the `-a` or `--app` flag.
 
 ```cmd
 fly volumes create myapp_data --region yyz --size 1


### PR DESCRIPTION
When creating a volume, the docs mention the region option (e.g. `fly volumes create myapp_data -r lhr`) multiple times. Although the region option can be found on the [volumes-create page](https://fly.io/docs/flyctl/volumes-create/), this change makes it easier for users to quickly look up their nearest region and associated region code name by mentioning the `fly platform regions` command up front.