### PR TITLE
Add volume fork docs

### DIFF
--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -98,7 +98,7 @@ For options, refer to the [`fly volumes fork` docs](/docs/flyctl/volumes-fork/) 
 
 We take daily snapshots and keep them for five days. 
 
-1. Run `fly volumes list` and copy the volume ID.
+1. Run `fly volumes list` and copy ID of volume to restore.
 
 1. List the volume's snapshots:
 
@@ -164,17 +164,21 @@ Clone a Machine with a volume to create a new Machine in the same region with an
     vol_zmjnv8m81p5rywgx    created data    1GB     lhr     b6a7    true            5683606c41098e  7 minutes ago
     ```
 
-<div class="warning icon">
-<b>Warning:</b> `fly machine clone` doesn't write data into the new volume.
+<div class="note icon">
+<b>Note:</b> `fly machine clone` doesn't write data into the new volume.
 </div>
 
 For options, refer to the [`fly machine clone` docs](/docs/flyctl/machine-clone/) or run `fly m clone -h`.
 
 ## Destroy a volume
 
-When you destroy a volume, you delete all its data.
+<div class="warning icon">
+<b>Warning:</b> When you destroy a volume, you permanently delete all its data.
+</div>
 
-Run:
+1. Run `fly volumes list` and copy ID of volume to restore.
+
+2. Destroy the volume:
 
 ```cmd
 fly vol destroy <volume id>

