### PR TITLE
link Rails migrate-from-heroku guide from Getting Started landing

### DIFF
--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -18,6 +18,7 @@ If you'd rather jump right in, try [Speedrun](/docs/speedrun/) to launch your ow
 Once that's done, check out our in-depth docs:
 
 * **[Language & Framework Guides](/docs/languages-and-frameworks/)**: Comprehensive and starter guides for your favorite languages and frameworks.
+* **[Migrate from Heroku](/docs/rails/getting-started/migrate-from-heroku/)**: See how you'd move an existing Rails app and supporting services from Heroku to Fly.io.
 * **[Fly Launch](/docs/apps)**: You've tried the `fly launch` command. Now learn how to use all the Fly Launch features that help you manage and run your apps.
 * **[Databases & Storage](/docs/database-storage-guides/)**: Options for persistent data storage on the Fly Platform
 * **[Fly Machines](/docs/machines/)**: Go deeper with our VMs, and use them to run your projects and tasks.


### PR DESCRIPTION
Quick-and-dirty interim tweak to make a migration doc more visible