### PR TITLE
Update auto start and stop to make defaults more clear

### DIFF
--- a/apps/autostart-stop.html.markerb
+++ b/apps/autostart-stop.html.markerb
@@ -1,5 +1,5 @@
 ---
-title: Automatically Stop and Start Machines
+title: Automatically stop and start Machines
 objective: 
 layout: docs
 nav: firecracker
@@ -7,22 +7,18 @@ order: 65
 ---
 
 <div class="callout">
-This feature only works for V2 Apps running on Fly Machines. You might also be interested in learning about [scaling the number of machines](/docs/apps/scale-count/) for the V2 Apps Platform. For information about scaling V1 Apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
+The auto start and stop feature only works for V2 Apps running on Fly Machines. You might also be interested in learning about [scaling the number of machines](/docs/apps/scale-count/) for V2 Apps. For information about scaling V1 Apps, refer to [Scale V1 Nomad Apps](/docs/apps/legacy-scaling/).
 </div>
 
 Fly Machines are fast to start and stop, and you don't pay for their CPU and RAM when they're in the `stopped` state. For Fly Apps with a service configured, Fly Proxy can automatically start and stop existing Machines based on incoming requests, so that your app can meet demand without keeping extra Machines running. And if your app needs to have one or more Machines always running in your primary region, then you can set a minimum number of machines to keep running.
 
