### PR TITLE
No longer mention Hashicorp products as open-source

### DIFF
--- a/about/open-source.html.markerb
+++ b/about/open-source.html.markerb
@@ -10,7 +10,7 @@ nav: firecracker
 
 Fly builds on the work of a tremendous open source infrastructure community. We want open source authors to benefit from their work because we think a healthy, thriving open source ecosystem will help us build better products.
 
-Fly is, like many infrastructure platforms, an intricate system built on a number of commercial companies' open source projects.  We use Nomad, Consul and Vault from <a href="https://www.hashicorp.com/" target="_blank" rel="nofollow noopener">Hashicorp</a>. At the heart of our application execution is a variant of Amazon's <a href="https://github.com/firecracker-microvm/firecracker" target="_blank" rel="nofollow noopener">Firecracker</a>. Our monitoring and dashboards use <a href="https://prometheus.io/" target="_blank" rel="nofollow noopener">Prometheus</a> and <a href="https://grafana.com/" target="_blank" rel="nofollow noopener">Grafana</a>. We contribute to projects in a few different ways:
+Fly is, like many infrastructure platforms, an intricate system built on a number of commercial companies' open source projects. At the heart of our application execution is a variant of Amazon's <a href="https://github.com/firecracker-microvm/firecracker" target="_blank" rel="nofollow noopener">Firecracker</a>. Our monitoring and dashboards use <a href="https://prometheus.io/" target="_blank" rel="nofollow noopener">Prometheus</a> and <a href="https://grafana.com/" target="_blank" rel="nofollow noopener">Grafana</a>. We contribute to projects in a few different ways:
 
 ## Equity Grants
 


### PR DESCRIPTION
These products are now source-available instead of open-source.

The flow of the paragraph is changed by removing this sentence so perhaps it needs more work.