### PR TITLE
Add exec option to experimental config section of fly.toml

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -716,3 +716,7 @@ This overrides the `CMD` set by the Dockerfile. It should be specified as an arr
 ### `entrypoint`
 
 This overrides the `ENTRYPOINT` set by the Dockerfile. It should be specified as an array of strings, as seen in the example above.
+
+### `exec`
+
+This overrides both the `CMD` and the `ENTRYPOINT` set by the Dockerfile. It should be specified as an array of strings, as seen in the example above.


### PR DESCRIPTION
The exec option is available in V2 and now it's in the docs. 

Suggested by: https://github.com/superfly/docs/pull/829