### PR TITLE
Update fly.toml docs with missing config options

### DIFF
--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -262,6 +262,18 @@ In the following example, `Example-Header` will be removed from the final respon
     Example-Multi-Value = ["value1", "value2"]
 ```
 
+### `http_service.proxy_proto_options`
+
+Configure the version of the PROXY protocol that your app accepts. Version 1 is the default.
+
+For example:
+```toml
+[http_service.proxy_proto_options]
+  version = "v2"
+```
+
+* `version` : A string to indicate that the TCP connection uses PROXY protocol version 2. The default when not set is version 1.
+
 ### `http_service.tls_options`
 
 Configure the TLS versions and ALPN protocols that Fly's edge will use to terminate TLS for your application with:
@@ -427,7 +439,7 @@ For example:
   proxy_proto_options = { version = "v2" }
 ```
 
-* `version` : A string to indicate that the TCP connection uses PROXY protocol version 2.
+* `version` : A string to indicate that the TCP connection uses PROXY protocol version 2. The default when not set is version 1.
 
 #### `services.ports.tls_options`
 
@@ -442,6 +454,7 @@ Configure the TLS versions and ALPN protocols that Fly's edge will use to termin
 
 * `alpn` : Array of strings indicating how to handle ALPN negotiations with clients.
 * `versions` : Array of strings indicating which TLS versions are allowed.
+* `default_self_signed`: When `true`, serve a self-signed certificate if no certificate exists. Default is `false`.
 
 Fly.io can also terminate TLS only and pass through directly to your service. This works for a variety of applications that can benefit from offloading TLS termination and accept the unencrypted connection.
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -262,6 +262,32 @@ In the following example, `Example-Header` will be removed from the final respon
     Example-Multi-Value = ["value1", "value2"]
 ```
 
+### `http_service.tls_options`
+
+Configure the TLS versions and ALPN protocols that Fly's edge will use to terminate TLS for your application with:
+
+```toml
+[http_service.tls_options]
+  alpn = ["h2", "http/1.1"]
+  versions = ["TLSv1.2", "TLSv1.3"]
+  default_self_signed = false
+```
+
+* `alpn`: Array of strings indicating how to handle ALPN negotiations with clients.
+* `versions`: Array of strings indicating which TLS versions are allowed.
+* `default_self_signed`: When `true`, serve a self-signed certificate if no certificate exists. Default is `false`. 
+
+Fly.io can also terminate TLS only and pass through directly to your service. This works for a variety of applications that can benefit from offloading TLS termination and accept the unencrypted connection.
+
+One use case is applications using HTTP/2, like gRPC. Fly's edge terminates TLS and sends h2c (HTTP/2 without TLS) directly to your application through our backhaul. The config below will negotiate HTTP/2 with clients, and then send h2c to the application:
+
+```toml
+  [[services.ports]]
+    handlers = ["tls"]
+    port = "443"
+    tls_options = { "alpn" = ["h2"] }
+```
+
 ### `http_service.checks`
 
 To configure health checks for your http service, you can use the `http_service.checks` section. These checks expect a successful HTTP status in response (i.e, 2xx). Here is an example of a `http_service.checks` section:
@@ -388,6 +414,20 @@ In the following example, `Example-Header` will be removed from the final respon
     Example-Header-1 = "value"
     Example-Multi-Value = ["value1", "value2"]
 ```
+
+#### `services.ports.proxy_proto_options`
+
+Configure the version of the PROXY protocol that your app accepts. Version 1 is the default.
+
+For example:
+```toml
+[[services.ports]]
+  handlers = ["proxy_proto"]
+  port = "5000"
+  proxy_proto_options = { version = "v2" }
+```
+
+* `version` : A string to indicate that the TCP connection uses PROXY protocol version 2.
 
 #### `services.ports.tls_options`
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -277,16 +277,7 @@ Configure the TLS versions and ALPN protocols that Fly's edge will use to termin
 * `versions`: Array of strings indicating which TLS versions are allowed.
 * `default_self_signed`: When `true`, serve a self-signed certificate if no certificate exists. Default is `false`. 
 
