### PR TITLE
Edit for number of machines on deploy

### DIFF
--- a/apps/deploy.html.md.erb
+++ b/apps/deploy.html.md.erb
@@ -17,9 +17,9 @@ fly deploy
 
 from the root directory of your project, where any app source code, project config, `fly.toml`, and Dockerfile are located.
 
-If you haven't deployed the app before, `fly deploy` will create one Machine for every [process group](/docs/apps/processes/) defined in the app's configuration. If you haven't explicitly defined any process groups, the first deployment gives you one Machine.
+If you haven't deployed the app before, `fly deploy` creates one or two Machines for every [process group](/docs/apps/processes/) defined in the app's `fly.toml` file, depending on whether there are services and volumes configured. If you haven't explicitly defined any process groups, the first deployment gives you two Machines. For more information about when Fly Launch creates one Machines or two Machines for redundancy, refer to [Redundancy by default on first deploy](/docs/reference/app-availability/#redundancy-by-default-on-first-deploy).
 
-Subsequent deployments update the app's Machines as a group, with the latest local changes to the app's source and configuration. It is possible for a Fly App to have Machines that aren't managed by `fly deploy`.
+Subsequent deployments update the app's Machines as a group, with the latest local changes to the app's source and configuration. It's possible for a Fly App to have standalone Machines that aren't managed by `fly deploy`.
 
 
 ## Configuration
@@ -43,17 +43,17 @@ Here's how `fly deploy` determines how to get the app's Docker image:
 
 If the app to be deployed is configured with an eligible HTTP `[[services]]` section, and it does not yet have [public IP addresses](/docs/reference/services/), `fly deploy` provisions a public IPv6 and a shared public IPv4 Anycast address. 
 
-## Machines not managed by `fly deploy`
+## Standalone Machines that don't belong to Fly Launch
 
-Machines created using `fly deploy` (or as part of a deployment during `fly launch`), or by `fly clone`ing such a Machine, carry a piece of metadata marking them as belonging to the Fly Apps V2 platform. These machines are updated as a group on all subsequent `fly deploy` commands, as are Machines that existed on a Machines App at the moment that it was migrated to Apps V2.
+Machines created using `fly launch` or `fly deploy`, or by `fly clone`ing such a Machine, carry a piece of metadata marking them as belonging to Fly Launch. These machines are updated as a group on all subsequent `fly deploy` commands, as are Machines that existed on a Machines App at the moment that it was migrated to Apps V2.
 
-New Machines created within an App using `fly machine run` don't have the Apps V2 metadata, and are not automatically managed by `fly deploy`, so these can have their own configuration different from that of the App, and can even be based on a different Docker image.
+New Machines created within an App using `fly machine run` don't have the Apps V2 metadata, and are not automatically managed by `fly deploy`, so these Machines can have their own configuration different from that of the App, and can even be based on a different Docker image.
 
 ## Volume mounts and `fly deploy`
 
 If a Machine has a mounted [volume](/docs/reference/volumes/), `fly deploy` can't be used to mount a different one. You can change the mount point at which the volume's data is available in the Machine's file system, though. This is configured in the [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) of `fly.toml`.
 
-[More about using Fly Volumes with Fly Apps](/docs/apps/volume-storage/)
+Learn more about [using Fly Volumes with Fly Apps](/docs/apps/volume-storage/).
 
 ## `fly deploy` configuration in `fly.toml`
 


### PR DESCRIPTION
Must have missed this one when updating for redundant Machine creation on deploy. This PR updates the doc and adds links for more info. Also other minor updates/edits.