### PR TITLE
`_instances.internal` reports only running instances

### DIFF
--- a/reference/private-networking.html.md
+++ b/reference/private-networking.html.md
@@ -95,7 +95,7 @@ Finally, You can discover all the apps in the organization by requesting the TXT
 |`_apps.internal`|none|names of all 6PN<br/> private networking apps<br/> in the same organization|
 |`_peer.internal`|none|names of all wireguard peers|
 |`<peername>._peer.internal`|IPv6 of peer|none|
-|`_instances.internal`|none|all addresses, apps, regions, and instances<br>comma separated|
+|`_instances.internal`|none|IDs, apps, addresses, and regions<br>of all running instances<br>comma separated|
 |`<value>.<key>.kv._metadata.<appname>.internal`|IPv6 of machines with matching [metadata](https://community.fly.io/t/dynamic-machine-metadata/13115)|none|
 
 Examples of retrieving this information are in the [fly-examples/privatenet](https://github.com/fly-apps/privatenet) repository.


### PR DESCRIPTION
Adjust the wording so that this is clear. The current wording suggests that even stopped instances should be included. See [the community forum](https://community.fly.io/t/txt-instances-internal-seemingly-not-containing-all-apps/14924).