### PR TITLE
hiding web launchers: redirect /launch to docs/apps/launch for now

### DIFF
--- a/apps/launch.html.markerb
+++ b/apps/launch.html.markerb
@@ -4,6 +4,7 @@ objective:
 layout: docs
 nav: firecracker
 order: 10
+redirect_from: /launch/
 ---
 
 <%= partial "/docs/partials/v2_transition_banner" %>


### PR DESCRIPTION
This is one tiny step on the way to phasing out web launchers.
