### PR TITLE
Adapt to deprecations in superfly/flyctl#2733

### DIFF
--- a/app-guides/planetscale.html.markerb
+++ b/app-guides/planetscale.html.markerb
@@ -306,7 +306,7 @@ If you try deploying the app to Fly and that fails, the most _likely_ reason is 
 
 ## View your application on Fly
 
-Use `fly open` as a shortcut to open the app's URL in your browser.
+Use `fly apps open` as a shortcut to open the app's URL in your browser.
 
 Use `fly logs` to see its log files.
 
@@ -336,7 +336,7 @@ abcdefgh	app    	1     	lhr   	run    	running	2 total, 2 passing	0       	0h1m 
 
 To avoid charges you might want to delete the app and the PlanetScale database:
 
-- To delete the sample Fly app (this is irreversible), run `fly destroy the-app-name-here`
+- To delete the sample Fly app (this is irreversible), run `fly apps destroy the-app-name-here`
 - To delete the PlanetScale database, click the red delete button within the database's _Settings_ tab:
 
 ![Screenshot](/docs/images/planetscale_misc_delete.webp)

--- a/apps/delete.html.markerb
+++ b/apps/delete.html.markerb
@@ -6,7 +6,7 @@ nav: firecracker
 order: 110
 ---
 
-You can scale an App right down to zero Machines if you like. But if you're done with an App forever, you can delete it using `fly destroy <app-name>`. 
+You can scale an App right down to zero Machines if you like. But if you're done with an App forever, you can delete it using `fly apps destroy <app-name>`. 
 
 Once you destroy an App, you can no longer access any part of it, and you'll no longer be charged for any part of it either. This includes Machines, Volumes, IP addresses, Secrets, Docker images, and so on. 
 

