### PR TITLE
Escape backslashes

### DIFF
--- a/languages-and-frameworks/partials/_launch_with_postgres.html.erb
+++ b/languages-and-frameworks/partials/_launch_with_postgres.html.erb
@@ -3,7 +3,7 @@
 When we run `fly launch` from the newly-created project directory, the launcher will:
 
 * Ask you to select a deployment region
-* Set secrets required by <%= detected %> (`SECRET\_KEY\_BASE`, for example)
+* Set secrets required by <%= detected %> (`SECRET\\_KEY\\_BASE`, for example)
 * Run the <%= detected %> deployment setup task
 * Optionally setup a Postgres instance in your selected region
 * Deploy the application in your selected region
@@ -20,7 +20,7 @@ Detected a <%= detected %> app
 ? Select organization: flyio (flyio)
 ? Select region: mad (Madrid, Spain)
 Created app <%= app_name %> in organization soupedup
-Set secrets on <%= app_name %>: SECRET\_KEY\_BASE
+Set secrets on <%= app_name %>: SECRET\\_KEY\\_BASE
 Installing dependencies
 Running Docker release generator
 Wrote config file fly.toml
@@ -40,7 +40,7 @@ Monitoring Deployment
 
 Connect to postgres
 Any app within the flyio organization can connect to postgres using the above credentials and the hostname "<%= app_name %>-db.internal."
-For example: postgres\://postgres\:password@<%= app_name %>-db.internal\:5432
+For example: postgres\\://postgres\\:password@<%= app_name %>-db.internal\\:5432
 
 See the postgres docs for more information on next steps, managing postgres, connecting from outside fly:  https://fly.io/docs/reference/postgres/
 Postgres cluster <%= app_name %>-db is now attached to <%= app_name %>


### PR DESCRIPTION
Related to: #978 

The `app_name` also has backslashes, but didn't know how to change it.