### PR TITLE
Document deploy strategy "rolling_one"

### DIFF
--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -66,7 +66,8 @@ You can run a one-off [release command](/docs/reference/configuration/#run-one-o
 
 You can specify one of the following deployment strategies:
 
-* `rolling` (default): wait for each Machine to be successfully deployed before starting the update of the next one
+* `rolling` (default): update the first machine, then every remaining Machine in successive batches. By default, splits machines into three batches.
+* `rolling_one`: wait for each Machine to be successfully deployed before starting the update of the next one
 * `immediate`: bring all Machines down for update at once
 * `canary`: boot a single new Machine, verify its health, and then proceed with a rolling restart strategy
 * `bluegreen`: boot a new Machine alongside each running Machine in the same region, and migrate traffic to the new Machines only once all the new Machines pass health checks

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -191,7 +191,9 @@ The environment variable `RELEASE_COMMAND=1` is set within the temporary release
 
 The available strategies are:
 
-**rolling**: The default strategy for apps with or without volumes. One by one, each running Machine is taken down and replaced by a new release Machine.
+**rolling**: The default strategy for apps with or without volumes. Updates the first machine individually, then updates every remaining Machine in successive batches. By default, rolling splits machines into three batches.
+
+**rolling_one**: One by one, each running Machine is taken down and replaced by a new release Machine.
 
 **immediate**: Replace all Machines with new releases immediately without waiting for health checks to pass. This is useful in emergency situations where you're confident about release health and can't wait for health checks.
 


### PR DESCRIPTION
### Summary of changes
Document "rolling_one", also changes docs for "rolling" to clarify that it's batched now.

### Related Fly.io community and GitHub links
https://github.com/superfly/flyctl/pull/2905