### PR TITLE
Update log shipper docs to ensure that no public access is granted

### DIFF
--- a/going-to-production/monitoring/exporting-logs.html.md
+++ b/going-to-production/monitoring/exporting-logs.html.md
@@ -32,7 +32,7 @@ mkdir logshippper
 cd logshippper
 
 # Create the app but don't deploy just yet
-fly launch --no-deploy --image ghcr.io/superfly/fly-log-shipper:latest
+fly launch --no-deploy --no-public-ips --image ghcr.io/superfly/fly-log-shipper:latest
 
 # Set some secrets. The secret / env var you set
 # determines which "sinks" are configured

--- a/going-to-production/monitoring/exporting-logs.html.md
+++ b/going-to-production/monitoring/exporting-logs.html.md
@@ -32,7 +32,7 @@ mkdir logshippper
 cd logshippper
 
 # Create the app but don't deploy just yet
-fly launch --no-deploy --no-public-ips --image ghcr.io/superfly/fly-log-shipper:latest
+fly launch --no-deploy --image ghcr.io/superfly/fly-log-shipper:latest
 
 # Set some secrets. The secret / env var you set
 # determines which "sinks" are configured
@@ -43,18 +43,12 @@ fly secrets set LOGTAIL_TOKEN=<token provided by logtail source>
 
 You can configure as many providers as you'd like by adding more secrets. The secrets needed are determined by [which provider(s)](https://github.com/superfly/fly-log-shipper#provider-configuration) you want to use.
 
-Before launching your application, you should edit the generated `fly.toml` file and delete the entire `[[services]]` section. Replace it with this:
+Before launching your application, you should edit the generated `fly.toml` file and delete the entire `[[http_service]]` section.
 
-```toml
-[[services]]
-  http_checks = []
-  internal_port = 8686
-```
-
-Then you can deploy it:
+Then you can deploy:
 
 ```cmd
-fly deploy
+fly deploy --no-public-ips
 ```
 
 ## Shipping Specific Logs


### PR DESCRIPTION
A customer [pointed out](https://community.fly.io/t/fly-log-shipper-publishes-graphql-publicly/14836/2) that our log shipper could expose its GraphQL API. We want standard shipper deployments to have no services nor IPs.

Note: `--no-public-ips` fails when an HTTP service is setup by default by `fly launch`.