### PR TITLE
Specify in fly ips release command that you have to pass the address …

### DIFF
--- a/getting-started/app-services.html.md
+++ b/getting-started/app-services.html.md
@@ -53,7 +53,7 @@ To have Fly Proxy route requests to an app from the public internet, provision a
 
 #### Private (Flycast) apps
 
-To have Fly Proxy load-balance among VMs on a non-public app, [allocate a _private_ (Flycast) IPv6 address](/docs/reference/private-networking/#assigning-a-flycast-address) using `fly ips allocate-v6 --private`, and **remove any public IPs from the app** using `fly ips release`. A Flycast IP can only be reached from within the private network it's allocated on, which must belong to the same Fly Organization as the Fly App it points to. 
+To have Fly Proxy load-balance among VMs on a non-public app, [allocate a _private_ (Flycast) IPv6 address](/docs/reference/private-networking/#assigning-a-flycast-address) using `fly ips allocate-v6 --private`, and **remove any public IPs from the app** using `fly ips release <address>`. A Flycast IP can only be reached from within the private network it's allocated on, which must belong to the same Fly Organization as the Fly App it points to. 
 
 <section class="warning icon">
 If your configuration includes any services for Fly Proxy to route to, and the app has a public IP, that service is exposed to the whole internet.</section>

--- a/reference/services.html.markerb
+++ b/reference/services.html.markerb
@@ -37,7 +37,7 @@ If you want to allocate a shared IPv4 to an app without a public IPv4 address, t
 fly ips allocate-v4 --shared
 ```
 
-This command will fail if the app has a dedicated IPv4 address. You can release an IP with `fly ips release`.
+This command will fail if the app has a dedicated IPv4 address. You can release an IP with `fly ips release <address>`.
 
 ### Dedicated IPv4
 


### PR DESCRIPTION
…of the ip or it will fail

### Summary of changes
Specified where `fly ips release` was mentioned to include `<address>` at the end of the command, because if no address is passed in, the command fails
### Related GitHub and Fly.io community links
n/a if none

### Notes
n/a if none
