### PR TITLE
Adjust some docs for removal of maa region

### DIFF
--- a/reference/load-balancing.html.md
+++ b/reference/load-balancing.html.md
@@ -51,7 +51,7 @@ We set `type = "requests"` so Fly.io will use concurrent http requests to determ
 
 We choose to set our `soft_limit` to 20, so we have a little room for Fly.io to shift load to other instances before a single instance becomes overwhelmed.
 
-We deployed 10 VMs in four regions: `ams`, `maa`, `sea`, and `sin`, with three of those in `ams`.
+We deployed 10 VMs in four regions: `ams`, `bom`, `sea`, and `sin`, with three of those in `ams`.
 
 In this contrived example, all of the users are currently in Amsterdam (ams region) so their traffic is arriving at one of the Fly.io edges in Amsterdam. There are currently 3 instances of our web service running in Amsterdam.
 

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -191,11 +191,11 @@ To restore from the snapshot to a new volume, use `fly volumes create <volume-na
 fly volumes create pg_data --snapshot-id vs_0Gvz2kBKJ28Mph4y -a cat-pg
 ```
 ```out
-? Select region: Chennai (Madras), India (maa)
+? Select region: Sydney, Australia (syd)
         ID: vol_mjn924o9l3q403lq
       Name: pg_data
        App: cat-pg
-    Region: maa
+    Region: syd
       Zone: 180d
    Size GB: 3
  Encrypted: true


### PR DESCRIPTION
This PR makes some minor changes to docs to remove the `maa` region from examples. More changes might be needed when flyctl updates.