### PR TITLE
Update volume default size info

### DIFF
--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -62,7 +62,7 @@ You can extend (increase) a volume's size, but you can't make a volume smaller.
     /dev/vdb         2043856   3072   1930400   1% /storage
     ```
 
-    In the preceding example, the volume is mounted under `/storage` and has been resized to 2GB. The `df` command shows disk space in 1K blocks by default. Use the `-h` flag to return a more human-readable format.
+    In the preceding example, the volume is mounted under `/storage` and has been resized to from 1GB to 2GB. The `df` command shows disk space in 1K blocks by default. Use the `-h` flag to return a more human-readable format.
 
 For options, refer to the [`fly volumes extend` docs](/docs/flyctl/volumes-extend/) or run `fly vol extend -h`.
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -42,7 +42,7 @@ Volumes are, by default, created with encryption-at-rest enabled for additional 
 
 ## Volume size
 
-The default volume size is 3GB when you create a volume with `fly volumes create`. The default volume size is 1GB when you use `fly launch` to [launch an app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume). The maximum volume size is 500GB.
+The default volume size is 3GB when you create a volume with the `fly volumes create` command. The default volume size is 1GB when you use the `fly launch` command to [launch an app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume). The maximum volume size is 500GB.
 
 ## Volume snapshots
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -42,7 +42,7 @@ Volumes are, by default, created with encryption-at-rest enabled for additional 
 
 ## Volume size
 
-The default volume size is 3GB. The maximum size is 500GB.
+The default volume size is 3GB when you create a volume with `fly volumes create`. The default volume size is 1GB when you use `fly launch` to [launch an app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume). The maximum volume size is 500GB.
 
 ## Volume snapshots
 


### PR DESCRIPTION
### Summary of changes

The default volume size is 1GB, not 3GB when you get new volumes via the `fly launch` command. It's 3GB when you run 'fly vol create`. 

### Related GitHub and Fly.io community links
https://github.com/superfly/flyctl/issues/2868

### Notes
n/a