--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -35,7 +35,7 @@ For Machines managed individually, specify the mount path in the `fly machine cl
 
 You can extend (increase) a volume's size, but you can't make a volume smaller.
 
-1. Run `fly volumes list` and copy the volume ID.
+1. Run `fly volumes list` and copy the ID of the volume to extend.
 
 1. Extend the volume size:
 
@@ -65,6 +65,34 @@ You can extend (increase) a volume's size, but you can't make a volume smaller.
     In the preceding example, the volume is mounted under `/storage` and has been resized to from 1GB to 2GB. The `df` command shows disk space in 1K blocks by default. Use the `-h` flag to return a more human-readable format.
 
 For options, refer to the [`fly volumes extend` docs](/docs/flyctl/volumes-extend/) or run `fly vol extend -h`.
+
+## Create a copy of a volume (Fork a volume)
+
+Create an exact copy of a volume, including its data. By default, we place the new volume on a separate physical host in the same region.
+
+1. Run `fly volumes list` and copy the ID of the volume to fork.
+
+2. Fork the volume:
+
+    ```cmd
+    fly volumes fork <volume ID>
+    ```
+
+    Example output:
+    ```out
+           ID: vol_grnoq5796wwj0dkv
+         Name: my_volume_name
+          App: my-app-name
+       Region: yyz
+         Zone: 511d
+      Size GB: 3
+   Encrypted: true
+  Created at: 12 Oct 23 18:57 UTC
+    ```
+
+3. (Optional) Attach the volume to a new Machine by cloning with `fly machine clone <machine id> -r <region code> --attach-volume <volume id>:<destination mount path>` or [use `fly scale count`](/docs/apps/scale-count/#scale-an-app-with-volumes) to create a new Machine that picks up the unattached volume.
+
+For options, refer to the [`fly volumes fork` docs](/docs/flyctl/volumes-fork/) or run `fly vol fork -h`.
 
 ## Restore a volume from a snapshot
 
@@ -141,6 +169,11 @@ Clone a Machine with a volume to create a new Machine in the same region with an
 </div>
 
 For options, refer to the [`fly machine clone` docs](/docs/flyctl/machine-clone/) or run `fly m clone -h`.
+
+## Attach a volume to a Machine
+
+There are a few ways to create a volume that's not attached to a Machine yet, such as `fly vol create`, `fly vol snapshots`, or `fly vol fork`. One way to attach the volume to a Machine is by cloning. You can also add volumes to an app when you deploy, or 
+
 
 ## Destroy a volume
 

--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -170,11 +170,6 @@ Clone a Machine with a volume to create a new Machine in the same region with an
 
 For options, refer to the [`fly machine clone` docs](/docs/flyctl/machine-clone/) or run `fly m clone -h`.
 
-## Attach a volume to a Machine
-
-There are a few ways to create a volume that's not attached to a Machine yet, such as `fly vol create`, `fly vol snapshots`, or `fly vol fork`. One way to attach the volume to a Machine is by cloning. You can also add volumes to an app when you deploy, or 
-
-
 ## Destroy a volume
 
 When you destroy a volume, you delete all its data.

--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -73,7 +73,7 @@ For options, refer to the [`fly volumes extend` docs](/docs/flyctl/volumes-exten
 Create an exact copy of a volume, including its data. By default, we place the new volume on a separate physical host in the same region.
 
 <div class="important icon">
-**Important:** When you fork a volume, the source volume and the new volume are not synced.
+**Important:** After you fork a volume, the new volume is independent of the source volume. The new volume and the source volume do not continue to sync.
 </div>
 
 1. Run `fly volumes list` and copy the ID of the volume to fork.

--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -5,7 +5,9 @@ nav: firecracker
 order: 40
 ---
 
-Manage Fly Volumes using the [`fly volumes`](/docs/flyctl/volumes/) command.
+Manage Fly Volumes using the [`fly volumes`](/docs/flyctl/volumes/) command. 
+
+Fly Volumes are local persistent storage for [Fly Machines](/docs/machines/). Learn [how Fly Volumes work](/docs/reference/volumes/).
 
 <div class="note icon">**Note**: `fly volumes` is aliased to `fly volume` and `fly vol`.</div>
 
@@ -21,7 +23,7 @@ Use the `-r` option to set a [region](/docs/reference/regions/), or select a reg
 
 For options, refer to the [`fly volumes create` docs](/docs/flyctl/volumes-create/) or run `fly vol create -h`.
 
-To add a volume to your app, refer to [Add volume storage](/docs/apps/volume-storage/).
+To add a volume to your app, see [Add volume storage](/docs/apps/volume-storage/).
 
 ## Access a volume
 
@@ -69,6 +71,10 @@ For options, refer to the [`fly volumes extend` docs](/docs/flyctl/volumes-exten
 ## Create a copy of a volume (Fork a volume)
 
 Create an exact copy of a volume, including its data. By default, we place the new volume on a separate physical host in the same region.
+
+<div class="important icon">
+**Important:** When you fork a volume, the source volume and the new volume are not synced.
+</div>
 
 1. Run `fly volumes list` and copy the ID of the volume to fork.
 

--- a/apps/volume-manage.html.markerb
+++ b/apps/volume-manage.html.markerb
@@ -98,7 +98,7 @@ For options, refer to the [`fly volumes fork` docs](/docs/flyctl/volumes-fork/) 
 
 We take daily snapshots and keep them for five days. 
 
-1. Run `fly volumes list` and copy ID of volume to restore.
+1. Run `fly volumes list` and copy ID of the volume to restore.
 
 1. List the volume's snapshots:
 
@@ -176,7 +176,7 @@ For options, refer to the [`fly machine clone` docs](/docs/flyctl/machine-clone/
 <b>Warning:</b> When you destroy a volume, you permanently delete all its data.
 </div>
 
-1. Run `fly volumes list` and copy ID of volume to restore.
+1. Run `fly volumes list` and copy ID of volume to destroy.
 
 2. Destroy the volume:
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -46,7 +46,7 @@ The default volume size is 3GB when you create a volume with the `fly volumes cr
 
 ## Volume forks
 
-When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create a new volume with an exact copy of the data from the source volume to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine. The new volume and the source volume are not synced.
+When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create a new volume with an exact copy of the data from the source volume to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine. The new volume and the source volume are independent, and changes to their contents are not synchronized.
 
 ## Volume snapshots
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -20,7 +20,7 @@ A Fly Volume is a slice of an NVMe drive on the physical server your Fly App run
 * **Create redundancy in your primary region**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. You can run multiple Machines with volumes in your app's primary region to mitigate hardware failures.
 * **Create and store backups**: If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
 
