### PR TITLE
fly.toml ref: add how to remove a Machine file

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -711,6 +711,14 @@ You can optionally restrict which Machine(s) contain the file using the [process
   processes = ["web"]
 ```
 
+To remove a previously configured file on the next deployment, set its source to an empty string. For example:
+
+```toml
+[[files]]
+  guest_path = "/path/to/config.yaml"
+  local_path = ""
+```
+
 ## The `experimental` section
 
 This section is for flags and feature settings which have yet to be promoted into the main configuration.


### PR DESCRIPTION
### Summary of changes
fly.toml ref: add how to remove a Machine file

### Related GitHub and Fly.io community links
https://community.fly.io/t/files-removed-from-fly-toml-persist-in-the-apps-vm-after-deploy/15582
https://github.com/superfly/flyctl/issues/2851

