### PR TITLE
Machines API and docs: replace example app name

### DIFF
--- a/machines/guides-examples/functions-with-machines.html.md.erb
+++ b/machines/guides-examples/functions-with-machines.html.md.erb
@@ -38,10 +38,10 @@ Pick a unique name and create the required application to group machines togethe
 
 Note the `network` field. This is necessary to isolate the app from other private networks on the organization.
 
-Allocate an IP address to the app. This makes our app accessible at the IP, and via `user-functions.fly.dev`.
+Allocate an IP address to the app. This makes our app accessible at the IP, and via `my-app-name.fly.dev`.
 
 ```cmd
-fly ips allocate-v4 -a user-functions
+fly ips allocate-v4 -a my-app-name
 ```
 
 ## Launch a new machine
@@ -54,7 +54,7 @@ Machines are permanent, so keep the ID from the response handy.
 
 Your users' service will boot immediately after this API call. Launch speed is a function of image size. Tiny images should boot in less than 2 seconds. Large, complex images are much slower to boot.
 
-Try accessing your new machine at `https://user-functions.fly.dev`. If no requests arrive within 120 seconds ([default](https://github.com/fly-apps/fastify-functions/blob/0f4ef94451/start.sh#L3) but configurable), the machine will exit, but a request will force it to start back up automatically.
+Try accessing your new machine at `https://my-app-name.fly.dev`. If no requests arrive within 120 seconds ([default](https://github.com/fly-apps/fastify-functions/blob/0f4ef94451/start.sh#L3) but configurable), the machine will exit, but a request will force it to start back up automatically.
 
 ## Launch a Machine in another region
 
@@ -84,17 +84,17 @@ Start operations clear filesystem changes. The user process comes up with a fres
 
 ## Get details about the deployment
 
-Now we have a couple machines running, we can use `fly logs -a user-functions` to see what's going on. Also, for an overview:
+Now we have a couple machines running, we can use `fly logs -a my-app-name` to see what's going on. Also, for an overview:
 
 ```cmd
-fly status -a user-functions
+fly status -a my-app-name
 ```
 
 ```out
 App
-  Name     = user-functions
+  Name     = my-app-name
   Owner    = personal
-  Hostname = user-functions.fly.dev
+  Hostname = my-app-name.fly.dev
 
 Machines
 ID            	NAME          	REGION	STATE    	CREATED
@@ -131,7 +131,7 @@ fly ssh console '[fdaa:0:6787:a7b:a15f:1a8c:2c01:2]'
 Or you can select a machine to connect to from a list using `fly ssh console -s`:
 
 ```cmd
-fly ssh console -a user-functions -s
+fly ssh console -a my-app-name -s
 ? Select instance:  [Use arrows to move, type to filter]
 > sjc (fdaa:0:6787:a7b:a15f:ee6a:3882:2)
   sjc (fdaa:0:6787:a7b:a15f:c306:4566:2)

--- a/machines/guides-examples/machine-sizing.html.md.erb
+++ b/machines/guides-examples/machine-sizing.html.md.erb
@@ -33,7 +33,7 @@ Here's what that looks like to launch a `performance-2x` machine (2 CPU, 4gb mem
 curl -i -X POST \
   -H "Authorization: Bearer ${FLY_API_TOKEN}" \
   -H "Content-Type: application/json" \
-  "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines" \
+  "http://${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines" \
   -d '{
   "name": "savvy-machine",
   "config": {
@@ -47,7 +47,7 @@ If you're using `flyctl`, the equivalent command looks like this:
 
 ```bash
 fly machine run \
-    -a user-functions \
+    -a my-app-name \
     --name savvy-machine \
     --size performance-2x \
     some-savvy-image
@@ -63,7 +63,7 @@ Here we create a machine with a 2 CPUs but double the RAM you'd get if using siz
 curl -i -X POST \
   -H "Authorization: Bearer ${FLY_API_TOKEN}" \
   -H "Content-Type: application/json" \
-  "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines" \
+  "http://${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines" \
   -d '{
   "name": "savvy-machine",
   "config": {
@@ -83,7 +83,7 @@ If you're using `flyctl`, the equivalent command looks like this:
 
 ```bash
 fly machine run \
-    -a user-functions \
+    -a my-app-name \
     --name savvy-machine \
     --cpus 2 \
     --memory 1024 \
@@ -104,7 +104,7 @@ If we create a machine with the same command as above (using 1024m memory), but 
 curl -i -X POST \
   -H "Authorization: Bearer ${FLY_API_TOKEN}" \
   -H "Content-Type: application/json" \
-  "http://${FLY_API_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \
+  "http://${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589" \
   -d '{
   "config": {
     "image": "some-savvy-image",
@@ -121,7 +121,7 @@ If you're using `flyctl`, the equivalent command looks like this:
 
 ```bash
 fly machine update \
-    -a user-functions \
+    -a my-app-name \
     -i some-savvy-image \
     --cpus 2 \
     --memory 512 \

--- a/machines/working-with-machines.html.md.erb
+++ b/machines/working-with-machines.html.md.erb
@@ -66,7 +66,7 @@ A convenient way to set the `FLY_API_HOSTNAME` is to add it to your `Dockerfile`
 ENV FLY_API_HOSTNAME="https://api.machines.dev"
 ```
 
-<section class="warning">The cURL examples in this document are for an app named `user-functions`. Replace `user-functions` with the name of your own app! Also replace any Machine IDs with those of Machines that belong to your app.
+<section class="warning">The cURL examples in this document are for an app named `my-app-name`. Replace `my-app-name` with the name of your app. Also replace any example Machine IDs with your app's Machine IDs.
 </section>
 
 ### Authentication
@@ -91,14 +91,14 @@ this is done using `flyctl` or the [Fly.io GraphQL API](https://api.fly.io/graph
 Example:
 
 ```cmd
-fly ips allocate-v4 -a user-functions
+fly ips allocate-v4 -a my-app-name
 ```
 ```out
 TYPE ADDRESS    REGION CREATED AT
 v4   37.16.9.52 global 7s ago
 ```
 
-The app will answer on this IP address, and after a small delay, at `user-functions.fly.dev`.
+The app will answer on this IP address, and after a small delay, at `my-app-name.fly.dev`.
 
 ### Get application details
 
@@ -110,7 +110,7 @@ Get details about an application, like its organization slug and name. Also, to 
 
 For sensitive environment variables, such as credentials, you can set [secrets](https://fly.io/docs/reference/secrets/) as you would for standard Fly Apps using `flyctl`:
 
-<%= partial "/docs/partials/set_secrets", locals: { app_name: "user-functions" } %>
+<%= partial "/docs/partials/set_secrets", locals: { app_name: "my-app-name" } %>
 
 Machines inherit secrets from the app. Existing Machines must be [updated](#update-a-machine) to pick up secrets set after the Machine was created.
 
@@ -203,7 +203,7 @@ An example of two checks:
         }
 ```
 
-Example create Machine request and response on app `user-functions`:
+Example create Machine request and response on app `my-app-name`:
 
 <%= partial "/docs/reference/machines/launch_req" %>
 <%= partial "/docs/reference/machines/launch_resp" %>
@@ -293,7 +293,7 @@ For example, if 3 out of 6 Machines have service configurations set to listen on
 
 Machines can be reached within the private network by hostname, in the format `<id>.vm.<app-name>.internal`. 
 
-So, to reach a Machine with ID `3d8d413b29d089` on an app called `user-functions`, use hostname `3d8d413b29d089.vm.user-functions.internal`.
+So, to reach a Machine with ID `3d8d413b29d089` on an app called `my-app-name`, use hostname `3d8d413b29d089.vm.my-app-name.internal`.
 
 ## Machine states
 

--- a/reference/machines.html.md.erb
+++ b/reference/machines.html.md.erb
@@ -95,14 +95,14 @@ this is done using `flyctl` or the [Fly GraphQL API](https://api.fly.io/graphql)
 Example:
 
 ```cmd
-flyctl ips allocate-v4 -a user-functions
+flyctl ips allocate-v4 -a my-app-name
 ```
 ```out
 TYPE ADDRESS    REGION CREATED AT
 v4   37.16.9.52 global 7s ago
 ```
 
-The app will answer on this IP address, and after a small delay, at `user-functions.fly.dev`.
+The app will answer on this IP address, and after a small delay, at `my-app-name.fly.dev`.
 
 ### Get application details
 
@@ -114,7 +114,7 @@ Get details about an application, like its organization slug and name. Also, to 
 
 For sensitive environment variables, such as credentials, you can set [secrets](https://fly.io/docs/reference/secrets/) as you would for standard Fly apps using `flyctl`:
 
-<%= partial "docs/partials/set_secrets", locals: { app_name: "user-functions" } %>
+<%= partial "docs/partials/set_secrets", locals: { app_name: "my-app-name" } %>
 
 Machines inherit secrets from the app. Existing machines must be [updated](#update-a-machine) to pick up secrets set after the machine was created.
 

--- a/reference/machines/create_app.html.md
+++ b/reference/machines/create_app.html.md
@@ -3,9 +3,9 @@ curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
     "${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
-      "app\_name": "user-functions",
+      "app\_name": "my-app-name",
       "org\_slug": "personal",
-      "network": "user-functions-network"
+      "network": "my-app-name-network"
     }'
 
 ```

--- a/reference/machines/create_app_req.html.md
+++ b/reference/machines/create_app_req.html.md
@@ -3,7 +3,7 @@ curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
     "${FLY\_API\_HOSTNAME}/v1/apps" \\
   -d '{
-      "app\_name": "user-functions",
+      "app\_name": "my-app-name",
       "org\_slug": "personal"
     }'
 

--- a/reference/machines/delete.html.md
+++ b/reference/machines/delete.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/delete_app.html.md
+++ b/reference/machines/delete_app.html.md
@@ -1,12 +1,12 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name" 
 
 ```
 **Status: 404**
 ```json
 {
-  "error": "Could not find App \"user-functions\""
+  "error": "Could not find App \"my-app-name\""
 }
 ```

--- a/reference/machines/delete_app_req.html.md
+++ b/reference/machines/delete_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name" 
 
 ```
 **Status: 202**

--- a/reference/machines/delete_req.html.md
+++ b/reference/machines/delete_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/24d896dec64879" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/24d896dec64879" 
 ```
 
 Optionally append `?force=true` to the URI to kill a running machine.

--- a/reference/machines/get.html.md
+++ b/reference/machines/get.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/d5683210c7968e" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app.html.md
+++ b/reference/machines/get_app.html.md
@@ -1,13 +1,13 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name" 
 
 ```
 **Status: 200**
 ```json
 {
-  "name": "user-functions",
+  "name": "my-app-name",
   "organization": {
     "name": "My Org",
     "slug": "personal"

--- a/reference/machines/get_app_req.html.md
+++ b/reference/machines/get_app_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name" 
 
 ```
 **Status: 200**

--- a/reference/machines/get_app_resp.html.md
+++ b/reference/machines/get_app_resp.html.md
@@ -1,7 +1,7 @@
 
 ```json
 {
-  "name": "user-functions",
+  "name": "my-app-name",
   "organization": {
     "name": "My Org",
     "slug": "personal"

--- a/reference/machines/get_req.html.md
+++ b/reference/machines/get_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589" 
 
 ```
 **Status: 200**

--- a/reference/machines/launch.html.md
+++ b/reference/machines/launch.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch_req.html.md
+++ b/reference/machines/launch_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines" \\
   -d '{
       "name": "quirky-machine",
       "config": {

--- a/reference/machines/launch_syd_req.html.md
+++ b/reference/machines/launch_syd_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines" \\
   -d '{
       "name": "machine-syd",
       "config": {

--- a/reference/machines/lease.html.md
+++ b/reference/machines/lease.html.md
@@ -3,11 +3,11 @@ Add the `fly-machine-lease-nonce` header to all subsequent API calls.
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/stop"
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/3d8d413b29d089/stop"
 ```
 #### Release the lease
 ```
 curl -i -X DELETE \
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/3d8d413b29d089/lease" 
 ```

--- a/reference/machines/lease_req.html.md
+++ b/reference/machines/lease_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/3d8d413b29d089/lease" \
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/3d8d413b29d089/lease" \
     -d '{
         "ttl": 500
     }'

--- a/reference/machines/list.html.md
+++ b/reference/machines/list.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/list_req.html.md
+++ b/reference/machines/list_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines" 
 
 ```
 **Status: 200**

--- a/reference/machines/start.html.md
+++ b/reference/machines/start.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/start" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/d5683210c7968e/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/start_req.html.md
+++ b/reference/machines/start_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/start" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589/start" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop.html.md
+++ b/reference/machines/stop.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/stop" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/d5683210c7968e/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/stop_req.html.md
+++ b/reference/machines/stop_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/stop" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589/stop" 
 
 ```
 **Status: 200**

--- a/reference/machines/update.html.md
+++ b/reference/machines/update.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/d5683210c7968e" \\
   -d '{
       "region": "ord",
       "config": {

--- a/reference/machines/update_req.html.md
+++ b/reference/machines/update_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X POST \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589" \\
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589" \\
   -d '{
       "config": {
         "image": "flyio/fastify-functions",

--- a/reference/machines/wait.html.md
+++ b/reference/machines/wait.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/d5683210c7968e/wait" 
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/d5683210c7968e/wait" 
 
 ```
 **Status: 200**

--- a/reference/machines/wait_req.html.md
+++ b/reference/machines/wait_req.html.md
@@ -1,7 +1,7 @@
 ```
 curl -i -X GET \\
     -H "Authorization: Bearer ${FLY\_API\_TOKEN}" -H "Content-Type: application/json" \\
-    "${FLY\_API\_HOSTNAME}/v1/apps/user-functions/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
+    "${FLY\_API\_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589/wait?instance_id=01GXPEEEOF95AYV5J1HYLGZ8P1&state=stopped"
 
 ```
 **Status: 200**


### PR DESCRIPTION
This PR replaces the `user-functions` example app name with `my-app-name` to make it obvious where the app name goes in a request. The examples are used in multiple places and users might enter the docs in the middle, so changing the name should help avoid confusion. 
Fixes:
#579 
