### PR TITLE
Machine docs: new nav + formatting + feature recap

### DIFF
--- a/machines/guides-examples.html.md
+++ b/machines/guides-examples.html.md
@@ -1,6 +1,7 @@
 ---
 title: Guides and Examples
-layout: framework_docs_overview
+layout: docs
+nav: machines
 objective: Examples on how to use Machines in fun ways.
 toc: false
 order: 3

--- a/machines/guides-examples/functions-with-machines.html.markerb
+++ b/machines/guides-examples/functions-with-machines.html.markerb
@@ -1,12 +1,12 @@
 ---
 title: Run User Code on Fly Machines
-layout: framework_docs
+layout: docs
 sitemap: false
 author: joshua
 order: 10
 categories:
   - machines
-nav: firecracker
+nav: machines
 date: 2022-05-20
 redirect_from: /docs/app-guides/functions-with-machines/
 ---

--- a/machines/guides-examples/machine-restart-policy.html.markerb
+++ b/machines/guides-examples/machine-restart-policy.html.markerb
@@ -1,8 +1,8 @@
 ---
 title: Machine restart policy
-layout: framework_docs
+layout: docs
 order: 35
-nav: firecracker
+nav: machines
 ---
 
 The Machine restart policy defines whether and how flyd restarts a Machine after its main process exits. The restart policy applies per Machine, and is not an app-wide setting.

--- a/machines/guides-examples/machine-sizing.html.markerb
+++ b/machines/guides-examples/machine-sizing.html.markerb
@@ -1,12 +1,12 @@
 ---
 title: Machine Sizing
-layout: framework_docs
+layout: docs
 sitemap: false
 author: fideloper
 order: 30
 categories:
   - machines
-nav: firecracker
+nav: machines
 date: 2022-12-08
 ---
 

--- a/machines/guides-examples/machines-app-using-flyctl.html.markerb
+++ b/machines/guides-examples/machines-app-using-flyctl.html.markerb
@@ -1,11 +1,11 @@
 ---
 title: Run Machines with flyctl
-layout: framework_docs
+layout: docs
 sitemap: false
 order: 20
 categories:
   - machines
-nav: firecracker
+nav: machines
 date: 2022-12-20
 ---
 

--- a/machines/guides-examples/terraform-machines.html.markerb
+++ b/machines/guides-examples/terraform-machines.html.markerb
@@ -1,8 +1,8 @@
 ---
 title: Getting Started with Terraform and Machines
-layout: framework_docs
+layout: docs
 sitemap: false
-nav: firecracker
+nav: machines
 order: 40
 author: dov
 categories:

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -1,7 +1,7 @@
 ---
 title: "Fly Machines"
-layout: framework_docs_overview
-toc: false
+layout: docs
+nav: machines
 redirect_from: /docs/reference/machines/
 ---
 

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -1,6 +1,7 @@
 ---
 title: "Fly Machines"
-layout: framework_docs
+layout: framework_docs_overview
+toc: false
 redirect_from: /docs/reference/machines/
 ---
 
@@ -48,7 +49,7 @@ Linux d8d9510a295118 5.15.98-fly #gf0950f1d7c SMP Sun Sep 17 02:33:12 UTC 2023 x
 
 Go ahead and try it! When you `run` a Machine with `--shell`, we'll make a small one, and we'll tear it down when you're done poking around.
 
-### Machine State
+### Machine state
 
 The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast. Doing things like 
 that is why you'd use Fly Machines directly, rather than a [Fly App](https://fly.io/docs/apps/deploy/). 
@@ -75,10 +76,10 @@ Here's [more detail on using flyctl to manage individual Machines](/docs/machine
 
 ### Scaling Machines
 
-<div class="border border-blue-600 bg-blue-50 rounded-l p-4 my-4 text-base text-navy">
+<div class="important icon">
 Remember, the ordinary way to scale an application on Fly.io is to use [Fly Launch](/docs/apps), which offers convenient
 commands to scale instances out or up. Here, we're going to scale Machines directly, in a fiddly way.
-<br><br>
+
 Whether or not you use `fly launch` to boot up a Fly App, every Machine belongs to an "App" (an "App" is ultimately just a named 
 collection of resources, configuration, and routing rules). But you don't have to use the `fly apps` commands to manage Machines;
 you can do it directly.
@@ -146,11 +147,11 @@ API are best-effort. If you're working with us at this level of control, it's on
 that burden, we try to make sure the Fly Machines API is responsive, so you get quick answers.
 </section>
 
-## Recapping Machine Features
+## Recapping Fly Machine features
 
-1. They can be managed by API
-1. They turn off automatically when a program exits
-1. They can be started very quickly
-1. Restarted machines are a blank slate - they are ephemeral
-1. They can be started manually, but can also wake on network access
-1. You can run multiple machines within an application
+* Manage with the Machines API or flyctl commands
+* Stop automatically when a program exits
+* Stop or start quickly, either manually or automatically based on traffic
+* Provide ephemeral storage, a blank slate on every startup 
+* Attach a volume for persistent storage
+* Place in any region

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -1,7 +1,8 @@
 ---
 title: Working with the Machines API
 objective: Get familiar with the Fly Machines API.
-layout: framework_docs
+layout: docs
+nav: machines
 order: 1
 ---
 

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -125,6 +125,12 @@
         <%= nav_link "Working with the Machines API", "/docs/machines/working-with-machines/" %>
       </li>
       <li>
+        <%= nav_link "Machines API Spec", "https://docs.machines.dev/swagger/index.html" %>
+      </li>
+      <li>
+        <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
+      </li>
+      <li>
         <%= nav_link "Run Machines with flyctl", "/docs/machines/guides-examples/machines-app-using-flyctl/" %>
       </li>
       <li>
@@ -132,9 +138,6 @@
       </li>
       <li>
         <%= nav_link "Machine restart policy", "/docs/machines/guides-examples/machine-restart-policy/" %>
-      </li>
-      <li>
-        <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
       </li>
       <li>
         <%= nav_link "Use Terraform with Fly Machines", "/docs/machines/guides-examples/terraform-machines/" %>

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -1,0 +1,43 @@
+<%= partial "/docs/partials/back_to_docs" %>
+<ul class="outline-list">
+  <li>
+    <%= nav_link "Fly Machines", "/docs/machines/" %>
+  </li>
+</ul>
+
+<ul class="outline-list">
+  <li>
+    <%= nav_link "Machines API Spec", "https://docs.machines.dev/swagger/index.html" %>
+  </li>
+</ul>
+
+<ul class="outline-list">
+  <li>
+    <%= nav_link "Working with the Machines API", "/docs/machines/working-with-machines/" %>
+  </li>
+</ul>
+
+<ul class="outline-list">
+  <li>    
+    <span>
+      Guides and Examples
+    </span>
+    <ul>
+      <li>
+        <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
+      </li>
+      <li>
+        <%= nav_link "Run Machines with flyctl", "/docs/machines/guides-examples/machines-app-using-flyctl/" %>
+      </li>
+      <li>
+        <%= nav_link "Machine Sizing", "/docs/machines/guides-examples/machine-sizing/" %>
+      </li>
+      <li>
+        <%= nav_link "Machine restart policy", "/docs/machines/guides-examples/machine-restart-policy/" %>
+      </li>
+      <li>
+        <%= nav_link "Getting started with Terraform and Machines", "/docs/machines/guides-examples/terraform-machines/" %>
+      </li>
+    </ul>
+  </li>
+</ul>


### PR DESCRIPTION
### Summary of changes

- add a new nav for Machines docs
- add link to API spec to nav
- format a callout
- update the feature recap list
- fix some formatting

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