-This Fly Proxy feature also plays well with apps whose Machines [exit from within](#stop-a-machine-by-terminating-its-main-process) when idle. If your app already shuts down when idle, then the proxy can restart it when there's traffic.
+The auto start and stop feature also plays well with apps whose Machines [exit from within](#stop-a-machine-by-terminating-its-main-process) when idle. If your app already shuts down when idle, then the proxy can restart it when there's traffic.
 
 ## Configure automatic start and stop
 
-The autostart and stop settings apply per service, so you set them within the [[[services]]](/docs/reference/configuration/#the-services-sections) or [[http_service]](/docs/reference/configuration/#the-http_service-section) sections of `fly.toml`. You can configure automatic starts and stops separately with the `auto_start_machines` and `auto_stop_machines` settings, and set the minimum number of machines to keep running with the `min_machines_running` setting.
+The auto start and stop settings apply per service, so you set them within the [[[services]]](/docs/reference/configuration/#the-services-sections) or [[http_service]](/docs/reference/configuration/#the-http_service-section) sections of `fly.toml`:
 
-Concurrency limits for services affect [how automatic starts and stops work](#how-it-works).
-
-### Default and recommended values
-
-Default settings in `fly.toml` for V2 Apps created using the `fly launch` command:
+For example:
 
 ```toml
 ...
@@ -35,6 +31,20 @@ Default settings in `fly.toml` for V2 Apps created using the `fly launch` comman
 ...
 ```
 
+Briefly, the settings are:
+
+* `auto_start_machines`: Whether Fly Proxy should automatically start Machines based on requests and capacity.
+* `auto_stop_machines`: Whether Fly Proxy should automatically stop Machines when the app is idle for several minutes.
+* `min_machines_running`: The minimum number of Machines to keep running in the primary region when `auto_stop_machines = true`.
+
+Concurrency limits for services affect [how automatic starts and stops work](#how-it-works).
+
+### Default values
+
+The default settings for apps that don't specify any auto start and stop settings in `fly.toml` are `auto_start_machines = true` and `auto_stop_machines = false`.
+
+When you create an app using the `fly launch` command, the default settings in `fly.toml` are:
+
 ```toml
 ...
 [http_service]
@@ -46,21 +56,17 @@ Default settings in `fly.toml` for V2 Apps created using the `fly launch` comman
 ...
 ```
 
-<div class="callout">
-Existing V2 Apps&mdash;or any V2 Apps that don't have these settings in `fly.toml`&mdash;have the default values `auto_start_machines = true` and `auto_stop_machines = false`.
-</div>
+### Recommended settings
 
-In general, we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having Machines that either never start or never stop. 
+If your app already [exits when idle](#stop-a-machine-by-terminating-its-main-process), then you can set `auto_start_machines = true` and `auto_stop_machines = false` to have Fly Proxy automatically restart the Machines stopped by your app. 
 
-If `auto_start_machines = true` and `auto_stop_machines = false`, then Fly Proxy will automatically start your Machines but will never stop them. This means you'll have to stop Machines manually, or have your [app exit when idle](#stop-a-machine-by-terminating-its-main-process).
+If your app doesn't exit when idle, then we recommend setting `auto_stop_machines` and `auto_start_machines` to the same value (either both `true` or both `false`) so that Fly Proxy doesn't stop Machines and never restart them. For example, if `auto_start_machines = false` and `auto_stop_machines = true`, then Fly Proxy automatically stops your Machines when there's low traffic but doesn't start them again. When all or most of your Machines are stopped, requests to your app will start failing.
 
-If `auto_start_machines = false` and `auto_stop_machines = true`, then Fly Proxy will automatically stop your Machines when there's low traffic, but won't be able to start them again. If all or most of your Machines are stopped, then requests to your app will start failing.
-
-You can set `min_machines_running` to `1` or higher if you need at least one instance of your app running all the time. This setting is for the total number of Machines, not Machines per region. For example, if `min_machines_running = 1`, then your app will scale down until there is only one Machine running in your primary region. 
+When `auto_stop_machines = true`, set `min_machines_running` to `1` or higher if you need to keep one or more Machines running all the time in your primary region. The `min_machines_running` value applies to the total number of Machines, not Machines per region. For example, if `min_machines_running = 1` and there's no traffic to your app, then Fly Proxy will stop Machines until eventually there is only one Machine running in your primary region.
 
 There's no "maximum machines running" setting, because the maximum number of Machines is just the total number of Machines you've created for your app. Learn more in the [How It Works](#how-it-works) section.
 
-## How It Works
+## How it works
 
 The Fly Proxy runs a process to automatically stop and start existing Fly Machines every few minutes.
 
@@ -68,7 +74,7 @@ The Fly Proxy runs a process to automatically stop and start existing Fly Machin
 The automatic start and stop feature only works on existing Machines and never creates or destroys Machines for you. The maximum number of running Machines is the number of Machines you've created for your app using `fly scale count` or `fly machine clone`. Learn more about [scaling the number of Machines](/docs/apps/scale-count/). 
 </div>
 
-### Fly Proxy Stops Machines
+### Fly Proxy stops Machines
 
 When `auto_stop_machines = true` in your `fly.toml`, the proxy looks at Machines running in a single region and uses the concurrency [`soft_limit` setting](/docs/reference/configuration/#the-http_service-section) for each Machine to determine if there's excess capacity. If the proxy decides there's excess capacity, it stops exactly one machine. The proxy repeats this process every few minutes, stopping only one machine per region, if needed, each time.
 
@@ -83,7 +89,7 @@ Fly Proxy determines excess capacity per region as follows:
   * the proxy checks if the Machine has any traffic
   * if the Machine has no traffic (a load of 0), then the proxy stops the Machine
 
-### Fly Proxy Starts Machines
+### Fly Proxy starts Machines
 
 When `auto_start_machines = true` in your `fly.toml`, the Fly Proxy restarts a Machine in the nearest region when required.
 
@@ -93,15 +99,15 @@ Fly Proxy determines when to start a Machine as follows:
 * If all the running Machines are above their `soft_limit` setting, then the proxy starts a stopped Machine in the nearest region (if there are any stopped Machines).
 * The proxy routes the request to the newly started Machine.
 
-## When to Stop and Start Fly Machines Automatically, or Not
+## When to stop and start Fly Machines automatically, or not
 
 If your app has highly variable request workloads, then you can set `auto_stop_machines` and `auto_start_machines` to `true` to manage your Fly Machines as demand decreases and increases. This could reduce costs, because you'll never have to run excess Machines to handle peak load; you'll only run, and be charged for, the number of Machines that are needed at any given time.
 
 The difference between this feature and what is typical in autoscaling, is that it doesn't create new Machines up to a specified maximum. It automatically starts only existing Machines. For example, if you want to have a maximum of 10 Machines available to service requests, then you need to create 10 Machines for your app.
 
-If you need all of your app's Machines to be “always on”, then you can set `auto_stop_machines` and `auto_start_machines` to `false`. If `auto_stop_machines = true`, `min_machines_running = 0`, and there’s no traffic to your app, eventually all of your app's Machines could be stopped. 
+If you need all of your app's Machines to run continuously, then you can set `auto_stop_machines` and `auto_start_machines` to `false`.
 
-If you only need one or a few instances of your app to keep running in your primary region all the time, then you can set `min_machines_running` to `1` or higher.
+If you only need a certain number of your app's Machines to run continuously, then you can set `auto_stop_machines = true` and `min_machines_running` to `1` or higher.
 
 ## Stop a Machine by terminating its main process
 

--- a/apps/autostart-stop.html.markerb
+++ b/apps/autostart-stop.html.markerb
@@ -64,7 +64,7 @@ If your app doesn't exit when idle, then we recommend setting `auto_stop_machine
 
 When `auto_stop_machines = true`, set `min_machines_running` to `1` or higher if you need to keep one or more Machines running all the time in your primary region. The `min_machines_running` value applies to the total number of Machines, not Machines per region. For example, if `min_machines_running = 1` and there's no traffic to your app, then Fly Proxy will stop Machines until eventually there is only one Machine running in your primary region.
 
-There's no "maximum machines running" setting, because the maximum number of Machines is just the total number of Machines you've created for your app. Learn more in the [How It Works](#how-it-works) section.
+There's no "maximum machines running" setting, because the maximum number of Machines is just the total number of Machines you've created for your app. Learn more in the [How it works](#how-it-works) section.
 
 ## How it works
 


### PR DESCRIPTION
This PR clarifies defaults by splitting up the `Defaults and recommended values` section. Also includes minor edits to other areas. 

Preview: https://aa-docs-2.fly.dev/docs/apps/autostart-stop/