### PR TITLE
Update Github actions yml

### DIFF
--- a/app-guides/continuous-deployment-with-github-actions.html.md
+++ b/app-guides/continuous-deployment-with-github-actions.html.md
@@ -33,7 +33,7 @@ The first section is a speed-run through the steps to make the go-example app au
     on:
       push:
         branches:
-          - master
+          - main
     jobs:
       deploy:
         name: Deploy app


### PR DESCRIPTION
### Summary of changes
Updates the yaml for the example github action to use `main` instead of `master` as that is the most common branch name now and the one recommended by github


### Related GitHub and Fly.io community links
https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/

### Notes
n/a if none
