### PR TITLE
the default is 5 minutes now

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -239,7 +239,7 @@ Secrets take precedence over env variables with the same name.
 
 #### Dealing with timeout errors while deploying a new version
 
-Every time `fly deploy` runs, it builds a new docker image, pushes it to an internal registry, and then updates or creates machines for the app. Sometimes the image is too large, or the platform is slower than usual pulling the new image layers, triggering the default 2 minute timeout waiting for the Machine to be in a started state.
+Every time `fly deploy` runs, it builds a new docker image, pushes it to an internal registry, and then updates or creates machines for the app. Sometimes the image is too large, or the platform is slower than usual pulling the new image layers, triggering the default 5 minute timeout waiting for the Machine to be in a started state.
 
 The good thing is that this timeout can be controlled in two ways, with the `--wait-timeout` option, for example `fly deplopy --wait-timeout=10m`, or as a more permanent `fly.toml` setting:
 


### PR DESCRIPTION
### Summary of changes

### Related Fly.io community and GitHub links

* https://github.com/superfly/flyctl/pull/2961/files#diff-4251d8215f73cf413b3febd989c9853c5c6d80d94c5b8ced61697ff05c8e563fR27
* https://github.com/superfly/docs/pull/1133

### Notes
n/a if none