-Fly.io can also terminate TLS only and pass through directly to your service. This works for a variety of applications that can benefit from offloading TLS termination and accept the unencrypted connection.
-
-One use case is applications using HTTP/2, like gRPC. Fly's edge terminates TLS and sends h2c (HTTP/2 without TLS) directly to your application through our backhaul. The config below will negotiate HTTP/2 with clients, and then send h2c to the application:
-
-```toml
-  [[services.ports]]
-    handlers = ["tls"]
-    port = "443"
-    tls_options = { "alpn" = ["h2"] }
-```
+Fly.io can also terminate TLS only and pass through directly to your service. For more information, refer to [services.ports.tls_options](/docs/reference/configuration/#services-ports-tls_options)
 
 ### `http_service.checks`
 

--- a/reference/configuration.html.md.erb
+++ b/reference/configuration.html.md.erb
@@ -262,18 +262,6 @@ In the following example, `Example-Header` will be removed from the final respon
     Example-Multi-Value = ["value1", "value2"]
 ```
 
-### `http_service.proxy_proto_options`
-
-Configure the version of the PROXY protocol that your app accepts. Version 1 is the default.
-
-For example:
-```toml
-[http_service.proxy_proto_options]
-  version = "v2"
-```
-
-* `version` : A string to indicate that the TCP connection uses PROXY protocol version 2. The default when not set is version 1.
-
 ### `http_service.tls_options`
 
 Configure the TLS versions and ALPN protocols that Fly's edge will use to terminate TLS for your application with:

--- a/reference/services.html.md.erb
+++ b/reference/services.html.md.erb
@@ -65,7 +65,7 @@ client can handle reconnects cleanly. For example, the `ioredis` Node.js client 
 Set the `handlers` config setting in the `services.ports` section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
 
 Valid handler strings:
-* [`"http"`](#http): Convert TCP connection to HTTP
+* `"http"`(#http): Convert TCP connection to HTTP
 * [`"tls"`](#tls): Convert TLS connection to unencrypted TCP
 * `"pg_tls"`: Handle TLS for PostgreSQL connections
 * `"proxy_proto"`: Wrap TCP connection in PROXY protocol

--- a/reference/services.html.md.erb
+++ b/reference/services.html.md.erb
@@ -62,7 +62,7 @@ client can handle reconnects cleanly. For example, the `ioredis` Node.js client 
 
 ## Connection handlers
 
-Set the `handlers` config setting in the `services.ports` or section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
+Set the `handlers` config setting in the `services.ports` section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
 
 Valid handler strings:
 * [`"http"`:](#http) Convert TCP connection to HTTP
@@ -112,7 +112,9 @@ The `pg_tls` handler manages Postgres connections, so that you can expose your P
 
 ### PROXY protocol
 
-The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly. Fly.io supports version 1 (human-readable header format) of the PROXY protocol by default with the `proxy_proto` handler. To use version 2 (binary header format), use `proxy_proto_options` in `[[services.ports]]` or `[http_service]`
+The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly. 
+
+Fly.io supports version 1 (human-readable header format) of the PROXY protocol by default with the `proxy_proto` handler. You can configure the `proxy_proto` handler to use version 2 (binary header format) in the [`services.ports.proxy_proto_options`](/docs/reference/configuration/#services-ports-proxy_proto_options) section of your `fly.toml` file.
 
 ## HTTP to HTTPS redirects
 

--- a/reference/services.html.md.erb
+++ b/reference/services.html.md.erb
@@ -65,20 +65,17 @@ client can handle reconnects cleanly. For example, the `ioredis` Node.js client 
 Set the `handlers` config setting in the `services.ports` section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
 
 Valid handler strings:
-* `"tls"`: Convert TLS connection to unencrypted TCP
+* [`"http"`](#http): Convert TCP connection to HTTP
+* [`"tls"`](#tls): Convert TLS connection to unencrypted TCP
 * `"pg_tls"`: Handle TLS for PostgreSQL connections
-* `"http"`: Convert TCP connection to HTTP
 * `"proxy_proto"`: Wrap TCP connection in PROXY protocol
 
+### TCP pass through
 
-### TLS
-The `TLS` middleware terminates TLS using Fly.io-managed application certificates, then forwards a plaintext connection to the application process. This is useful for running TCP services and offloading `TLS` to the Fly Proxy.
-
-For performance purposes, the Fly Proxy will terminate TLS on the host a client connects to, and then forward the connection to the nearest available application instance.
-
-_Note:_ the `TLS` handler includes ALPN negotiation for HTTP/2. When possible, applications will connect to these kinds of Fly.io services using HTTP/2, and we will forward an unencrypted HTTP/2 connection (`h2c`) to the application process.
+If you don't specify handlers, we just forward TCP to your application as is. This is useful if you want to handle TLS termination yourself, for example.
 
 ### HTTP
+
 Many applications have limited HTTP support, the `HTTP` middleware normalizes HTTP connections and sends HTTP 1.1 requests to the application process. This is roughly how `nginx` and other reverse proxies work, and allows your application to globally accept modern HTTP protocols (like HTTP/2) without extra complexity.
 
 If your application stack has good HTTP/2 support (like Go), you will get better performance accepting TCP connections directly, and using the TLS handler to terminate SSL. Your application _does_ need to understand `h2c` for this to work, however.
@@ -101,17 +98,21 @@ You can set a preference on HTTP requests for which region you would like to con
 Fly-Prefer-Region: region-code
 ```
 
-### TCP pass through
+### TLS
 
-If you don't specify handlers, we just forward TCP to your application as is. This is useful if you want to handle TLS termination yourself, for example.
+The `TLS` middleware terminates TLS using Fly.io-managed application certificates, then forwards a plaintext connection to the application process. This is useful for running TCP services and offloading `TLS` to the Fly Proxy.
 
-### Proxy protocol
+For performance purposes, the Fly Proxy will terminate TLS on the host a client connects to, and then forward the connection to the nearest available application instance.
 
-The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly.
+_Note:_ the `TLS` handler includes ALPN negotiation for HTTP/2. When possible, applications will connect to these kinds of Fly.io services using HTTP/2, and we will forward an unencrypted HTTP/2 connection (`h2c`) to the application process.
 
 ### Postgres connections
 
 The `pg_tls` handler manages Postgres connections, so that you can expose your Postgres databases over the proxy securely. Some interesting notes by @glebarez on why standard TLS termination won't work for Postgres: https://github.com/glebarez/pgssl#readme
+
+### PROXY protocol
+
+The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly.
 
 ## HTTP to HTTPS redirects
 

--- a/reference/services.html.md.erb
+++ b/reference/services.html.md.erb
@@ -62,17 +62,17 @@ client can handle reconnects cleanly. For example, the `ioredis` Node.js client 
 
 ## Connection handlers
 
-Set the `handlers` config setting in the `services.ports` section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
+Set the `handlers` config setting in the `services.ports` or section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
 
 Valid handler strings:
-* `"http"`(#http): Convert TCP connection to HTTP
+* [`"http"`:](#http) Convert TCP connection to HTTP
 * [`"tls"`](#tls): Convert TLS connection to unencrypted TCP
-* `"pg_tls"`: Handle TLS for PostgreSQL connections
-* `"proxy_proto"`: Wrap TCP connection in PROXY protocol
+* [`"pg_tls"`](#postgres-connections): Handle TLS for PostgreSQL connections
+* [`"proxy_proto"`](#proxy-protocol): Wrap TCP connection in PROXY protocol
 
 ### TCP pass through
 
-If you don't specify handlers, we just forward TCP to your application as is. This is useful if you want to handle TLS termination yourself, for example.
+If you don't specify handlers, we just forward TCP to your application as-is. This is useful if you want to handle TLS termination yourself, for example.
 
 ### HTTP
 
@@ -112,7 +112,7 @@ The `pg_tls` handler manages Postgres connections, so that you can expose your P
 
 ### PROXY protocol
 
-The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly.
+The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly. Fly.io supports version 1 (human-readable header format) of the PROXY protocol by default with the `proxy_proto` handler. To use version 2 (binary header format), use `proxy_proto_options` in `[[services.ports]]` or `[http_service]`
 
 ## HTTP to HTTPS redirects
 


### PR DESCRIPTION
This PR adds some missing config options for `fly.toml`, like `proxy_proto_options`. and `default_self_signed` for `tls_options`. Also updated and slighlty re-arranged the connection handler info in the Public Network Services doc. 

Related: 
- https://github.com/superfly/flyctl/pull/2169
- https://github.com/superfly/flyctl/pull/2177