### PR TITLE
Improve command prompt for Windows snippet in Getting Started docs for Django.

### DIFF
--- a/django/getting-started/index.html.md
+++ b/django/getting-started/index.html.md
@@ -42,14 +42,14 @@ $ python3 -m venv .venv
 $ source .venv/bin/activate
 (.venv) $
 ```
-```shell
-# Windows
-$ python -m venv .venv
-$ .venv\Scripts\activate
-(.venv) $
+```powershell
+# Windows (PowerShell)
+> python -m venv .venv
+> .venv\Scripts\Activate.ps1
+(.venv) ...>
 ```
 
-<section class="callout">From this point on, the commands won't be displayed with `(.venv) $` but we assume you have your Python virtual environment activated.</section>
+<section class="callout">From this point on, the commands won't be displayed with `(.venv)` but we assume you have your Python virtual environment activated.</section>
 
 ### Install Django
 


### PR DESCRIPTION
### Summary of changes

This changes a command prompt for a Windows snippet about activating virtual environments:
- changed a command prompt from `$` to `>`
- changed `activate` to `Activate.ps1` and made it explicit that it's a snippet for PowerShell
- changed style from `shell` to `powershell` to fix rendering
- removed trailing `$` from a callout as it seems unnecessary and is not correct for Windows users. 

Before:

![obraz](https://github.com/superfly/docs/assets/2865885/4f384b92-9e50-460d-9772-5b21aa622185)


After:

![obraz](https://github.com/superfly/docs/assets/2865885/329b9f3e-7ab3-4c3c-995d-2daf14a7d039)