### PR TITLE
Add hint about specifying dockerfile in case it is not automatically …

### DIFF
--- a/languages-and-frameworks/dockerfile.html.md.erb
+++ b/languages-and-frameworks/dockerfile.html.md.erb
@@ -31,7 +31,7 @@ Wrote config file fly.toml
 ? Would you like to deploy now?
 ```
 
-Let `fly launch` generate an app name for you or pick your own. You may need to explicitily specify Dockerfile path using `--dockerile` flag if fly doesn't detect Dockerfile automatically.
+Let `fly launch` generate an app name for you or pick your own. You may need to explicitly specify Dockerfile path using `--dockerfile` flag if fly doesn't detect Dockerfile automatically.
 
 Select the Fly.io [region](https://fly.io/docs/reference/regions/) to deploy to.
 

--- a/languages-and-frameworks/dockerfile.html.md.erb
+++ b/languages-and-frameworks/dockerfile.html.md.erb
@@ -31,7 +31,7 @@ Wrote config file fly.toml
 ? Would you like to deploy now?
 ```
 
-Let `fly launch` generate an app name for you or pick your own.
+Let `fly launch` generate an app name for you or pick your own. You may need to explicitily specify Dockerfile path using `--dockerile` flag if fly doesn't detect Dockerfile automatically.
 
 Select the Fly.io [region](https://fly.io/docs/reference/regions/) to deploy to.
 


### PR DESCRIPTION
…detected

I have a Rails app which has a dockerfile named `Dockerfile` in a main directory and still `fly launch` was trying to build it as a ruby app, hence I propose adding this hint.