### PR TITLE
Add region command  + more links to region info

### DIFF
--- a/apps/processes.html.markerb
+++ b/apps/processes.html.markerb
@@ -75,7 +75,7 @@ You can scale the number of Machines (up or down) per process group with the `fl
 fly scale count web=8 cron=2
 ```
 
-You can scale by region with the `--region` option. Specify multiple regions and the Machines will be distributed as evenly as possible between them. The following command would create 2 Machines in `gru` and 2 Machines in `bog`:
+You can scale by [region](/docs/reference/regions/) with the `--region` option. Specify multiple regions and the Machines will be distributed as evenly as possible between them. The following command would create 2 Machines in `gru` and 2 Machines in `bog`:
 
 ```cmd
 fly scale count web=4 --region gru,bog
@@ -85,7 +85,7 @@ fly scale count web=4 --region gru,bog
 
 You can also use the `fly machine clone` and `fly machine destroy` commands to scale the number of Machines individually within a process group. When you clone a Machine that belongs to a process group, the new Machine is created with the command, services, and checks that are configured on the app for that process.
 
-You can add a region to your app by cloning a Machine into a new region.
+You can add a [region](/docs/reference/regions/) to your app by cloning a Machine into a new region.
 
 First, run `fly status` to get a list of Machines with IDs and process groups. 
 

--- a/apps/scale-count.html.markerb
+++ b/apps/scale-count.html.markerb
@@ -27,7 +27,7 @@ You can also adjust the capacity of the app by starting and stopping its Machine
 
 ## View the app's current scale 
 
-`fly scale show` outputs all the scale information about an app's Machines: how many Machines of each VM specification, in each of the app's process groups, in each region.
+`fly scale show` outputs all the scale information about an app's Machines: how many Machines of each VM specification, in each of the app's process groups, in each [region](/docs/reference/regions/).
 
 Here's an example to illustrate that:
 

--- a/apps/volume-storage.html.markerb
+++ b/apps/volume-storage.html.markerb
@@ -34,7 +34,9 @@ Your app is ready! Deploy with `flyctl deploy`
 
 ### Configure the app to mount the new volume
 
-Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the Machine and the volume during the deploy process. The following configuration exposes data from a volume named `myapp_data` under the `/data` directory in the Machine's file system.
+Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the Machine and the volume during the deploy process. 
+
+The following example configuration exposes data from a volume named `myapp_data` under the `/data` directory in the Machine's file system:
 
 ```toml
 [mounts]
@@ -48,12 +50,13 @@ Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in
 fly deploy 
 ```
 
-On the first deployment, you'll get one Machine. You can confirm this with `fly status`.
+On the first deployment, you'll get one Machine. Confirm this with `fly status`:
 
 ```cmd
 fly status
 ```
 
+Example output:
 ```out
 App
   Name     = myapp
@@ -71,15 +74,19 @@ app    	5683606c41098e	1      	lhr   	started	1 total	2023-04-26T20:40:48Z
 
 You can check on all the volumes in your app using `fly volumes list`. The `ATTACHED VM` column lets you know which Machine, if any, the volume is mounted on.
 
+List the volumes:
+
 ```cmd
 fly volumes list
 ```
+
+Example output:
 ```out
 ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
 vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
 ```
 
-You can also see the volume in the Machine's file system (there's only one Machine so far):
+You can also see the volume in the Machine's file system (there's only one Machine so far). For example:
 ```cmd
 fly ssh console -s -C df
 ```
@@ -107,6 +114,9 @@ Check what that did:
 ```cmd
 fly volumes list
 ```
