### PR TITLE
Replace instances of deprecated open command

### DIFF
--- a/flyctl/index.html.md
+++ b/flyctl/index.html.md
@@ -19,8 +19,8 @@ If you are doing anything with Fly.io, you'll need it. We have [flyctl installat
 
 * Create An App: [fly launch](/docs/flyctl/launch/)
 * Deploy An App: [fly deploy](/docs/flyctl/deploy/)
+* Manage Apps: [fly apps](/docs/flyctl/apps/)
 * Manage App Secrets: [fly secrets](/docs/flyctl/secrets/)
-* View your App: [fly apps open](/docs/flyctl/open/)
 
 ## Viewing and monitoring an App
 

--- a/js/frameworks/svelte.html.markerb
+++ b/js/frameworks/svelte.html.markerb
@@ -190,16 +190,16 @@ app     e2865100000086  1       ord     stopped         2023-07-06T01:50:04Z
 
 ## _Connecting to the App_
 
-The quickest way to browse your newly deployed application is with the `flyctl open` command.
+The quickest way to browse your newly deployed application is with the `flyctl apps open` command.
 
 ```cmd
-flyctl open
+flyctl apps open
 ```
 ```output
-Opening http://hello-sveltekit.fly.dev/
+Opening https://hello-sveltekit.fly.dev/
 ```
 
-Your browser will be sent to the displayed URL. Fly will auto-upgrade this URL to a HTTPS secured URL.
+Your browser will be sent to the displayed URL.
 
 ## _Bonus Points_
 

--- a/languages-and-frameworks/crystal.html.markerb
+++ b/languages-and-frameworks/crystal.html.markerb
@@ -181,16 +181,16 @@ v6   2a09:8280:1::3:23f4 global 3m20s ago
 
 ## _Connecting to the App_
 
-The quickest way to browse your newly deployed application is with the `flyctl open` command.
+The quickest way to browse your newly deployed application is with the `flyctl apps open` command.
 
 ```cmd
-flyctl open
+flyctl apps open
 ```
 ```output
-Opening http://hello-lucky.fly.dev/
+Opening https://hello-lucky.fly.dev/
 ```
 
-Your browser will be sent to the displayed URL. Fly will auto-upgrade this URL to a HTTPS secured URL.
+Your browser will be sent to the displayed URL.
 
 ## Multi-Region Deployment with Postgres (Optional)
 

--- a/languages-and-frameworks/dotnet.html.markerb
+++ b/languages-and-frameworks/dotnet.html.markerb
@@ -141,16 +141,16 @@ app     e2865100000086  1       ord     stopped         2023-07-06T01:50:04Z
 
 ## _Connecting to the App_
 
-The quickest way to browse your newly deployed application is with the `flyctl open` command.
+The quickest way to browse your newly deployed application is with the `flyctl apps open` command.
 
 ```cmd
-flyctl open
+flyctl apps open
 ```
 ```output
-Opening http://hellodotnet.fly.dev/
+Opening https://hellodotnet.fly.dev/
 ```
 
-Your browser will be sent to the displayed URL. Fly will auto-upgrade this URL to a HTTPS secured URL.
+Your browser will be sent to the displayed URL.
 
 ## _Bonus Points_
 

--- a/languages-and-frameworks/golang.html.markerb
+++ b/languages-and-frameworks/golang.html.markerb
@@ -186,11 +186,16 @@ As you can see, the application has been deployed with a DNS hostname of hellofl
 
 ## _Connecting to the App_
 
-The quickest way to connect to your deployed app is with the `flyctl open` command. This will open a browser on the HTTP version of the site. That will automatically be upgraded to an HTTPS secured connection (for the fly.dev domain).
+The quickest way to browse your newly deployed application is with the `flyctl apps open` command.
 
+```cmd
+flyctl apps open
+```
+```output
+opening https://golang-example.fly.dev ...
+```
 
-To connect to it securely, add `/name` to `flyctl open` and it'll be appended to the URL as the path and you'll get an extra greeting from the hellofly application.
-
+Your browser will be sent to the displayed URL.
 
 ## _Bonus Points_
 

--- a/languages-and-frameworks/ruby.html.markerb
+++ b/languages-and-frameworks/ruby.html.markerb
@@ -165,16 +165,16 @@ This will lookup our `fly.toml` file, and get the app name from there. Then `fly
 
 ## _Connecting to the App_
 
-The quickest way to browse your newly deployed application is with the `flyctl open` command.
+The quickest way to browse your newly deployed application is with the `flyctl apps open` command.
 
 ```cmd
 fly apps open
 ```
 ```output
-Opening http://helloruby.fly.dev/
+Opening https://helloruby.fly.dev/
 ```
 
-Your browser will be sent to the displayed URL. Fly will auto-upgrade this URL to a HTTPS secured URL.
+Your browser will be sent to the displayed URL.
 
 ## _Arrived at Destination_
 

--- a/languages-and-frameworks/static.html.markerb
+++ b/languages-and-frameworks/static.html.markerb
@@ -142,15 +142,15 @@ The output should end something like this, if everything has gone well:
 
 ## _Viewing your static site_
 
-The quickest way to browse your newly deployed application is with the `flyctl open` command.
+The quickest way to browse your newly deployed application is with the `flyctl apps open` command.
 
 ```cmd
-flyctl open
+flyctl apps open
 ```
 ```output
-opening http://gostatic-example.fly.dev ...
+opening https://gostatic-example.fly.dev ...
 ```
 
-Your browser will be sent to the displayed URL. Fly will auto-upgrade this URL to an HTTPS secured URL.
+Your browser will be sent to the displayed URL.
 
 

--- a/rails/cookbooks/minimal.html.markerb
+++ b/rails/cookbooks/minimal.html.markerb
@@ -15,7 +15,7 @@ Create an empty directory, and place the following Dockerfile in there:
 
 If you've ever seen a Dockerfile before, the above seems too good to be true.  But try it.
 In your new directory run `flyctl launch`.
-Accept all the defaults, then run `flyctl deploy`, followed by `flyctl open`.
+Accept all the defaults, then run `flyctl deploy`, followed by `flyctl apps open`.
 
 Congratulations, you've deployed a Rails app.  True, it doesn't do much, but we will
 add more later.


### PR DESCRIPTION
### Summary of changes

- Change `flyctl open` to `flyctl apps open`
- Fix 404 link to /docs/flyctl/open/
- Remove notes about HTTPS auto-upgrade

Also, removed /name from golang example since the
example repo doesn't actually handle the /name path.

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
