### PR TITLE
Clean instances keyword from laravel storage page

### DIFF
--- a/laravel/the-basics/laravel-volume-storage.html.markerb
+++ b/laravel/the-basics/laravel-volume-storage.html.markerb
@@ -89,7 +89,7 @@ It's the default burrow for session, cache, and file data amongst others. If you
     - The condition statement checks if the app folder does not exist in the volumized storage folder. If it does not exist, it copies over the contents of the storage_ folder to the volumized storage folder.
 
 7. <b>Finally, deploy your Laravel Fly App!</b>
-
+ 
     ```cmd
     fly deploy
     ```

--- a/laravel/the-basics/laravel-volume-storage.html.markerb
+++ b/laravel/the-basics/laravel-volume-storage.html.markerb
@@ -95,7 +95,7 @@ It's the default burrow for session, cache, and file data amongst others. If you
     ```
 
 <div class="callout">
-Fly Volume instances do not automatically sync their data with each other. Please remember to create the appropriate data-replication logic if your Fly App will be using more than one volume instance, and if your app requires data available across the volume instances.
+Fly Volumes do not automatically sync their data with each other. Please remember to create the appropriate data-replication logic if your Fly App will be using more than one volume instance, and if your app requires data available across its Volumes.
 </div>
 
 #### **_Possible Errors_**

--- a/laravel/the-basics/laravel-volume-storage.html.markerb
+++ b/laravel/the-basics/laravel-volume-storage.html.markerb
@@ -96,7 +96,7 @@ It's the default burrow for session, cache, and file data amongst others. If you
 
 <div class="callout">
 Fly Volumes do not automatically sync their data with each other. Please remember to create the appropriate data-replication logic if your Fly App will be using more than one volume instance, and if your app requires data available across its Volumes.
-</div>
+</div> 
 
 #### **_Possible Errors_**
 


### PR DESCRIPTION
### Summary of changes
Removal of remaining mention of "instances" in the Laravel "Persisting the Storage Folder" page

### Related GitHub and Fly.io community links
n/a if none

### Notes
n/a if none