--- a/apps/scale-count.html.markerb
+++ b/apps/scale-count.html.markerb
@@ -324,4 +324,4 @@ If a Machine is misbehaving (for instance, it's not `stop`ping successfully), yo
 fly machine destroy --force 0e286039f42e86
 ```
 
-<div class="callout"> If you `destroy` a Machine, any volume that it had been using still exists until you either `fly volumes delete` it or `fly destroy` the Fly App it belongs to.</div>
+<div class="callout"> If you `destroy` a Machine, any volume that it had been using still exists until you either `fly volumes delete` it or `fly apps destroy` the Fly App it belongs to.</div>

--- a/apps/scale-count.html.markerb
+++ b/apps/scale-count.html.markerb
@@ -324,4 +324,4 @@ If a Machine is misbehaving (for instance, it's not `stop`ping successfully), yo
 fly machine destroy --force 0e286039f42e86
 ```
 
-<div class="callout"> If you `destroy` a Machine, any volume that it had been using still exists until you either `fly volumes delete` it or `fly apps destroy` the Fly App it belongs to.</div>
+<div class="callout"> If you destroy a Machine with a volume attached, the volume remains intact until you either explicitly destroy the volume or destroy the Fly App it belongs to.</div>

--- a/django/getting-started/existing.html.md
+++ b/django/getting-started/existing.html.md
@@ -109,7 +109,7 @@ fly deploy
 This will take a few seconds as it uploads your application, verifies the app configuration, builds the image, and then monitors to ensure it starts successfully. Once complete, visit your app with the following command:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 If everything went as planned you will see your Django application homepage.

--- a/django/getting-started/index.html.md
+++ b/django/getting-started/index.html.md
@@ -253,7 +253,7 @@ fly deploy
 This will take a few seconds as it uploads your application, verifies the app configuration, builds the image, and then monitors to ensure it starts successfully. Once complete visit your app with the following command:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 YAY! You are up and running! Wasn't that easy?

--- a/elixir/getting-started/existing.html.markerb
+++ b/elixir/getting-started/existing.html.markerb
@@ -29,7 +29,7 @@ deploys the images, and then monitors to ensure it starts successfully. Once com
 visit your app with the following command:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 If all went well, you'll see your Elixir application homepage.

--- a/elixir/getting-started/index.html.markerb
+++ b/elixir/getting-started/index.html.markerb
@@ -99,7 +99,7 @@ fly logs
 If everything looks good, open your app on Fly.io!
 
 ```cmd
-fly open
+fly apps open
 ```
 
 ### Important IPv6 settings

--- a/elixir/getting-started/legacy.html.markerb
+++ b/elixir/getting-started/legacy.html.markerb
@@ -349,10 +349,10 @@ f617e72a 3       sea    run     running 1 total, 1 passing 0        1m34s ago
 
 ## _Connecting to the App_
 
-The quickest way to browse your newly deployed application is with the `fly open` command.
+The quickest way to browse your newly deployed application is with the `fly apps open` command.
 
 ```cmd
-fly open
+fly apps open
 ```
 ```output
 Opening https://fly-elixir.fly.dev/

--- a/elixir/getting-started/migrate-from-heroku.html.markerb
+++ b/elixir/getting-started/migrate-from-heroku.html.markerb
@@ -25,7 +25,7 @@ From the root of the Elixir app you're running on Heroku, run `fly launch` and s
 When that's done, view your app in a browser:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 There's still work to be done to move more Heroku stuff over, so don't worry if the app doesn't boot right away. There's a few commands that you'll find useful to configure your environment:
@@ -89,7 +89,7 @@ fly secrets unset HEROKU_DATABASE_URL
 Then launch your Heroku app to see if its running.
 
 ```
-fly open
+fly apps open
 ```
 
 If you have a Redis server, there's a good chance you need to set that up.

--- a/flyctl/index.html.md
+++ b/flyctl/index.html.md
@@ -20,7 +20,7 @@ If you are doing anything with Fly.io, you'll need it. We have [flyctl installat
 * Create An App: [fly launch](/docs/flyctl/launch/)
 * Deploy An App: [fly deploy](/docs/flyctl/deploy/)
 * Manage App Secrets: [fly secrets](/docs/flyctl/secrets/)
-* View your App: [fly open](/docs/flyctl/open/)
+* View your App: [fly apps open](/docs/flyctl/open/)
 
 ## Viewing and Monitoring an App
 

--- a/hands-on/open-app.html.markerb
+++ b/hands-on/open-app.html.markerb
@@ -7,12 +7,12 @@ toc: false
 redirect_from: /docs/hands-on/connecting-to-an-app/
 ---
 
-The quickest way to connect to your deployed app is with the `fly open` command, which opens a browser on the http version of the site. That http connection will automatically be upgraded to an https secured connection (when using the fly.dev domain) to connect to it securely. 
+The quickest way to connect to your deployed app is with the `fly apps open` command, which opens a browser on the http version of the site. That http connection will automatically be upgraded to an https secured connection (when using the fly.dev domain) to connect to it securely. 
 
-For fun, add `/<your-name>` to `fly open` and your name will be appended to the app's path to add an extra greeting from the hellofly application.
+For fun, add `/<your-name>` to `fly apps open` and your name will be appended to the app's path to add an extra greeting from the hellofly application.
 
 ```cmd
-fly open /fred
+fly apps open /fred
 ```
 ```out
 Opening http://hellofly.fly.dev/fred

--- a/js/frameworks/deno.html.markerb
+++ b/js/frameworks/deno.html.markerb
@@ -139,7 +139,7 @@ ID       VERSION REGION DESIRED STATUS  HEALTH CHECKS      RESTARTS CREATED
 
 ## _Connecting to the App_
 
-The quickest way to view your application is to run `fly open` which will open your browser on the URL for your application. Run `fly open /name` to get an extra greeting from the app.
+The quickest way to view your application is to run `fly apps open` which will open your browser on the URL for your application. Run `fly apps open /name` to get an extra greeting from the app.
 
 If you want to manually enter a URL to check, remember to replace `empty-sea-2541.fly.dev` with the hostname you got from `fly status` and connect to `http://hellodeno.fly.dev/` where you should find a greeting - it will normally be upgraded to a secure connection. Use `https://hellodeno.fly.dev` to start with a secure connection. Add `/name` and you'll get an extra greeting from the hellodeno application.
 

--- a/js/frameworks/partials/_launched.html.erb
+++ b/js/frameworks/partials/_launched.html.erb
@@ -1,4 +1,4 @@
-That's it! Run `fly open` to see your deployed app in action.
+That's it! Run `fly apps open` to see your deployed app in action.
 
 Try a few other commands:
 

--- a/languages-and-frameworks/dockerfile.html.markerb
+++ b/languages-and-frameworks/dockerfile.html.markerb
@@ -98,7 +98,7 @@ By default, `fly deploy` builds the image using a remote builder. If you have Do
 
 ## _Open Your App_
 
-Run `fly open` to open your deployed app in a browser.
+Run `fly apps open` to open your deployed app in a browser.
 
 You're off and running!
 

--- a/languages-and-frameworks/dotnet.html.markerb
+++ b/languages-and-frameworks/dotnet.html.markerb
@@ -76,7 +76,7 @@ Deploying hellodotnet
 ...
 ```
 
-That's it! Run `fly open` to see your deployed app in action.
+That's it! Run `fly apps open` to see your deployed app in action.
 
 Try a few other commands:
 

--- a/languages-and-frameworks/partials/_launch_with_postgres.html.erb
+++ b/languages-and-frameworks/partials/_launch_with_postgres.html.erb
@@ -57,7 +57,7 @@ Remote builder fly-builder-little-glitter-8329 ready
 
 ```
 
-That's it! Run `fly open` to see your deployed app in action.
+That's it! Run `fly apps open` to see your deployed app in action.
 
 Try a few other commands:
 

--- a/languages-and-frameworks/partials/_launched.html.erb
+++ b/languages-and-frameworks/partials/_launched.html.erb
@@ -1,4 +1,4 @@
-That's it! Run `fly open` to see your deployed app in action.
+That's it! Run `fly apps open` to see your deployed app in action.
 
 Try a few other commands:
 

--- a/languages-and-frameworks/python.html.markerb
+++ b/languages-and-frameworks/python.html.markerb
@@ -299,7 +299,7 @@ This will lookup our `fly.toml` file, and get the app name `hello-fly-flask` fro
 Once complete, visit your app with the following command:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 ### View the Deployed App
@@ -327,12 +327,12 @@ The application has been assigned with a DNS hostname of `hello-fly-flask.fly.de
 
 ### Connecting to the App
 
-The quickest way to connect to your deployed app is with the `fly open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain).
+The quickest way to connect to your deployed app is with the `fly apps open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain).
 
-To specify a path, add `/name` to `fly open` and it'll be appended to the URL as the path and you'll get an extra greeting from the `hello-fly-flask` app:
+To specify a path, add `/name` to `fly apps open` and it'll be appended to the URL as the path and you'll get an extra greeting from the `hello-fly-flask` app:
 
 ```cmd