+
+Example output:
+
 ```
 ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT     
 vol_ez1nvxkwl3jrmxl7    created data    1GB     lhr     4de2    true            91851edb6ee983  39 seconds ago
@@ -127,7 +137,9 @@ You can add a volume, or volumes, to an existing app by adding `[mounts]` to the
 
 ### Configure the app to mount the new volume
 
-Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml`. The following example configures the app to expose data from a volume named `myapp_data` under the `/data` directory of the application.
+Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in the app's `fly.toml`. The `fly deploy` command you'll run in the next step will create the Machine and the volume during the deploy process. 
+
+The following example configuration exposes data from a volume named `myapp_data` under the `/data` directory in the Machine's file system:
 
 ```toml
 [mounts]
@@ -137,14 +149,16 @@ Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in
 
 ### Create the volume
 
-Create the volume (or volumes) in the same regions as your app's Machines. Run `fly status` to check the regions of the Machines.
+Create the volumes in the same [regions](/docs/reference/regions/) as your app's Machines. Run `fly status` to check the regions of the Machines.
+
+For example:
 
 ```cmd
 fly volumes create myapp_data -r lhr
 ```
 
 <div class="callout">
-You need to create as many volumes as you have Machines per process in your app. New apps deployed using the `fly launch` command might have two Machines in the `app` process by default.
+You need to create as many volumes as you have Machines per process in your app. Apps deployed using the `fly launch` command have two Machines in the `app` process by default.
 </div>
 
 If you configure [mounts] in `fly.toml` and then run `fly deploy` without first creating enough volumes, then you'll get an error similar to this one:
@@ -162,11 +176,14 @@ The error indicates that the app needs one more volume in the `lhr` region.
 fly deploy 
 ```
 
-Run `fly volumes list` to verify that your volumes now have `ATTACHED VM` populated.
+Run `fly volumes list` to verify that your volumes now have `ATTACHED VM` populated:
 
 ```cmd
 fly volumes list
 ```
+
+Example output:
+
 ```out
 ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
 vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago
@@ -178,18 +195,18 @@ If you're not using the `fly.toml` with `fly deploy` workflow for some Machines,
 
 ### Create the volume
 
-Create the volume in the same region as your app.
+Create the volume in the [region](/docs/reference/regions/) where you want to clone a Machine:
 
 ```cmd
-fly volumes create myapp_data -r lhr
+fly volumes create <volume name> -r <region code>
 ```
 
 ### Clone the Machine
 
-Clone one of your app's Machines (with no volume) and attach the volume you just created:
+Clone one of your app's Machines (with no volume) and attach the volume you just created
 
 ```
-fly machine clone <machine-id> --attach-volume <vol-id>:<destination-mount-path>
+fly machine clone <machine-id> -r <region code> --attach-volume <vol-id>:<destination-mount-path>
 ```
 
 `destination-mount-path` is the directory where the volume should be mounted on the file system.
@@ -197,13 +214,14 @@ fly machine clone <machine-id> --attach-volume <vol-id>:<destination-mount-path>
 For example:
 
 ```cmd
-fly machine clone 148eddeef09789 --attach-volume vol_8l524yj0ko347zmp:/data
+fly machine clone 148eddeef09789 -r yyz --attach-volume vol_8l524yj0ko347zmp:/data
 ```
 
 ### Destroy the Machine used to create the clone
 
+Destroy the Machine:
 ```cmd
-fly machine destroy 148eddeef09789
+fly machine destroy <machine id>
 ```
 
 Run `fly volumes list` to verify that the volume you just created has the newly-cloned Machine's ID listed under `ATTACHED VM`.
@@ -211,6 +229,9 @@ Run `fly volumes list` to verify that the volume you just created has the newly-
 ```cmd
 fly volumes list
 ```
+
+Example output:
+
 ```out
 ID                      STATE   NAME    SIZE    REGION  ZONE    ENCRYPTED       ATTACHED VM     CREATED AT    
 vol_8l524yj0ko347zmp    created data    1GB     lhr     b6a7    true            5683606c41098e  3 minutes ago

--- a/apps/volume-storage.html.markerb
+++ b/apps/volume-storage.html.markerb
@@ -137,7 +137,7 @@ Add a [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) in
 
 ### Create the volume
 
