### PR TITLE
Back to docs link for special sidebars

### DIFF
--- a/partials/_back_to_docs.html.erb
+++ b/partials/_back_to_docs.html.erb
@@ -1,0 +1,3 @@
+<div class="mb-2 pb-2 text-navy-900 font-[550] border-b">
+  <span class="absolute left-0">❮</span><a href="/docs/"> Docs home</a>
+</div>

--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -1,3 +1,7 @@
+<div class="mb-2 pb-2 text-navy-900 font-[550] border-b">
+  <span class="absolute left-0">❮</span><a href="/docs/"> Docs home</a>
+</div>
+
 <ul class="outline-list">
   <li>
     <%= nav_link "Fly.io Reference", "/docs/reference/" %>

--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -1,7 +1,4 @@
-<div class="mb-2 pb-2 text-navy-900 font-[550] border-b">
-  <span class="absolute left-0">❮</span><a href="/docs/"> Docs home</a>
-</div>
-
+<%= partial "/docs/partials/back_to_docs" %>
 <ul class="outline-list">
   <li>
     <%= nav_link "Fly.io Reference", "/docs/reference/" %>

--- a/partials/_hands_on_nav.html.erb
+++ b/partials/_hands_on_nav.html.erb
@@ -1,6 +1,4 @@
-<div class="mb-2 pb-2 text-navy-900 font-[550] border-b">
-  <span class="absolute left-0">❮</span><a href="/docs/"> Docs home</a>
-</div>
+<%= partial "/docs/partials/back_to_docs" %>
 <ul class="outline-list">
   <li>
     <%= nav_link "Hands-on with Fly.io", "/docs/hands-on/" %>

--- a/partials/_hands_on_nav.html.erb
+++ b/partials/_hands_on_nav.html.erb
@@ -1,3 +1,6 @@
+<div class="mb-2 pb-2 text-navy-900 font-[550] border-b">
+  <span class="absolute left-0">❮</span><a href="/docs/"> Docs home</a>
+</div>
 <ul class="outline-list">
   <li>
     <%= nav_link "Hands-on with Fly.io", "/docs/hands-on/" %>

--- a/partials/_litefs_nav.html.erb
+++ b/partials/_litefs_nav.html.erb
@@ -1,3 +1,4 @@
+<%= partial "/docs/partials/back_to_docs" %>
 <ul class="outline-list">
   <li>
     <%= nav_link "LiteFS Overview", "/docs/litefs/" %>


### PR DESCRIPTION
A potential temporary solution to feeling stranded on pages that replace the main docs sidebar. This PR adds a partial that renders a link back to fly.io/docs, which can be included in any of our "special" sidebars. The hands-on, litefs and flyctl menus are changed to include this link.

I'll PR the Landing repo one-liner to incorporate this in each of the frameworks layouts.

Obvious compromises: 
* the link isn't a list item because I didn't see a way to override some styles on the "outline-list" class, like the triangle marker on hover -- I suspect this is not super for navigating by keyboard
* it's not big and nice-looking

Check the effect at https://justchecking.fly.dev/docs/elixir/getting-started/ for example 