-fly open /fly
+fly apps open /fly
 ```
 
 Congrats! You have successfully built, deployed, and connected to your first Flask application on Fly.io.

--- a/languages-and-frameworks/ruby.html.markerb
+++ b/languages-and-frameworks/ruby.html.markerb
@@ -168,7 +168,7 @@ This will lookup our `fly.toml` file, and get the app name from there. Then `fly
 The quickest way to browse your newly deployed application is with the `flyctl open` command.
 
 ```cmd
-fly open
+fly apps open
 ```
 ```output
 Opening http://helloruby.fly.dev/

--- a/machines/guides-examples/machines-app-using-flyctl.html.markerb
+++ b/machines/guides-examples/machines-app-using-flyctl.html.markerb
@@ -102,7 +102,7 @@ Machine started, you can connect via the following private ip
 I can check on my app!
 
 ```
-fly open -a testrun
+fly apps open -a testrun
 ```
 
 …and, I get nothing. (Note that I'm appending `-a` to most of my flyctl commands, because we're not using a `fly.toml` for configuration, and a `fly.toml` in the working directory is where flyctl usually gets the app name that it thinks you're implying when you don't specify one.)
@@ -219,7 +219,7 @@ https://fly.io/apps/testrun/machines/21781160b41d89
 
 The VM is restarted with the updated configuration.
 
-Now I try `fly open -a testrun` again, and voilà:
+Now I try `fly apps open -a testrun` again, and voilà:
 
 ![The web app running in the browser. It says 'Hello from a Flask app on Fly.io; Or goodbye'. The word 'goodbye' is a hyperlink.](images/testrun-hello.webp)
 

--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -55,13 +55,7 @@
         <%= flyctl_nav_link "Deploy an App", "/docs/flyctl/deploy/" %>
       </li>
       <li>
-        <%= flyctl_nav_link "Delete an App", "/docs/flyctl/apps-destroy/" %>
-      </li>
-      <li>
         <%= flyctl_nav_link "View Fly docs", "/docs/flyctl/docs/" %>
-      </li>
-      <li>
-        <%= flyctl_nav_link "View Fly Launch release history", "/docs/flyctl/apps-releases/" %>
       </li>
       <li>
         <%= flyctl_nav_link "View or update App image", "/docs/flyctl/image/" %>
@@ -74,12 +68,6 @@
       </li>
       <li>
         <%= flyctl_nav_link "Monitor deployments", "/docs/flyctl/monitor/" %>
-      </li>
-      <li>
-        <%= flyctl_nav_link "Move an App", "/docs/flyctl/apps-move/" %>
-      </li>
-      <li>
-        <%= flyctl_nav_link "Visit App with browser", "/docs/flyctl/apps-open/" %>
       </li>
       <li>
         <%= flyctl_nav_link "Manage Organizations", "/docs/flyctl/orgs/" %>
@@ -130,7 +118,7 @@
         <%= flyctl_nav_link "Create a token", "/docs/flyctl/tokens/" %>
       </li>
       <li>
-        <%= flyctl_nav_link "About Flyctl versions", "/docs/flyctl/version/" %>
+        <%= flyctl_nav_link "Check flyctl version", "/docs/flyctl/version/" %>
       </li>
       <li>
         <%= flyctl_nav_link "Manage VM instances", "/docs/flyctl/vm/" %>

--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -55,13 +55,13 @@
         <%= flyctl_nav_link "Deploy an App", "/docs/flyctl/deploy/" %>
       </li>
       <li>
-        <%= flyctl_nav_link "Delete an App", "/docs/flyctl/destroy/" %>
+        <%= flyctl_nav_link "Delete an App", "/docs/flyctl/apps-destroy/" %>
       </li>
       <li>
         <%= flyctl_nav_link "View Fly docs", "/docs/flyctl/docs/" %>
       </li>
       <li>
-        <%= flyctl_nav_link "View App history", "/docs/flyctl/history/" %>
+        <%= flyctl_nav_link "View Fly Launch release history", "/docs/flyctl/apps-releases/" %>
       </li>
       <li>
         <%= flyctl_nav_link "View or update App image", "/docs/flyctl/image/" %>
@@ -76,10 +76,10 @@
         <%= flyctl_nav_link "Monitor deployments", "/docs/flyctl/monitor/" %>
       </li>
       <li>
-        <%= flyctl_nav_link "Move an App", "/docs/flyctl/move/" %>
+        <%= flyctl_nav_link "Move an App", "/docs/flyctl/apps-move/" %>
       </li>
       <li>
-        <%= flyctl_nav_link "View App with browser", "/docs/flyctl/open/" %>
+        <%= flyctl_nav_link "Visit App with browser", "/docs/flyctl/apps-open/" %>
       </li>
       <li>
         <%= flyctl_nav_link "Manage Organizations", "/docs/flyctl/orgs/" %>

--- a/rails/advanced-guides/litefs.html.md
+++ b/rails/advanced-guides/litefs.html.md
@@ -47,7 +47,7 @@ Now we can deploy normally:
 fly deploy
 ```
 
