### PR TITLE
Don't call Fly Launch PaaS

### DIFF
--- a/apps/index.html.markerb
+++ b/apps/index.html.markerb
@@ -6,14 +6,16 @@ nav: firecracker
 ---
 <%= partial "/docs/partials/v2_transition_banner" %>
 
-Fly Launch is our a Platform-as-a-Service product with features that help you serve up your app, including (but not limited to):
+Fly Launch is a collection of opinionated Fly.io platform features that help you configure and orchestrate your app as a unit. The following are some Fly Launch features:
 
 - the `fly launch` command to get started
 - the `fly.toml` file for app configuration
 - the `fly deploy` command to deploy all your app's Machines
 - the `fly scale` command for horizontal and vertical scaling
 
-Learn how to use all the Fly Launch features that help you manage and run your apps:
+You can also configure and manage Fly Machines individually; see the [Fly Machines](/docs/machines/) docs.
+
+Learn how to use Fly Launch:
 
 <ul class="outline-list">
     <li>
@@ -55,6 +57,3 @@ Learn how to use all the Fly Launch features that help you manage and run your a
     <%= nav_link "Fly Launch Configuration Reference", "/docs/reference/configuration/" %>
     </li>
 </ul>
-
-<br>
-You can also configure and manage Machines individually; see the [Fly Machines](/docs/machines/) docs.


### PR DESCRIPTION
### Summary of changes

Edited the landing page for Fly Launch (formerly known as Fly Apps V2) to identify Fly Launch as something other than a "PaaS product," and moved up the sentence pointing out you don't have to use it to run Machines.