### PR TITLE
Update continuous-deployment-with-github-actions.html.md

### DIFF
--- a/app-guides/continuous-deployment-with-github-actions.html.md
+++ b/app-guides/continuous-deployment-with-github-actions.html.md
@@ -33,7 +33,7 @@ The first section is a speed-run through the steps to make the go-example app au
     on:
       push:
         branches:
-          - master
+          - main
     jobs:
       deploy:
         name: Deploy app


### PR DESCRIPTION

### Summary of changes

The default branch name is `main` now

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
