### PR TITLE
Support + Pricing pages: update email support and other edits

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -100,6 +100,6 @@ backups and point-in-time restore for your SQLite-based applications that use
 
 [Community support](https://community.fly.io) is included for all customers, regardless of usage level.
 
-Email support is included with our paid plans: [Plan Pricing](https://fly.io/plans)
+Email support is included with our [Launch, Scale, and Enterprise plans](https://fly.io/plans).
 
-For more about Support, see: [Support at Fly.io](https://fly.io/docs/about/support/)
+For more about Support, see [Support at Fly.io](https://fly.io/docs/about/support/).

--- a/about/support.html.md
+++ b/about/support.html.md
@@ -9,38 +9,45 @@ toc: false
 
 Need support? We can help! Here's where to look.
 
-## Fly.io Status 
+## Fly.io status
+
 For platform-wide issues and updates, please view our [status page](https://status.flyio.net/).
 
-## Community forum 
+For host-level issues that might affect your apps, see your [dashboard](https://fly.io/dashboard).
+
+## Community forum
+
 **Who can use this:** Everyone
 
 **Use this for:** General questions, troubleshooting advice, best practices, and sharing tips with other Fly users.
 
-All customers have access to our active [community forum](https://community.fly.io). We&#39;re in the forums regularly to help out with customer issues and post new feature announcements.
+All customers have access to our active [community forum](https://community.fly.io). We're in the forums regularly to help out with customer issues and post new feature announcements.
 
-Customers also frequently help each other out and share insights on running their apps on Fly.  Especially helpful contributors can earn a special "Aeronaut" badge to signify their troubleshooting prowess, great advice, and exceptional kindness.
+Customers also frequently help each other out and share insights on running their apps on Fly.io. Especially helpful contributors can earn a special "Aeronaut" badge to signify their troubleshooting prowess, great advice, and exceptional kindness.
 
 ## Email support
-**Who can use this:** Customers with paid plans
+
+**Who can use this:** Customers on [Launch, Scale, and Enterprise plans](https://fly.io/plans).
 
 **Use this for:**  Issues or questions specific to you.
 
-Customers on [Launch, Scale, and Enterprise plans](https://fly.io/plans) have access to email support. These plans come with an organization-specific address for emailing support questions, typically &lt;org-name&gt;@support.fly.io.
+Our Launch, Scale, and Enterprise plans have access to email support. These plans come with an organization-specific address for emailing support questions, typically &lt;org-name&gt;@support.fly.io.
 
 Your support address is in the [Fly.io dashboard](https://fly.io/dashboard). Select your organization, and look for your Support email address in the Billing section.
 
 ## Working with support
-We understand that describing technical issues can sometimes be challenging. Providing a clear and detailed description of the problem, including any noticeable symptoms and relevant artifacts, can greatly assist us in identifying similar cases and speeding up the resolution process.
 
-Here are some things that would be good to incude in your ticket:
-- Your app name and/or Machine ID
-- Specific errors in your app logs or browser. What you observed (e.g. 'it threw a 500 error')
-- What you were trying to achieve (e.g. deploy the application)
-- What you did (e.g. I ran fly deploy)
-- UTC timestamps for when the issue occured
-- Prepending `LOG_LEVEL=debug` to any flyctl command will give us a great level of insight into the lower-level API calls being made
-- If you are sending us error messages or log output, it's best to send that as plain text in the body of the email (or upload a .txt or .log file for longer outputs), rather than attached screenshots of your terminal window.
+We understand that describing technical issues can sometimes be challenging. Providing a clear and detailed description of the problem, including any noticeable symptoms and relevant artifacts, can help us identify similar cases and potentially speed up the resolution process.
+
+Here are some things to include in your ticket:
+- Your app name and/or Machine ID.
+- Specific errors in your app logs or browser. What you observed (e.g. 'it threw a 500 error').
+- What you were trying to achieve (e.g. deploy the application).
+- What you did (e.g. I ran `fly deploy`).
+- UTC timestamps for when the issue occurred.
+- Prepending `LOG_LEVEL=debug` to any flyctl command will provide insight into the lower-level API calls being made.
+- If you are sending us error messages or log output, it's best to send that as plain text in the body of the email (or upload a `.txt` or `.log` file for longer outputs), rather than attached screenshots of your terminal window.
 
 ## Other questions?
-For questions about a specific invoice or  account management issues, email us at [billing@fly.io](mailto:billing@fly.io).
+
+For questions about a specific invoice or account management issues, email us at [billing@fly.io](mailto:billing@fly.io).

--- a/about/support.html.md
+++ b/about/support.html.md
@@ -19,7 +19,7 @@ For host-level issues that might affect your apps, see your [dashboard](https://
 
 **Who can use this:** Everyone
 
-**Use this for:** General questions, troubleshooting advice, best practices, and sharing tips with other Fly users.
+**Use this for:** General questions, troubleshooting advice, best practices, and sharing tips with other Fly.io users.
 
 All customers have access to our active [community forum](https://community.fly.io). We're in the forums regularly to help out with customer issues and post new feature announcements.
 


### PR DESCRIPTION
### Summary of changes

- update the email support info slightly so it doesn't imply that the Hobby plan gets email support
- added a line about host-level issues being in the dashboard (i.e. not the status page)
- fix typos
- minor edits and formatting

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
