### PR TITLE
Add litefs-cloud to flyctl nav

### DIFF
--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -64,6 +64,9 @@
         <%= flyctl_nav_link "Manage IP addresses", "/docs/flyctl/ips/" %>
       </li>
       <li>
+        <%= flyctl_nav_link "LiteFS Cloud", "/docs/flyctl/litefs-cloud/" %>
+      </li>
+      <li>
         <%= flyctl_nav_link "View App logs", "/docs/flyctl/logs/" %>
       </li>
       <li>


### PR DESCRIPTION
### Summary of changes

Adds `litefs-cloud` to the nav for `flyctl` autogenerated docs.

### Related Fly.io community and GitHub links
- https://github.com/superfly/flyctl/pull/2786

### Notes
- The actual docs themselves were automatically generated by the `flyctl` release.
