### PR TITLE
Fix app_name rendering in Elixir docs

### DIFF
--- a/elixir/getting-started/existing.html.markerb
+++ b/elixir/getting-started/existing.html.markerb
@@ -12,7 +12,7 @@ If you have an existing Elixir app that you want to move over to Fly, this guide
 
 To configure and launch your Elixir app, you can use `fly launch` and follow the wizard.
 
-<%= partial "docs/languages-and-frameworks/partials/launch_with_postgres", locals: { detected: "Phoenix", app_name: "<app_name>" } %>
+<%= partial "docs/languages-and-frameworks/partials/launch_with_postgres", locals: { detected: "Phoenix", app_name: "app_name" } %>
 
 You can set a name for the app, choose a default region, and choose to launch and attach a PostgreSQL database.
 

--- a/elixir/getting-started/migrate-from-heroku.html.markerb
+++ b/elixir/getting-started/migrate-from-heroku.html.markerb
@@ -20,7 +20,7 @@ The steps below run you through the process of migrating your Phoenix app from H
 
 From the root of the Elixir app you're running on Heroku, run `fly launch` and select the options to provision a new Postgres database.
 
-<%= partial "docs/languages-and-frameworks/partials/launch_with_postgres", locals: { detected: "Phoenix", app_name: "<app_name>" } %>
+<%= partial "docs/languages-and-frameworks/partials/launch_with_postgres", locals: { detected: "Phoenix", app_name: "app_name" } %>
 
 When that's done, view your app in a browser:
 


### PR DESCRIPTION
### Summary of changes
Remove < and > from `app_name` as it was causing issues by being rendered as literally `&lt;app_name&gt;`.

### Related GitHub and Fly.io community links
https://fly.io/docs/elixir/getting-started/existing/
https://fly.io/docs/elixir/getting-started/migrate-from-heroku/

### Notes
Removing the ampersands makes it consistent with the rest of the docs and seemed easier than figuring out how to make it work as is.