### PR TITLE
Replace app root with project source in some spots

### DIFF
--- a/app-guides/continuous-deployment-with-github-actions.html.md
+++ b/app-guides/continuous-deployment-with-github-actions.html.md
@@ -13,21 +13,21 @@ date: 2020-06-20
 
 <img src="/static/images/continuous-deployment.webp" alt="A man writing code on a vintage desktop computer" class="rounded-xl">
 
-So you want your application continuously deployed to Fly.io from its GitHub repository. Let's work through setting up an application for just that.
+This guide works through setting up your app for continuous deployment to Fly.io from the app's GitHub repository.
 
-We'll start with an application from one of our other examples, [go-example](https://github.com/fly-apps/go-example). It's a simple lightweight app that displays the Fly.io region that served the request.
+You'll start with an example application called [go-example](https://github.com/fly-apps/go-example). It's a simple, lightweight app that displays the Fly.io region that served the request.
 
-We'll speed-run through the steps needed to make the go-example app automatically deploy to Fly.io from GitHub and then we'll loop back for a longer look at some of the steps.
+The first section is a speed-run through the steps to make the go-example app automatically deploy to Fly.io from GitHub. The next section loops back for a [longer look at each step](#a-longer-look-at-the-deployment-process).
 
 ## Speed-run your way to continuous deployment
 
 1.  Fork the [go-example](https://github.com/fly-apps/go-example) repository to your GitHub account.
 2.  Clone the new repository to your local machine.
-3.  Run `fly launch` from within the app's root directory to create a new app and a `fly.toml` configuration file. Say `N` to adding databases and `N` to deploy now.
-4.  Still in the app's root directory, get a Fly API deploy token by running `fly tokens create deploy -x 999999h`. Copy the output.
+3.  Run `fly launch` from within the project source directory to create a new app and a `fly.toml` configuration file. Type `N` when `fly launch` asks if you want to set up databases and `N` when it asks if you want to deploy.
+4.  Still in the project source directory, get a Fly API deploy token by running `fly tokens create deploy -x 999999h`. Copy the output.
 5.  Go to your newly-created repository on GitHub and select **Settings**.
 6.  Under **Secrets and variables**, select **Actions**, and then create a new repository secret called `FLY_API_TOKEN` with the value of the token from step 4.
-7.  Back in your app's root directory, create `.github/workflows/fly.yml` with these contents:
+7.  Back in your project source directory, create `.github/workflows/fly.yml` with these contents:
     ```yaml
     name: Fly Deploy
     on:
@@ -65,7 +65,7 @@ If you want to watch the process take place, head to the repository and select t
 **Step 3** creates a `fly.toml` file to go into the repository.
 
 <div class="callout">
-A note about `fly.toml` in repositories: Usually, when we ship examples, we avoid putting the `fly.toml` file in the repository by including `fly.toml` in the `.gitignore` file. And users should be creating their own `fly.toml` with the `fly launch` command. When using GitHub Actions though, you want your `fly.toml` in the repository so that the action can use it in the deployment process.
+A note about `fly.toml` in repositories: Usually, when Fly.io ships examples, we avoid putting the `fly.toml` file in the repository by including `fly.toml` in the `.gitignore` file. And users should be creating their own `fly.toml` with the `fly launch` command. When using GitHub Actions though, you want your `fly.toml` in the repository so that the action can use it in the deployment process.
 </div>
 
 ### API Tokens
@@ -74,7 +74,7 @@ A note about `fly.toml` in repositories: Usually, when we ship examples, we avoi
 
 **Steps 5 and 6** make your new token available to GitHub Actions that run against your repository. You'll add the token as a secret in the repository's settings. Under the **Settings** tab, go to **Secrets and variables** and select **Actions**. Click on the green "New repository secret" button, enter the name as `FLY_API_TOKEN`, and copy the token as the secret.
 
-If you'd prefer an environment secret instead, make sure you list the environment you selected in your deploy step.  For example:
+If you'd prefer an environment secret instead, then you need to list the environment you selected in your deploy step.  For example:
 
 ```yaml
 deploy:
@@ -85,7 +85,9 @@ deploy:
 
 ### Building the workflow and Deployment
 
-**Step 7** is the heart of the process, where we put in place a workflow. Now, GitHub has a UI which allows you to select and edit workflows, but you can also modify them as part of the repository. So we create `.github/workflows/fly.yml` - you'll likely want to `mkdir -p .github/workflows` to quickly create the directories - and load up the file with a GitHub Action recipe. We'll go through it line by line now:
+**Step 7** is the heart of the process, where you put in place a workflow. Now, GitHub has a UI which allows you to select and edit workflows, but you can also modify them as part of the repository. So you create `.github/workflows/fly.yml` - you'll likely want to `mkdir -p .github/workflows` to quickly create the directories - and load up the file with a GitHub Action recipe.
+
+Github Action recipe, line by line:
 
 ```yaml
 name: Fly Deploy
@@ -109,19 +111,20 @@ jobs:
       runs-on: ubuntu-latest
 ```
 
-So an action is made up of named jobs, in this case one to deploy the application. The jobs run on a virtual machine. Here we are giving the "deploy" job the name "Deploy app" and telling GitHub Actions to run it on a virtual machine with the latest version of Ubuntu on it. The next part is to set up the steps needed to complete this job.
+So an action is made up of named jobs, in this case one to deploy the application. The jobs run on a virtual machine. This section gives the "deploy" job the name "Deploy app" and tells GitHub Actions to run it on a virtual machine with the latest version of Ubuntu on it. The next part is to set up the steps needed to complete this job.
 
 ```yaml
       steps:
         - uses: actions/checkout@v3
 ```
 
-The first step is one of the built in Actions steps. The step `uses` the `checkout@v3` action which checks out the repository into a directory on the virtual machine. We are now ready to deploy.
+The first step is one of the built in Actions steps. The step `uses` the `checkout@v3` action which checks out the repository into a directory on the virtual machine. You're now ready to deploy.
 
 ```yaml
         - uses: superfly/flyctl-actions/setup-flyctl@master
         - run: flyctl deploy --remote-only
 ```
+
 This step `uses` the superfly/flyctl-actions action. This is a GitHub action created by Fly.io which wraps around the `flyctl` command. The wrapper is invoked with the `deploy` argument which will take over the process of building and moving the application to the Fly.io infrastructure. It uses the settings from the `fly.toml` file to guide it and uses the `FLY_API_TOKEN` to authorize its access to the Fly.io GraphQL API.
 
 ```yaml
@@ -129,7 +132,7 @@ This step `uses` the superfly/flyctl-actions action. This is a GitHub action cre
             FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 ```
 
-Here is where we pull the API token from GitHub's secrets engine and put it into the environmental variables passed to the action.
+This pulls the API token from GitHub's secrets engine and puts it into the environmental variables passed to the action.
 
 **Step 8** pushes your two new files to the repository: `fly.toml`, the Fly Launch configuration file, and `fly.yml`, the GitHub action file. The push triggers your first automatic deploy. The GitHub action now triggers a redeploy each time you push changes to your repo.
 

--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -15,7 +15,7 @@ Whether you've run [`fly launch`](/docs/apps/launch/) but haven't deployed yet, 
 fly deploy
 ``` 
 
-from the root directory of your project, where any app source code, project config, `fly.toml`, and Dockerfile are located.
+from the source directory of your project, where any app source code, project config, `fly.toml`, and Dockerfile are located.
 
 If you haven't deployed the app before, `fly deploy` creates one or two Machines for every [process group](/docs/apps/processes/) defined in the app's `fly.toml` file, depending on whether there are services and volumes configured. If you haven't explicitly defined any process groups, the first deployment gives you two Machines for redundancy. For more information about when Fly Launch creates one Machine or two Machines, refer to [Redundancy by default on first deploy](/docs/reference/app-availability/#redundancy-by-default-on-first-deploy).
 

--- a/apps/launch.html.markerb
+++ b/apps/launch.html.markerb
@@ -8,7 +8,7 @@ order: 10
 
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-With Fly Launch, you can create a brand new app on Fly.io by running this command from the root directory of your project:
+With Fly Launch, you can create a brand new app on Fly.io by running this command from the source directory of your project:
 
 ```cmd
 fly launch
@@ -51,7 +51,7 @@ You can nudge `fly launch` to better suit your project.
 
 ### Choose how the Docker image is built
 
-Tell `fly launch` how you want to get the Docker image for your app, using either the `--image` or `--dockerfile` option, or by catching the Dockerfile launch scanner's attention with the presence of a [Dockerfile](/docs/languages-and-frameworks/dockerfile/) in your app's root directory. The Dockerfile scanner doesn't do a lot of configuration, but it prevents other scanners from taking over.
+Tell `fly launch` how you want to get the Docker image for your app, using either the `--image` or `--dockerfile` option, or by catching the Dockerfile launch scanner's attention with the presence of a [Dockerfile](/docs/languages-and-frameworks/dockerfile/) in your project source directory. The Dockerfile scanner doesn't do a lot of configuration, but it prevents other scanners from taking over.
 
 The actual Docker image build (or image pull) for a Fly App takes place during deployment. `fly launch` sets the stage by recording how to build, or get, the image, and both the first and all later deploys use that information.
 

--- a/apps/migrate-to-v2.html.markerb
+++ b/apps/migrate-to-v2.html.markerb
@@ -206,7 +206,7 @@ Fly Launch allows you to manage Fly Machines with app-wide configuration and coo
 
 Thus, migrating an older "Machines" Fly App to Fly Launch is fairly straightforward **if all the Machines belonging to the app are running the same image with the same configuration.**
 
-From your project's root directory (where you'll be deploying it from, and where `fly.toml` should live):
+From your project's source directory (where you'll be deploying it from, and where `fly.toml` should live):
 
 ```
 $ fly config save -a appname # to get a fly.toml from a machine's config


### PR DESCRIPTION
This PR replaces "the app's root" with "project source directory" in a few key places where it might confuse some users. Plus a few other minor fixes to the Github actions doc.