### PR TITLE
Update link to machine restart policy doc

### DIFF
--- a/apps/migrate-to-v2.html.markerb
+++ b/apps/migrate-to-v2.html.markerb
@@ -147,7 +147,7 @@ We recommend updating such Machines to use the `always` restart policy, to ensur
 fly machine update --restart always <machine-id>
 ```
 
-See [more about restart policies here](https://community.fly.io/t/issues-with-machines-restart-policy/11943/25).
+Learn more about [Machine restart policies](/docs/machines/guides-examples/machine-restart-policy/).
 
 
 ### Scale your deployed Machine(s)

--- a/machines/guides-examples/machine-restart-policy.html.markerb
+++ b/machines/guides-examples/machine-restart-policy.html.markerb
@@ -1,7 +1,6 @@
 ---
 title: Machine restart policy
 layout: framework_docs
-sitemap: false
 order: 35
 nav: firecracker
 ---


### PR DESCRIPTION
### Summary of changes

- update the link from the migrate to V2 page to the restart policy doc
- remove the front matter tag from the restart policy doc that excluded from the sitemap (oops) 

### Related GitHub and Fly.io community links
https://github.com/superfly/docs/pull/1043

### Notes
n/a
