### PR TITLE
Update machine flags

### DIFF
--- a/apps/legacy-scaling.html.markerb
+++ b/apps/legacy-scaling.html.markerb
@@ -145,7 +145,7 @@ Scaled VM Memory size to 1 GB
 You can also change the VM type and memory size at the same time. The `fly scale vm` command can take an additional memory flag which specifies the megabytes of RAM to be allocated to the VM. For example, if we wanted to allocate 4GB of RAM to our application and switch to a dedicated CPU option, we'd run:
 
 ```cmd
-fly scale vm dedicated-cpu-1x --memory 4096
+fly scale vm dedicated-cpu-1x --vm-memory 4096
 ```
 ```output
 Scaled VM size to dedicated-cpu-1x

--- a/apps/scale-machine.html.markerb
+++ b/apps/scale-machine.html.markerb
@@ -209,4 +209,4 @@ fly machine update --vm-memory 1024 21781973f03e89
 fly machine update --vm-cpus 2 21781973f03e89
 ```
 
-Again, if you try to set an incompatible CPU/RAM combination through `fly machine update --memory` or `fly machine update --cpus`, flyctl will let you know.
+Again, if you try to set an incompatible CPU/RAM combination through `fly machine update --vm-memory` or `fly machine update --vm-cpus`, flyctl will let you know.

--- a/machines/guides-examples/machine-sizing.html.markerb
+++ b/machines/guides-examples/machine-sizing.html.markerb
@@ -49,7 +49,7 @@ If you're using `flyctl`, the equivalent command looks like this:
 fly machine run \
     -a my-app-name \
     --name savvy-machine \
-    --size performance-2x \
+    --vm-size performance-2x \
     some-savvy-image
 ```
 
@@ -85,8 +85,8 @@ If you're using `flyctl`, the equivalent command looks like this:
 fly machine run \
     -a my-app-name \
     --name savvy-machine \
-    --cpus 2 \
-    --memory 1024 \
+    --vm-cpus 2 \
+    --vm-memory 1024 \
     some-savvy-image
 ```
 
@@ -123,7 +123,7 @@ If you're using `flyctl`, the equivalent command looks like this:
 fly machine update \
     -a my-app-name \
     -i some-savvy-image \
-    --cpus 2 \
-    --memory 512 \
+    --vm-cpus 2 \
+    --vm-memory 512 \
     73d8d46dbee589
 ```

--- a/postgres/managing/scaling.html.markerb
+++ b/postgres/managing/scaling.html.markerb
@@ -18,7 +18,7 @@ If you're scaling your VMs up, then scale the VMs first before adjusting the Pos
 Scale VM resources for each Machine in the cluster with the [`flyctl machine update`](https://fly.io/docs/flyctl/machine-update/) command. Here's an example of scaling RAM to 1GB on a machine:
 
 ```cmd
-fly machine update e784079b449483 --memory 1024 --app pg-test
+fly machine update e784079b449483 --vm-memory 1024 --app pg-test
 ```  
 
 You can use [`fly machine status`](/docs/flyctl/machine-status/) again to confirm the new scale of the Machine.

--- a/rails/advanced-guides/anycable.html.md
+++ b/rails/advanced-guides/anycable.html.md
@@ -117,7 +117,7 @@ server {
 If you haven't already done so, scale your machine:
 
 ```cmd
-fly scale vm shared-cpu-1x --memory 512
+fly scale vm shared-cpu-1x --vm-memory 512
 ```
 
 Now you are ready to deploy:


### PR DESCRIPTION
### Summary of changes

Machine flags for cpu, memory, and size are prefixed by `--vm-` per https://github.com/superfly/flyctl/pull/2323

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
