### PR TITLE
Added the necessary url that points to the correct doc

### DIFF
--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -44,7 +44,7 @@ Learn more about using volumes:
 
 - How to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
 - How to configure the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` Fly Launch configuration file.
-- How to [scale an app with volumes attached](https://fly.io/docs/apps/scale-count/#scale-an-app-with-volumes)
+- How to [scale an app with volumes attached](/docs/apps/scale-count/#scale-an-app-with-volumes)
 
 ## Reference: Working with volumes using flyctl
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -44,7 +44,7 @@ Learn more about using volumes:
 
 - How to [add volume storage for your app](/docs/apps/volume-storage/), step-by-step.
 - How to configure the [`mounts` section](/docs/reference/configuration/#the-mounts-section) for volumes in the `fly.toml` Fly Launch configuration file.
-- How to [scale an app with volumes attached]()
+- How to [scale an app with volumes attached](https://fly.io/docs/apps/scale-count/#scale-an-app-with-volumes)
 
 ## Reference: Working with volumes using flyctl
 


### PR DESCRIPTION
### Summary of changes
Added the necessary url to the href that points to the correct doc. Located on this page-`/docs/reference/volumes/`
### Related GitHub and Fly.io community links
#1067

### Notes
n/a if none
