### PR TITLE
Vale: Remove "for free" from cliche list

### DIFF
--- a/styles/proselint/Cliches.yml
+++ b/styles/proselint/Cliches.yml
@@ -248,7 +248,6 @@ tokens:
   - fly the coop
   - follow your heart
   - for all intents and purposes
-  # - for free
   - for the birds
   - for what it's worth
   - force of nature


### PR DESCRIPTION
### Summary of changes

Thought I had already done this by commenting it out, but `#` didn't work. 😭  Deleted it this time.

### Related GitHub and Fly.io community links
n/a

### Notes
n/a
