### PR TITLE
Fixed link to Litefs Cloud in Cloud Backup section

### DIFF
--- a/litefs/cloud-backups.html.md.erb
+++ b/litefs/cloud-backups.html.md.erb
@@ -79,4 +79,4 @@ systemctl restart litefs
 
 Remember that this needs to be run for every LiteFS node.
 
-[LiteFS Cloud Dashboard]: https://fly.io/dashboard/personal/litefs-cloud
+[LiteFS Cloud Dashboard]: https://fly.io/dashboard/personal/litefs


### PR DESCRIPTION
The link in the docs failed. I updated with new url