### PR TITLE
Fix smokescreen example url in smokescreen.html.erb

### DIFF
--- a/app-guides/smokescreen.html.erb
+++ b/app-guides/smokescreen.html.erb
@@ -4,7 +4,7 @@ layout: docs
 sitemap: false
 nav: firecracker
 author: dj
-source: https://github.com/fly-apps/smokescreen-example/
+source: https://github.com/fly-apps/smokescreen/
 categories:
   - proxy
   - security


### PR DESCRIPTION
### Summary of changes

Update incorrect url to example repo for using Smokescreen

### Related GitHub and Fly.io community links
n/a

### Notes
n/a
