### PR TITLE
Expose Sentry docs in the nav

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -194,6 +194,9 @@
         <%= nav_link "Dynamic Request Routing", "/docs/reference/dynamic-request-routing/" %>
       </li>
       <li>
+        <%= nav_link "Sentry Error Tracking", "/docs/reference/sentry/" %>
+      </li>
+      <li>
         <%= nav_link "Fly Launch", "/docs/reference/fly-launch/" %>
       </li>
       <li>


### PR DESCRIPTION
Sentry is launching, so we're exposing the docs right before launch.