### PR TITLE
Vale: rm weird cliche rule that's erroring

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -34,6 +34,7 @@ Google.Slang = NO
 Google.Spelling = NO
 
 proselint.But = NO
+proselint.Cliches = NO
 proselint.Typography = NO
 proselint.Very = NO
 


### PR DESCRIPTION
### Summary of changes

the proselint cliche rule is erroring on a phrase that was removed in previous pr which is super suspicious
going to turn off that rule for now

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
