### PR TITLE
Custom metrics config per process group

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -636,12 +636,25 @@ Volumes can also be assigned to specific processes; use double brackets to inclu
 
 ## The `metrics` section
 
-Fly apps can be configured to export custom metrics to the Fly.io-hosted Prometheus service. Add this section to fly.toml.
+Fly apps can be configured to export custom metrics to the Fly.io-hosted Prometheus service.
 
 ```toml
 [metrics]
-port = 9091       # default for most prometheus clients
-path = "/metrics" # default for most prometheus clients
+  port = 9091
+  path = "/metrics" # default for most prometheus exporters
+```
+
+Custom metrics can be also configured for specific `processes`, using double brackets to define multiple `[[metrics]]` tables:
+```toml
+[[metrics]]
+  port = 9394
+  path = "/metrics"
+  processes = ["web"]
+
+[[metrics]]
+  port = 9113
+  path = "/metrics"
+  processes = ["proxy"]
 ```
 
 Check out [Metrics on Fly.io](/docs/reference/metrics/) for more information about collecting metrics for your apps.

--- a/reference/metrics.html.md
+++ b/reference/metrics.html.md
@@ -361,15 +361,27 @@ send the results to Prometheus.
 Add a `[metrics]` section to your application's `fly.toml`:
 
 ```toml
-app = "your-app-name"
-
 [metrics]
-port = 9091 # default for most prometheus clients
-path = "/metrics" # default for most prometheus clients
+port = 9091
+path = "/metrics" # default for most prometheus exporters
+```
+
+If your app uses [multiple processes](/docs/apps/processes/), you can add multiple `[[metrics]]` sections, each with its own set of `processes`:
+
+```toml
+[[metrics]]
+port = 9394
+path = "/metrics"
+processes = ["web"]
+
+[[metrics]]
+port = 9113
+path = "/metrics"
+processes = ["proxy"]
 ```
 
 ### Instrumentation
 
 Instrument your app and expose your metrics on `0.0.0.0`.
 
-There are many supported [client libraries](https://prometheus.io/docs/instrumenting/clientlibs/) as well as 3rd party libraries able to return Prometheus-formatted metrics.
+There are many supported [client libraries](https://prometheus.io/docs/instrumenting/clientlibs/) as well as off-the-shelf [exporters](https://prometheus.io/docs/instrumenting/exporters/) able to return Prometheus-formatted metrics.


### PR DESCRIPTION
superfly/flyctl#2825 adds support for `metrics` per process group.
Update documentation with examples of the updated syntax:

> Custom metrics can be also configured for specific `processes`, using double brackets to define multiple `[[metrics]]` tables:
> ```toml
> [[metrics]]
>   port = 9394
>   path = "/metrics"
>   processes = ["web"]
> 
> [[metrics]]
>   port = 9113
>   path = "/metrics"
>   processes = ["proxy"]
> ```