### PR TITLE
Update edgedb guide for v2 machines

### DIFF
--- a/app-guides/edgedb.html.md
+++ b/app-guides/edgedb.html.md
@@ -17,7 +17,7 @@ Create a Postgres app. You'll need to replace `mypostgres` with a unique name of
 ```cmd
 flyctl postgres create \
   --name mypostgres \
-  --vm-size dedicated-cpu-1x \
+  --vm-size performance-1x \
   --volume-size 10 \
   --initial-cluster-size 1
 ```


### PR DESCRIPTION
Currently on latest v0.1.77 I get
```
Error: vm size "dedicated-cpu-1x" is not valid
```