### PR TITLE
release_command VMs don't have access to volumes

### DIFF
--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -60,7 +60,7 @@ Learn more about [using Fly Volumes with Fly Apps](/docs/apps/volume-storage/).
 Configure the following deployment behavior in the [`[deploy]` section](/docs/reference/configuration/#the-deploy-section) of `fly.toml`.
 
 ### Release commands
-You can run a one-off [release command](/docs/reference/configuration/#run-one-off-commands-before-releasing-a-deployment) in a temporary VM&mdash;using the successfully built release&mdash;before that release is deployed. This is good for, e.g., running database migrations.
+You can run a one-off [release command](/docs/reference/configuration/#run-one-off-commands-before-releasing-a-deployment) in a temporary VM&mdash;using the successfully built release&mdash;before that release is deployed. This is good for, e.g., running database migrations. Keep in mind that these temporary VMs do not have access to any volumes you may have mounted in your apps.
 
 ### Deployment strategy
 

--- a/laravel/the-basics/customizing-deployments.html.md
+++ b/laravel/the-basics/customizing-deployments.html.md
@@ -19,7 +19,7 @@ You can enable or disable those as you see fit, as well as add your own `.sh` sc
 
 ## Release Command
 
-You may want to use the [`release_command`](/docs/reference/configuration/#the-deploy-section) to perform database migrations or other tasks. The release command is run in a temporary VM that is created just before your application is deployed and released. This potentially helps with zero-downtime deploys.
+You may want to use the [`release_command`](/docs/reference/configuration/#the-deploy-section) to perform database migrations or other tasks. The release command is run in a temporary VM that is created just before your application is deployed and released. Keep in mind that this temporary VM doesn't have access to volumes. This potentially helps with zero-downtime deploys.
 
 Note, however, that any Startup Script in `.fly/scripts` will also be run when a `release_command` is used.
 


### PR DESCRIPTION
### Summary of changes

In some places that we mention release_command machines, make a note about it not having access to volumes.

### Related Fly.io community and GitHub links
https://community.fly.io/t/using-sqlite-from-persistent-volume-for-django-application/16206/3

### Notes
n/a