### PR TITLE
Add docs/litefs/getting-started/ redirect

### DIFF
--- a/litefs/getting-started-fly.html.md.erb
+++ b/litefs/getting-started-fly.html.md.erb
@@ -4,7 +4,9 @@ layout: docs
 sitemap: false
 nav: litefs
 toc: true
-redirect_from: /docs/litefs/example/
+redirect_from:
+  - /docs/litefs/example/
+  - /docs/litefs/getting-started/
 ---
 
 ## Overview


### PR DESCRIPTION
We removed `/docs/litefs/getting-started/` because it split into fly/docker getting started guides. This will redirect the old URL to the Fly getting started doc. 