-Once the application has been deployed, running `fly open` will open a
+Once the application has been deployed, running `fly apps open` will open a
 browser. Add one name.
 
 Return back to your terminal window and run:

--- a/rails/advanced-guides/machine.html.md
+++ b/rails/advanced-guides/machine.html.md
@@ -64,7 +64,7 @@ bin/rails deploy
 You have now successfully deployed a trivial Rails app Fly.io machines platform.
 
 You can verify that this is running on the machines platform via `fly status`.
-You can also run commands like `fly open` to bring your application up in the
+You can also run commands like `fly apps open` to bring your application up in the
 browser.
 
 Now lets make that application launch more machines.
@@ -251,7 +251,7 @@ Now deploy the application:
 bin/rails deploy
 ```
 
-If you run `fly open` you will arrive at your application's welcome page.
+If you run `fly apps open` you will arrive at your application's welcome page.
 Take a note of the URL.  Either in the browser or in a command window add
 `/job/start`.  As a response (either in your browser or terminal window
 you will see something like:

--- a/rails/advanced-guides/phusion-passenger.html.md
+++ b/rails/advanced-guides/phusion-passenger.html.md
@@ -141,7 +141,7 @@ exit 0
 ## Deployment
 
 That's it.  As always you deploy your application via `fly deploy` and
-can open it via `fly open`.  Everything else remains the same.  You
+can open it via `fly apps open`.  Everything else remains the same.  You
 can use your same Postgre database, redis data store, and any other
 secrets you may have set.
 

--- a/rails/advanced-guides/terraform.html.md
+++ b/rails/advanced-guides/terraform.html.md
@@ -82,7 +82,7 @@ rerun `terraform` commands directly.  You can even `terraform destroy` and
 `rm terraform.tfstate` and start over.  What's important is `main.tf` already
 reflects the name of the latest image.
 
-Also, because a `fly.toml` file was generated, you can use commands like `fly open`,
+Also, because a `fly.toml` file was generated, you can use commands like `fly apps open`,
 `fly ssh console` and `fly logs`.
 
 ## Open issues

--- a/rails/getting-started/existing.html.md
+++ b/rails/getting-started/existing.html.md
@@ -72,7 +72,7 @@ deploys the images, and then monitors to ensure it starts successfully. Once com
 visit your app with the following command:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 If all went well, you'll see your Rails application homepage.

--- a/rails/getting-started/fly-rails.html.md
+++ b/rails/getting-started/fly-rails.html.md
@@ -34,7 +34,7 @@ bin/rails fly:launch
 If the deployment is successful, you can view your app by running:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 You should see your application!

--- a/rails/getting-started/index.html.md
+++ b/rails/getting-started/index.html.md
@@ -134,7 +134,7 @@ deploys the images, and then monitors to ensure it starts successfully. Once com
 visit your app with the following command:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 That's it!  You are up and running!  Wasn't that easy?
@@ -203,7 +203,7 @@ you need to do is the following:
 
 ``` shell
 $ fly deploy