-If volumes don't work for your use case, then explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+Explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
 
 ## Volume redundancy
 
@@ -34,7 +34,7 @@ Many developers use volumes for databases, so if possible, each volume you creat
 
 ## Volumes and regions
 
-Volumes exist in a single region. For redundancy within a region, you can run multiple Machines with attached volumes by creating multiple volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run. Every volume has a unique ID to allow for multiple volumes with the same name. Remember that volumes don't automatically replicate data between them.
+Volumes exist in a single[region](/docs/reference/regions/). For redundancy within a region, you can run multiple Machines with attached volumes by creating multiple volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run. Every volume has a unique ID to allow for multiple volumes with the same name. Remember that volumes don't automatically replicate data between them.
 
 ## Volume encryption
 
@@ -44,11 +44,11 @@ Volumes are, by default, created with encryption-at-rest enabled for additional 
 
 The default volume size is 3GB when you create a volume with the `fly volumes create` command. The default volume size is 1GB when you use the `fly launch` command to [launch an app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume). The maximum volume size is 500GB.
 
-## Volume snapshots
+## Volume snapshots and forks
 
-Fly.io takes daily block-level snapshots of volumes. Snapshots are kept for five days. You can restore a volume snapshot into a new volume of equal or greater size.
+Fly.io takes daily block-level snapshots of volumes. We keep snapshots for five days. You can [restore a volume snapshot](/docs/apps/volume-manage/#restore-a-volume-from-a-snapshot) into a new volume of equal or greater size. Snapshots may not have your latest data. You should still implement your own backup plan for important data.
 
-Snapshots may not have your latest data. You should still implement your own backup plan for important data.
+When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create an exact copy to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine.
 
 ## Related topics
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -46,7 +46,7 @@ The default volume size is 3GB when you create a volume with the `fly volumes cr
 
 ## Volume forks
 
-When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create a new volume with an exact copy of the data from the source volume to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine. The source volume and the new volume are not synced.
+When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create a new volume with an exact copy of the data from the source volume to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine. The new volume and the source volume are not synced.
 
 ## Volume snapshots
 

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -44,11 +44,13 @@ Volumes are, by default, created with encryption-at-rest enabled for additional 
 
 The default volume size is 3GB when you create a volume with the `fly volumes create` command. The default volume size is 1GB when you use the `fly launch` command to [launch an app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume). The maximum volume size is 500GB.
 
-## Volume snapshots and forks
+## Volume forks
+
+When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create a new volume with an exact copy of the data from the source volume to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine. The source volume and the new volume are not synced.
+
+## Volume snapshots
 
 Fly.io takes daily block-level snapshots of volumes. We keep snapshots for five days. You can [restore a volume snapshot](/docs/apps/volume-manage/#restore-a-volume-from-a-snapshot) into a new volume of equal or greater size. Snapshots may not have your latest data. You should still implement your own backup plan for important data.
-
-When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create an exact copy to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine.
 
 ## Related topics
 


### PR DESCRIPTION
### Summary of changes

Add info about the volume forks and the `fly vol fork` command to volumes docs.

TODO: Postgres docs for forking in another PR

### Related Fly.io community and GitHub links

- https://community.fly.io/t/fork-yeah-new-volume-forking-feature-for-postgres/12390
- #1109 

### Notes
n/a

### Changes on the page

Added to https://fly.io/docs/apps/volume-manage/

![Screenshot 2023-10-13 at 4 28 37 PM](https://github.com/superfly/docs/assets/13827355/375cba5e-1d9d-4dcb-a8f3-aa4851c85749)

Added to https://fly.io/docs/reference/volumes/

![Screenshot 2023-10-13 at 2 45 20 PM](https://github.com/superfly/docs/assets/13827355/474c7726-c9e6-414b-98cf-2f5754dd11c3)

