### PR TITLE
Update exporting-logs.html.md to fix env var name

### DIFF
--- a/going-to-production/monitoring/exporting-logs.html.md
+++ b/going-to-production/monitoring/exporting-logs.html.md
@@ -38,7 +38,7 @@ fly launch --no-deploy --image ghcr.io/superfly/fly-log-shipper:latest
 # determines which "sinks" are configured
 fly secrets set ORG=personal
 fly secrets set ACCESS_TOKEN=$(fly auth token)
-fly secrets set LOGTAIL_TOKEN=<token provided by logtail source>
+fly secrets set BETTER_STACK_SOURCE_TOKEN=<token provided by logtail source>
 ```
 
 You can configure as many providers as you'd like by adding more secrets. The secrets needed are determined by [which provider(s)](https://github.com/superfly/fly-log-shipper#provider-configuration) you want to use.


### PR DESCRIPTION
Replaces LOGTAIL_TOKEN env variable by BETTER_STACK_SOURCE_TOKEN, since that is the current name used by http://logs.betterstack.com and it's explicitly informed in https://github.com/superfly/fly-log-shipper