### PR TITLE
Update the obsolete warning to use warning callout style

### DIFF
--- a/partials/_obsolete_doc.html.erb
+++ b/partials/_obsolete_doc.html.erb
@@ -1,1 +1,1 @@
-<aside class="callout"><strong>Warning: This document is old! It is likely wrong in some important way.</strong></aside>
+<aside class="warning icon"><strong>Warning: This document is old! It is likely wrong in some important way.</strong></aside>


### PR DESCRIPTION
### Summary of changes
- Apply the warning icon callout style to the "old document" notice partial. The rationale to use a warning is that we don't know what could happen since these old docs aren't tested.

### Related GitHub and Fly.io community links
n/a

### Notes
n/a
