### PR TITLE
In Fly launch config page > build section > dockerfile, put the gotchas with this setup in a callout.

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -109,7 +109,10 @@ The image builder is used when you want to immediately deploy an existing public
 
 `dockerfile` accepts a relative path to a Dockerfile, or a URL. By default, `flyctl` looks for `Dockerfile` in the application root.
 
-**Gotchas:** 1) This option will not change the Docker context path, which is set to the project root directory by default. If you want the `Dockerfile` to use its containing directory as the context root, use `fly deploy <directory>`. 2) When specifying a local Dockerfile, make sure it's not excluded from the Docker build context in your `.dockerignore`.
+<div class="callout">
+- This option will not change the Docker context path, which is set to the project root directory by default. If you want the `Dockerfile` to use its containing directory as the context root, use `fly deploy <directory>`.
+- When specifying a local Dockerfile, make sure it's not excluded from the Docker build context in your `.dockerignore`.
+</div>
 
 ### Specify a Docker ignore file
 

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -109,7 +109,8 @@ The image builder is used when you want to immediately deploy an existing public
 
 `dockerfile` accepts a relative path to a Dockerfile, or a URL. By default, `flyctl` looks for `Dockerfile` in the application root.
 
-<div class="callout">
+<div class="note icon">
+**Gotchas:**
 - This option will not change the Docker context path, which is set to the project root directory by default. If you want the `Dockerfile` to use its containing directory as the context root, use `fly deploy <directory>`.
 - When specifying a local Dockerfile, make sure it's not excluded from the Docker build context in your `.dockerignore`.
 </div>


### PR DESCRIPTION
### Summary of changes
In Fly launch config page > build section > dockerfile, put the gotchas with the dockerfile setup in a callout.

### Related GitHub and Fly.io community links
https://fly.io/docs/reference/configuration/#specify-a-dockerfile

### Notes
Before: 
<img width="667" alt="Scherm­afbeelding 2023-10-06 om 09 21 19" src="https://github.com/superfly/docs/assets/114000210/cb4c06cf-51ad-4ee7-955a-cf017c1bc06a">

After: 
<img width="678" alt="Scherm­afbeelding 2023-10-06 om 09 29 06" src="https://github.com/superfly/docs/assets/114000210/21b1b01e-a0f2-4328-b03f-19a62e00fed1">