-$ fly open
+$ fly apps open
 ```
 
 Subsequent deploys are quicker than the first one as substantial portions of you
@@ -306,7 +306,7 @@ There is only one step left, and that is to modify `app/controllers/names_contro
 ### Deployment and testing
 
 By now it should be no surprise that deployment is as easy as `fly deploy` and
-`fly open`. Once that is done, copy the browser URL, open a second browser
+`fly apps open`. Once that is done, copy the browser URL, open a second browser
 window (it can even be a different browser or even on a different machine), and
 paste the URL into the new window.
 

--- a/rails/getting-started/migrate-from-heroku.html.md
+++ b/rails/getting-started/migrate-from-heroku.html.md
@@ -82,7 +82,7 @@ fly deploy
 When that's done, view your app in a browser:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 There's still work to be done to move more Heroku stuff over, so don't worry if the app doesn't boot right away. There's a few commands that you'll find useful to configure your environment:
@@ -151,7 +151,7 @@ fly secrets unset HEROKU_DATABASE_URL
 Then launch your Heroku app to see if its running.
 
 ```
-fly open
+fly apps open
 ```
 
 If you have a Redis server, there's a good chance you need to set that up.

--- a/rails/the-basics/deployments.html.md
+++ b/rails/the-basics/deployments.html.md
@@ -14,7 +14,7 @@ fly deploy
 When the application successfully deploys, you can quickly open it in the browser by running:
 
 ```cmd
-fly open
+fly apps open
 ```
 
 If all goes well, you should see a running application in your web browser. You can also view a history of deployments by running:

--- a/rails/the-basics/turbo-streams-and-action-cable.html.md
+++ b/rails/the-basics/turbo-streams-and-action-cable.html.md
@@ -120,7 +120,7 @@ There is only one step left, and that is to modify `app/controllers/names_contro
 ## Deployment and testing
 
 By now it should be no surprise that deployment is as easy as `fly deploy` and
-`fly open`. Once that is done, copy the browser URL, open a second browser
+`fly apps open`. Once that is done, copy the browser URL, open a second browser
 window (it can even be a different browser or even on a different machine), and
 paste the URL into the new window.
 

--- a/reference/fly-launch.html.md
+++ b/reference/fly-launch.html.md
@@ -230,7 +230,7 @@ I can [scale out](/docs/apps/scale-count/) by adding Machines in other regions i
 To check that my new web app is actually working, I run
 
 ```cmd
-fly open
+fly apps open
 ```
 
 to visit my app in the browser!

--- a/speedrun.html.markerb
+++ b/speedrun.html.markerb
@@ -29,7 +29,7 @@ Refer to [Launch a new app](/docs/apps/launch/) to learn more about what `fly la
 ## Next steps
 
 1. Run `fly status` - show the status of the application instances.
-2. Run `fly open` - open your browser and direct it to your app.
+2. Run `fly apps open` - open your browser and direct it to your app.
 
 
 If things don't go as smoothly as you'd like, visit our [community forum](https://community.fly.io) and get help.


### PR DESCRIPTION
This is a quick adaptation to recent flyctl changes (superfly/flyctl#2733). Replaces deprecated top-level commands with their `fly apps` equivalents in docs, and removes deprecated commands from the flyctl nav.