### PR TITLE
Posgres docs: fix broken link 

### DIFF
--- a/postgres/managing/scaling.html.markerb
+++ b/postgres/managing/scaling.html.markerb
@@ -29,4 +29,4 @@ If you have more than one instance in the primary region cluster, scale these VM
 
 ## Postgres resource parameters
 
-When you created your Fly Postgres cluster, certain Postgres configuration parameters were set to sensible values for the resources being provisioned. This means you may want, or need, to change them if you scale your VM resources. Read [Configuration Tuning](/docs/postgres/managing/configuration-tuning.html) before scaling down.
+When you created your Fly Postgres cluster, certain Postgres configuration parameters were set to sensible values for the resources being provisioned. This means you may want, or need, to change them if you scale your VM resources. Read [Configuration Tuning](/docs/postgres/managing/configuration-tuning/) before scaling down.


### PR DESCRIPTION
### Summary of changes
Fixes a broken link in the postgres docs


### Related Fly.io community and GitHub links
n/a

### Notes
n/a
