### PR TITLE
Make the term "health check" consistent

### DIFF
--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -174,7 +174,7 @@ The only required parameter is `image` in the `config` object. Other parameters:
       + `type`: `tcp` or `http`
       + `port`: The port to connect to, likely should be the same as `internal_port`
       + `interval`: The time between connectivity checks
-      + `timeout`: The maximum time a connection can take before being reported as failing its healthcheck
+      + `timeout`: The maximum time a connection can take before being reported as failing its health check
       + `method`: For http checks, the HTTP method to use to when making the request
       + `path`: For http checks, the path to send the request to
       + `protocol`: For http checks, whether to use `http` or `https`

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -264,7 +264,7 @@ In the following example, `Example-Header` will be removed from the final respon
 
 ### `http_service.checks`
 
-To configure healthchecks for your http service, you can use the `http_service.checks` section. These checks expect a successful HTTP status in response (i.e, 2xx). Here is an example of a `http_service.checks` section:
+To configure health checks for your http service, you can use the `http_service.checks` section. These checks expect a successful HTTP status in response (i.e, 2xx). Here is an example of a `http_service.checks` section:
 
 ```toml
 [[http_service.checks]]
@@ -281,7 +281,7 @@ Times are in milliseconds unless units are specified.
 
 * `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your app to start up. For example, if your app takes 2 seconds to start up, give it some runway by setting `grace_period` to at least 3 seconds.
 * `interval`: The time between connectivity checks. There should be a balance between the interval and the grace period. If it's long and your grace_period shorter than your app's startup time, health check will take too long adding you your deployment time.
-* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `timeout`: The maximum time a connection can take before being reported as failing its health check.
 * `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive HTTP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed HTTP health checks.
 * `method`: The HTTP method to be used for the check.
 * `path`: The path of the URL to be requested.
@@ -444,7 +444,7 @@ Times are in milliseconds unless units are specified.
 * `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your application to start up. For example if your app takes 2 seconds to start up, give it some runway by setting this to at least 3 seconds.
 * `interval`: The time between connectivity checks. If the interval is long, and the `grace_period` is shorter than your app's startup time, then the health check will take longer and will add to your deployment time.
 * `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive TCP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed TCP health checks.
-* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `timeout`: The maximum time a connection can take before being reported as failing its health check.
 
 ### `services.http_checks`
 
@@ -469,7 +469,7 @@ Times are in milliseconds unless units are specified.
 
 * `grace_period`: The time to wait after a VM starts before checking its health. Make sure this is long enough for your app to start up. For example, if your app takes 2 seconds to start up, give it some runway by setting `grace_period` to at least 3 seconds.
 * `interval`: The time between connectivity checks. There should be a balance between the interval and the grace period. If it's long and your grace_period shorter than your app's startup time, health check will take too long adding you your deployment time.
-* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `timeout`: The maximum time a connection can take before being reported as failing its health check.
 * `restart_limit`: Only applicable to V1 (Nomad) apps. The number of consecutive HTTP check failures to allow before attempting to restart the VM. The default is `0`, which disables restarts based on failed HTTP health checks.
 * `method`: The HTTP method to be used for the check.
 * `path`: The path of the URL to be requested.
@@ -545,7 +545,7 @@ For http checks only:
 
 * `method`: The HTTP method to be used for the check.
 * `path`: The path of the URL to be requested.
-* `timeout`: The maximum time a connection can take before being reported as failing its healthcheck.
+* `timeout`: The maximum time a connection can take before being reported as failing its health check.
 * `headers`: Specify key/value pairs will get passed as HTTP headers on the check request.
 
 Again, times are in milliseconds unless units are specified.


### PR DESCRIPTION
This PR just replaces occurrences of "healthcheck" with "health check" for consistency.