### PR TITLE
Update docs for scale with volumes +

### DIFF
--- a/apps/scale-count.html.md.erb
+++ b/apps/scale-count.html.md.erb
@@ -91,7 +91,7 @@ When the `fly scale count` command destroys Machines, the volumes become unattac
 The `fly scale count` command creates new empty volumes, or attaches existing volumes, and does not copy or move any data between volumes.
 </div>
 
-In this example, the app starts with 1 Machine with an attached volume in the `disk` process and 1 unattached volume, all in the `yul` region. The following command to scale the `disk` process to 3 Machines creates 2 new Machines and 1 new volume:
+In this example, the app starts with 1 Machine with an attached volume in the `disk` process and 1 unattached volume, all in the yul region. The following command to scale the `disk` process to 3 Machines creates 2 new Machines and 1 new volume:
 
 ```cmd
 fly scale count disk=3 --region yul
@@ -105,7 +105,7 @@ App 'my-example-app' is going to be scaled according to this plan:
 
 Note that the preceding example specifies:
 - The region where we have unattached volumes and want the Machines to live.
-- The process group, because our `my-example-app` app has volumes for Machines in the `disk` process group.
+- The process group, because our `my-example-app` app has volumes for Machines that belong to the `disk` process group.
 
 ## Scale an app's regions
 
@@ -131,7 +131,7 @@ You can also set the scale explicitly per region by specifying a single region p
 fly scale count 4 --region ewr
 ```
 
-If `--region` is not used, the target count is distributed across all regions in which the app already has Machines that belong to any process group.
+If `--region` is not used, then the target count is distributed across all the regions in which the app already has Machines that belong to any process group.
 
 ## Scale by process group
 

--- a/apps/scale-count.html.md.erb
+++ b/apps/scale-count.html.md.erb
@@ -13,20 +13,16 @@ order: 60
 
 </div>
 
