### PR TITLE
Remove duplicate "Volumes" entry from the navbar

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -232,9 +232,6 @@
       <li>
         <%= nav_link "TLS Support", "/docs/reference/tls/" %>
       </li>
-      <li>
-        <%= nav_link "Volumes", "/docs/reference/volumes" %>
-      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
We also have it under https://fly.io/docs/database-storage-guides/. (where it belongs?)