-Create the volume (or volumes) in the same region as your app.
+Create the volume (or volumes) in the same regions as your app's Machines. Run `fly status` to check the regions of the Machines.
 
 ```cmd
 fly volumes create myapp_data -r lhr

--- a/elixir/the-basics/clustering.html.md
+++ b/elixir/the-basics/clustering.html.md
@@ -146,7 +146,7 @@ I included the IEx prompt because it shows the IP address of the node I'm connec
 
 ### Scaling to multiple regions
 
-Fly.io makes it super easy to run VMs of your applications physically closer to your users. Through the magic of DNS, users are directed to the nearest region where your application is located. You can read about [regions](/docs/reference/regions/#welcome-message) here and see the list of regions to choose from.
+Fly.io makes it super easy to run VMs of your applications physically closer to your users. Through the magic of DNS, users are directed to the nearest [region](/docs/reference/regions/) where your application is located.
 
 Starting back from our baseline of a single VM running in `sea` which is Seattle, Washington (US), I'll add the region `ewr` which is Parsippany, NJ (US). I can do this by cloning the existing Fly Machine into my desired region:
 

--- a/hands-on/launch-app.html.markerb
+++ b/hands-on/launch-app.html.markerb
@@ -37,7 +37,7 @@ Here you can enter the name of the app. App names can include only numbers, lowe
     If you didn't add another organization to your account, the `personal` organization is selected automatically.  
 </div>
 
-Next, you'll be prompted to select a region to deploy in.
+Next, you'll be prompted to select a [region](/docs/reference/regions/) to deploy in.
 
 ```output
 ? Choose a region for deployment: Chicago, Illinois (US) (ord)

--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -7,6 +7,10 @@ nav: firecracker
 
 Fly.io runs applications physically close to users: in datacenters around the world, on servers we run ourselves. You can currently deploy your apps in 34 regions, connected to a global Anycast network that makes sure your users hit our nearest server, whether they’re in Tokyo, São Paolo, or Frankfurt.
 
+<div class="callout">
+Run <code>fly platforms regions</code> to get a list of regions.
+</div>
+
 <img style="border-radius: 0.75rem;" src="/docs/images/fly-region-map.webp" alt="Map showing the Fly.io balloon in 34 locations across a world map"/>
 
 ## Fly.io Regions
@@ -59,6 +63,6 @@ You can see the list of Fly.io regions any time with [`fly platform regions`](ht
 
 You can see which regions your app is running in with [`fly status`](https://fly.io/docs/flyctl/status/).
 
-Fly.io [storage volumes](/docs/reference/volumes/) are tied to the region they're created in.
+[Fly volumes](/docs/reference/volumes/) and [Fly Machines](/docs/machines/) are tied to the region they're created in.
 
 When an application instance is started, the three-letter name for the region it's running in is stored in the VM's `FLY_REGION`  environment variable. This, along with other [Runtime Environment](/docs/reference/runtime-environment/) information, is visible to your app running on that instance.

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -56,7 +56,7 @@ This section is a reference for working with volumes using the [`fly volumes`](/
 
 Create a volume for an app using `fly volumes create`. The default volume size is 3GB. The maximum size is 500GB. Refer to [`fly volumes create`](/docs/flyctl/volumes-create/) in the [flyctl reference](/docs/flyctl) for usage and options.
 
-The following example command creates a new volume named "myapp_data" with 1GB of storage in the yyz (Toronto) region, for the application whose `fly.toml` file is in the working directory. To specify a different app, use the `-a` or `--app` flag.
+The following example command creates a new volume named "myapp_data" with 1GB of storage in the yyz (Toronto) [region](/docs/reference/regions/), for the application whose `fly.toml` file is in the working directory. To specify a different app, use the `-a` or `--app` flag.
 
 ```cmd
 fly volumes create myapp_data --region yyz --size 1


### PR DESCRIPTION
Add the `fly platform regions` command to the top of the region page.
Add more links to region info wherever the `-r` or `--region` flags are used, or sometimes for the first mention of regions.