-There are two ways to scale the number of platform Machines&mdash;Machines managed by `fly deploy`&mdash;on a V2 Fly App after its first deployment: 
+There are two ways to scale the number of Machines managed by [Fly Launch](/docs/apps/) after deploying an app for the first time:
 
 1. with the `fly scale count` subcommand
 2. by explicitly [cloning](#scale-up-with-fly-machine-clone) or [destroying](#scale-down-with-fly-machine-destroy) existing Machines on the app
 
-<div class="callout">
-`fly scale count` does not yet support scaling Machines with [persistent storage volumes](/docs/apps/volume-storage/). Use [`fly machine clone`](#scale-up-with-fly-machine-clone) and [`fly machine destroy`](#scale-down-with-fly-machine-destroy) to scale any process groups with mounted volumes.
-</div>
+`fly scale count` uses internal rules to create or destroy Machines to reach the target scale that you specify. Machines get created when the target number of Machines is higher than the existing total, and Machines get destroyed when the target number of Machines is lower than the existing total.
 
-`fly scale count` uses internal rules to create or destroy Machines to reach the target scale that you specify. As you would expect, specifying a target number of Machines that's higher than the existing total results in the creation of Machines, while a lower target results in the destruction of Machines.
+When Machines are created or destroyed using `fly scale count` or `fly machine clone`/`fly machine destroy`, the resulting scale is preserved by `fly deploy`&mdash;except in the case that you scale right down to zero Machines. If there are no existing Machines, then `fly deploy` seeds the app with new Machines in the `primary_region` and according to the `[processes]` configured in your `fly.toml` file. For more information about how many Machines are created when you launch a new app or deploy from zero, refer to [Redundancy by default on first deploy](/docs/reference/app-availability/#redundancy-by-default-on-first-deploy).
 
-When Machines are created or destroyed using either of the above methods, the resulting scale is preserved by `fly deploy`&mdash;except in the case that you scale right down to zero Machines. In that case, `fly deploy` seeds the app with new Machines according to the `primary_region` and `[processes]` configured in `fly.toml`.
-
-Further adjustments to the capacity of the app can be made by starting and stopping its Machines. Stopped Machines cost less than running Machines because they don't consume any CPU or RAM resources. See [Automatically Stop and Start App Machines](/docs/apps/autostart-stop/) for ways to do this dynamically.
+You can also adjust the capacity of the app by starting and stopping its Machines. Stopped Machines cost less than running Machines because they don't consume any CPU or RAM resources. See [Automatically Stop and Start App Machines](/docs/apps/autostart-stop/) for ways to do this dynamically.
 
 
 ## View the app's current scale 
@@ -39,30 +35,30 @@ Here's an example to illustrate that:
 fly scale show
 ```
 ```out
-VM Resources for app: scalecmd
+VM Resources for app: my-example-app
 
 Groups
 NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
 app     3       shared          4       1024 MB mia,scl(2)
-other   3       shared          4       1024 MB ord(2),scl
+disk   3       shared          4       1024 MB ord(2),scl
 task    4       performance     1       2048 MB iad,mia,ord,scl
 ```
 
-This app has 10 Machines total. The `app` process group has two in scl (Santiago) and one in mia (Miami). `other` has two in ord (Chicago) and one in scl. `task` has one Machine in each of iad (Ashburn), mia, ord, and scl. You can put your Machines wherever works best for your app.
+This app has 10 Machines total. The `app` process group has two in scl (Santiago) and one in mia (Miami). `disk` has two in ord (Chicago) and one in scl. `task` has one Machine in each of iad (Ashburn), mia, ord, and scl. You can put your Machines wherever works best for your app.
 
-## Scale a simple app in a single region
+## Scale the number of Machines in a single region
 
-The default process name in a Fly App is `app`. If you don't define [process groups](docs/apps/processes/), all of the app's Machines belong to the `app` process group, with the exception of any standalone Machines (created with `fly machine` commands).
+The following examples apply to a Fly App's default process group: the `app` process group. If you don't define [process groups](docs/apps/processes/), then all of the app's Machines belong to the `app` process group, with the exception of any Machines created with `fly machine` commands or the Machines API.
 
 `fly scale count` applies changes to the default process group if it is not [passed explicit per-process target counts](#change-the-number-of-machines-in-a-process-group).
 
-Here's the `fly scale show` output for a simple newly deployed web app, with two machines in yyz (Toronto):
+Here's the `fly scale show` output for a newly deployed web app, with two machines in yyz (Toronto):
 
 ```cmd
 fly scale show
 ```
 ```out
-VM Resources for app: scalecmd
+VM Resources for app: my-example-app
 
 Groups
 NAME    COUNT   KIND    CPUS    MEMORY  REGIONS 
@@ -84,6 +80,32 @@ app     4       shared  1       256 MB  yyz(4)
 ```
 
 Now there are four Machines in yyz.
+
+## Scale an app with volumes
+
+When you scale an app with volumes, the `fly scale count` command attaches volumes to the Machines it creates: first using unattached volumes that already exist in the Machine's region, and then creating new volumes if there are not enough&mdash;or any&mdash;existing volumes.
+
+When the `fly scale count` command destroys Machines, the volumes become unattached and can be used again when scaling up.
+
+<div class="warning icon">
+The `fly scale count` command creates new empty volumes, or attaches existing volumes, and does not copy or move any data between volumes.
+</div>
+
+In this example, the app starts with 1 Machine with an attached volume in the `disk` process and 1 unattached volume, all in the `yul` region. The following command to scale the `disk` process to 3 Machines creates 2 new Machines and 1 new volume:
+
+```cmd
+fly scale count disk=3 --region yul
+```
+```output
+App 'my-example-app' is going to be scaled according to this plan:
+  +2 machines for group 'disk' on region 'yul' with size 'shared-cpu-1x'
+  +1 new volumes and using 1 existing volumes for group 'disk' in region 'yul'
+? Scale app my-example-app? (y/N)
+```
+
+Note that the preceding example specifies:
+- The region where we have unattached volumes and want the Machines to live.
+- The process group, because our `my-example-app` app has volumes for Machines in the `disk` process group.
 
 ## Scale an app's regions
 
@@ -109,10 +131,9 @@ You can also set the scale explicitly per region by specifying a single region p
 fly scale count 4 --region ewr
 ```
 
-If `--region` is not used, the target count is distributed across all regions in which the app already has platform Machines belonging to any process group.
+If `--region` is not used, the target count is distributed across all regions in which the app already has Machines that belong to any process group.
 
-
-## Change the number of Machines in a process group
+## Scale by process group
 
 `fly scale count` takes explicit target counts per process group. 
 
@@ -122,7 +143,7 @@ Here's an app with two process groups running in two regions, nrt (Tokyo) and yy
 fly scale show
 ```
 ```out
-VM Resources for app: scalecmd
+VM Resources for app: my-example-app
 
 Groups
 NAME    COUNT   KIND    CPUS    MEMORY  REGIONS       
@@ -136,12 +157,12 @@ Scale it out to 10 `web` Machines and 6 `worker` Machines, without constraining 
 fly scale count web=10 worker=6
 ```
 ```out
-App 'scalecmd' is going to be scaled according to this plan:
+App 'my-example-app' is going to be scaled according to this plan:
   +3 machines for group 'web' on region 'yyz' with size 'shared-cpu-1x'
   +3 machines for group 'web' on region 'nrt' with size 'shared-cpu-1x'
   +1 machines for group 'worker' on region 'yyz' with size 'shared-cpu-1x'
   +1 machines for group 'worker' on region 'nrt' with size 'shared-cpu-1x'
-? Scale app scalecmd? Yes
+? Scale app my-example-app? Yes
 Executing scale plan
   Created 9080eeddc29387 group:web region:yyz size:shared-cpu-1x
   ...
@@ -247,7 +268,7 @@ Check that it worked:
 fly scale show
 ```
 ```out
-VM Resources for app: scalecmd
+VM Resources for app: my-example-app
 
 Groups
 NAME    COUNT   KIND    CPUS    MEMORY  REGIONS 

--- a/apps/scale-count.html.md.erb
+++ b/apps/scale-count.html.md.erb
@@ -40,7 +40,7 @@ VM Resources for app: my-app-name
 Groups
 NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
 app     3       shared          4       1024 MB mia,scl(2)
-disk   3       shared          4       1024 MB ord(2),scl
+disk    3       shared          4       1024 MB ord(2),scl
 task    4       performance     1       2048 MB iad,mia,ord,scl
 ```
 

--- a/apps/scale-count.html.md.erb
+++ b/apps/scale-count.html.md.erb
@@ -35,7 +35,7 @@ Here's an example to illustrate that:
 fly scale show
 ```
 ```out
-VM Resources for app: my-example-app
+VM Resources for app: my-app-name
 
 Groups
 NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
@@ -58,7 +58,7 @@ Here's the `fly scale show` output for a newly deployed web app, with two machin
 fly scale show
 ```
 ```out
-VM Resources for app: my-example-app
+VM Resources for app: my-app-name
 
 Groups
 NAME    COUNT   KIND    CPUS    MEMORY  REGIONS 
@@ -97,15 +97,15 @@ In this example, the app starts with 1 Machine with an attached volume in the `d
 fly scale count disk=3 --region yul
 ```
 ```output
-App 'my-example-app' is going to be scaled according to this plan:
+App 'my-app-name' is going to be scaled according to this plan:
   +2 machines for group 'disk' on region 'yul' with size 'shared-cpu-1x'
   +1 new volumes and using 1 existing volumes for group 'disk' in region 'yul'
-? Scale app my-example-app? (y/N)
+? Scale app my-app-name? (y/N)
 ```
 
 Note that the preceding example specifies:
 - The region where we have unattached volumes and want the Machines to live.
-- The process group, because our `my-example-app` app has volumes for Machines that belong to the `disk` process group.
+- The process group, because our `my-app-name` app has volumes for Machines that belong to the `disk` process group.
 
 ## Scale an app's regions
 
@@ -143,7 +143,7 @@ Here's an app with two process groups running in two regions, nrt (Tokyo) and yy
 fly scale show
 ```
 ```out
-VM Resources for app: my-example-app
+VM Resources for app: my-app-name
 
 Groups
 NAME    COUNT   KIND    CPUS    MEMORY  REGIONS       
@@ -157,12 +157,12 @@ Scale it out to 10 `web` Machines and 6 `worker` Machines, without constraining 
 fly scale count web=10 worker=6
 ```
 ```out
-App 'my-example-app' is going to be scaled according to this plan:
+App 'my-app-name' is going to be scaled according to this plan:
   +3 machines for group 'web' on region 'yyz' with size 'shared-cpu-1x'
   +3 machines for group 'web' on region 'nrt' with size 'shared-cpu-1x'
   +1 machines for group 'worker' on region 'yyz' with size 'shared-cpu-1x'
   +1 machines for group 'worker' on region 'nrt' with size 'shared-cpu-1x'
-? Scale app my-example-app? Yes
+? Scale app my-app-name? Yes
 Executing scale plan
   Created 9080eeddc29387 group:web region:yyz size:shared-cpu-1x
   ...
@@ -268,7 +268,7 @@ Check that it worked:
 fly scale show
 ```
 ```out
-VM Resources for app: my-example-app
+VM Resources for app: my-app-name
 
 Groups
 NAME    COUNT   KIND    CPUS    MEMORY  REGIONS 

--- a/apps/volume-storage.html.md.erb
+++ b/apps/volume-storage.html.md.erb
@@ -34,12 +34,12 @@ Your app is ready! Deploy with `flyctl deploy`
 
 ### Configure the app to mount the new volume
 
-Add a `[mounts]` section in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the Machine and the volume during the deploy process. The following configuration exposes data from a volume named `myapp_data` under the `/data` directory of the application.
+Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the Machine and the volume during the deploy process. The following configuration exposes data from a volume named `myapp_data` under the `/data` directory of the application.
 
 ```toml
 [mounts]
-source="myapp_data"
-destination="/data"
+  source="myapp_data"
+  destination="/data"
 ```
 
 ### Deploy the app
@@ -127,12 +127,12 @@ You can add a volume, or volumes, to an existing app by adding `[mounts]` to the
 
 ### Configure the app to mount the new volume
 
-Add a `[mounts]` section in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
 
 ```toml
 [mounts]
-source="myapp_data"
-destination="/data"
+  source="myapp_data"
+  destination="/data"
 ```
 
 ### Create the volume

--- a/reference/app-availability.html.md.erb
+++ b/reference/app-availability.html.md.erb
@@ -31,12 +31,12 @@ This brings us to disaster recovery and being prepared. You should have backups 
 
 ## Fly.io features for app resiliency
 
-The Fly Apps V2 platform has features to help make your app more resilient in case of outages or hardware failures.
+The Fly Platform has features to help make your app more resilient in case of outages or hardware failures.
 
 The features for redundancy and availability are:
 
-* [Redundancy by default on first deploy](#redundancy-by-default-on-first-deploy): standby Machines and two Machines per process group
-* [Automatically start and stop Machines](#automatically-start-and-stop-machines) based on traffic
+* [Redundancy by default on first deploy](#redundancy-by-default-on-first-deploy)
+* [Automatically start and stop Machines](#automatically-start-and-stop-machines)
 * [Health check-based routing](#health-check-based-routing)
 
 <div class="callout">
@@ -47,7 +47,7 @@ You might also be interested in how we do [load balancing](/docs/reference/load-
 
 ## Redundancy by default on first deploy
 
-The first time you deploy your app to the Fly.io platform, you get some default redundancy configurations. These settings help you to deploy a recommended setup without having to think about it. On the other hand, if the defaults aren't what you're looking for, then you can still configure your app and processes the way you want. Learn more about [scaling Machine CPU and RAM](/docs/apps/scale-machine/) and [scaling the number of Machines](/docs/apps/scale-count/).
+Technically, the title of this section should be "Redundancy by default on first deploy or after scaling down to zero Machines". When you deploy your app for the first time (or after scaling down to zero Machines), you get some default redundancy configurations. These settings help you to deploy a recommended setup without having to think about it. On the other hand, if the defaults aren't what you're looking for, then you can still configure your app and processes the way you want. Learn more about [scaling Machine CPU and RAM](/docs/apps/scale-machine/) and [scaling the number of Machines](/docs/apps/scale-count/).
 
 Here's what Fly Launch (the `fly launch` or `fly deploy` command) does, based on your app configuration:
 
@@ -64,14 +64,6 @@ If a process group has services defined, two Machines are automatically created 
 * you deploy an app for the first time using `fly launch` or `fly deploy`,
 * you redeploy an app using `fly deploy` after scaling down to zero, or
 * you add a new process group with services in the `fly.toml` file and then run `fly deploy`
-
-But what if you don't want to keep Machines running all the time for an app with a small or variable workload? The [automatic start and stop feature](#automatically-start-and-stop-machines) is enabled by default for Machines and makes it possible to run at least two Machines without wasting resources.
-
-If you don't want `fly deploy` to create two Machines, then you can use the `--ha` option to turn off this feature:
-
-```cmd
-fly deploy --ha=false
-```
 
 ### Standby Machines for process groups without services
 
@@ -98,6 +90,16 @@ If you add services to the process group in `fly.toml`, then the standby designa
 You can recreate the standby Machine if you scale down to 0 and then run `fly deploy`, which will create one Machine and one standby Machine again.
 
 At a lower level, you can also use the `fly machines update` command with the `--standby-for` option to create a standby configuration using two existing Machines.
+
+### Turn off redundancy on deploy
+
+What if you don't want to keep Machines running all the time for an app with a small or variable workload? The [automatic start and stop feature](#automatically-start-and-stop-machines) is enabled by default for Machines and makes it possible to run at least two Machines without wasting resources.
+
+But if you still don't want `fly deploy` to create two Machines, then you can use the `--ha` option to turn off this feature:
+
+```cmd
+fly deploy --ha=false
+```
 
 ## Automatically start and stop Machines
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -485,8 +485,9 @@ This section supports the Volumes feature for persistent storage. The section ha
 
 ```toml
 [mounts]
-source="myapp_data"
-destination="/data"
+  source = "myapp_data"
+  destination = "/data"
+  processes= ["disk"] # optional - attach volumes to Machines that belong to one or more process groups
 ```
 
 ### `source`
@@ -560,8 +561,8 @@ To run multiple processes, you'll need a `[processes]` block containing a map of
 
 ```toml
 [processes]
-web = "bundle exec rails server -b [::] -p 8080"
-worker = "bundle exec sidekiqswarm"
+  web = "bundle exec rails server -b [::] -p 8080"
+  worker = "bundle exec sidekiqswarm"
 ```
 
 Furthermore, you can "match" a specific process (or processes) to an [`[http_service]`](#the-http_service-section) or [`[[services]]`](#the-services-sections) configuration. For example:

--- a/reference/volumes.html.md.erb
+++ b/reference/volumes.html.md.erb
@@ -38,13 +38,15 @@ Many developers use volumes for databases, so if possible, each volume you creat
 
 Volumes exist in a single region. For redundancy within a region, you can run multiple Machines with attached volumes by creating multiple volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run. Every volume has a unique ID to allow for multiple volumes with the same name. Remember that volumes don't automatically replicate data between them.
 
-## Volumes and Fly Apps
+## Using volumes with your Fly App
 
-Learn how to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+Learn more about using volumes:
 
-Learn about the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` Fly Launch configuration file.
+- How to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
+- How to configure the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` Fly Launch configuration file.
+- How to [scale an app with volumes attached]()
 
-## Working with volumes using flyctl
+## Reference: Working with volumes using flyctl
 
 This section is a reference for working with volumes using the [`fly volumes`](/docs/flyctl/volumes/) command. To add a volume to an existing app or launch a new app with a volume refer to [Add Volume Storage](/docs/apps/volume-storage/).
 


### PR DESCRIPTION
This PR mostly updates the docs for the `fly scale count` for Machines with volumes functionality, plus some further minor and semi-related edits:
- add a section the Scale the number of Machines doc for scaling Machines with volumes
- edit to the wording about the `scale` command to make things more explicit
- changed the app name in examples to `my-app-name`, which we used in the API docs
- add links to the mounts config from the volumes docs
- fix the formatting of the toml in the mounts examples in a bunch of places
- In the app resiliency doc:
  - added an extra sentence or two about redundancy on first deploy technically meaning on first deploy or after scaling to zero (totally related to the purpose of this PR!)
  - moved the bit about turning off redundant machines since it applies to the whole section

### Related
https://github.com/superfly/flyctl/pull/2547