### PR TITLE
Add redirect to Javascript docs

### DIFF
--- a/js/index.html.markerb
+++ b/js/index.html.markerb
@@ -3,7 +3,9 @@ title: JavaScript on Fly.io
 layout: framework_docs
 toc: false
 blog_path: /javascript-journal
-redirect_from: /docs/languages-and-frameworks/node/
+redirect_from: 
+  - /docs/languages-and-frameworks/node/
+  - /docs/getting-started/node/
 ---
 
 <div>


### PR DESCRIPTION
Sort of fixes https://github.com/superfly/docs/issues/975, so at least it doesn't 404.

We still need to figure out where "Try an Example" should link from the dashboard. 