### PR TITLE
MinIO multi-node deployment

### DIFF
--- a/app-guides/minio.html.markerb
+++ b/app-guides/minio.html.markerb
@@ -291,7 +291,7 @@ CMD [ "run.sh" ]
 
 When we `fly deploy`, we should have a working multi-node MinIO deployment!
 
-If you want to see it in action, try proxying to two different machines. In one terminal:
+If you want to see it in action, try proxying to two different Machines. In one terminal:
 
 ```cmd
 fly proxy 9001:9001 -s

--- a/app-guides/minio.html.markerb
+++ b/app-guides/minio.html.markerb
@@ -115,11 +115,11 @@ fly deploy
 
 ## Accessing the web-based MinIO admin panel
 
-MinIO has a web interface. It's served on the port specified by `--console-address` in the Dockerfile, which we set to `9001`. Fly restricts access to non-standard ports, so to access this panel we need to connect to our private WireGuard network.
+MinIO has a web interface. It's served on the port specified by `--console-address` in the Dockerfile, which we set to `9001`. We can access this panel over our private WireGuard network.
 
 One way to do this is to set up a [regular WireGuard tunnel](https://fly.io/docs/reference/private-networking/), and visit `http://my-minio.internal:9001` in the browser.
 
-A simpler way is to use flyctl's user-mode WireGuard to proxy the port to our local machine:
+A simpler way is to use flyctl's user-mode WireGuard to proxy a local port to the app:
 
 ```cmd
 fly proxy 9001 

--- a/app-guides/minio.html.markerb
+++ b/app-guides/minio.html.markerb
@@ -176,7 +176,7 @@ What if you want high availability? You can deploy MinIO in a multi-node configu
 
 Each node needs to know where to find the other nodes in the configuration. This can be done using either hostnames or IP addresses, but MinIO requires that they're sequential. We'll use hostnames since we can modify `/etc/hosts` to ensure their "sequential-ness". Ensuring sequential IP addresses is much more tricky!
 
-There's going to be a bit of back-and-forth here since we don't have any private IPs to put into `/etc/hosts` until we create the machines, but we need a Dockerfile to create them in the first place. Bear with me!
+There's going to be a bit of back-and-forth here since we don't have any private IPs to put into `/etc/hosts` until we create the Machines, but we need a Dockerfile to create them in the first place. Bear with me!
 
 ### Dockerfile
 
@@ -237,7 +237,7 @@ You need to deploy and scale the app in order for private IPs to be assigned. Fi
 fly deploy
 ```
 
-...then scale up to 3 machines:
+...then scale up to 3 Machines:
 
 ```cmd
 fly scale count 3
@@ -245,9 +245,9 @@ fly scale count 3
 
 ### Private networking
 
-One of the great things about Fly.io is the [private networking](https://fly.io/docs/reference/private-networking/) we get for free. We'll use our machines' private IPs to define hostnames in `/etc/hosts` which our nodes will use to communicate with each other.
+One of the great things about Fly.io is the [private networking](https://fly.io/docs/reference/private-networking/) we get for free. We'll use our Machines' private IPs to define hostnames in `/etc/hosts` which our nodes will use to communicate with each other.
 
-Get the private IPs of your machines:
+Get the private IPs of your Machines:
 
 ```cmd
 fly ip private ls

--- a/app-guides/minio.html.markerb
+++ b/app-guides/minio.html.markerb
@@ -170,6 +170,151 @@ At this point `<NEW-USER>` can log in and read the contents of your buckets. Mak
 mc admin policy set miniotest readwrite user=<NEW-USER>
 ```
 
+## Multi-node deployment
+
+What if you want high availability? You can deploy MinIO in a multi-node configuration!
+
+Each node needs to know where to find the other nodes in the configuration. This can be done using either hostnames or IP addresses, but MinIO requires that they're sequential. We'll use hostnames since we can modify `/etc/hosts` to ensure their "sequential-ness". Ensuring sequential IP addresses is much more tricky!
+
+There's going to be a bit of back-and-forth here since we don't have any private IPs to put into `/etc/hosts` until we create the machines, but we need a Dockerfile to create them in the first place. Bear with me!
+
+### Dockerfile
+
+We need to change the `CMD` in the Dockerfile to declare that we intend to run a multi-node deployment:
+
+```docker
+FROM minio/minio
+
+ENV MINIO_SERVER_URL="http://minio1.local:9000"
+
+CMD [ "server", "http://minio{1...3}.local:9000/data", "--console-address", ":9001"]
+```
+
+We're using [expansion notation](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#sequential-hostnames) to tell MinIO that there will be 3 nodes in the cluster.
+
+### Disk Storage
+
+Create 3 volumes, one for each node:
+
+```cmd
+fly vol create miniodata --count 3 --region lhr
+```
+```output
+                ID: vol_8r6kj28xq7e7qw14
+              Name: miniodata
+               App: my-minio
+            Region: lhr
+              Zone: 81b8
+           Size GB: 3
+         Encrypted: true
+        Created at: 13 Nov 23 12:38 UTC
+Snapshot retention: 5
+                ID: vol_9vle38y30eog2p8r
+              Name: miniodata
+               App: my-minio
+            Region: lhr
+              Zone: d88f
+           Size GB: 3
+         Encrypted: true
+        Created at: 13 Nov 23 12:38 UTC
+Snapshot retention: 5
+                ID: vol_7r11e3jk1p8g17pr
+              Name: miniodata
+               App: my-minio
+            Region: lhr
+              Zone: cbfa
+           Size GB: 3
+         Encrypted: true
+        Created at: 13 Nov 23 12:38 UTC
+Snapshot retention: 5
+```
+
+### Initial deployment
+
+You need to deploy and scale the app in order for private IPs to be assigned. First, deploy:
+
+```cmd
+fly deploy
+```
+
+...then scale up to 3 machines:
+
+```cmd
+fly scale count 3
+```
+
+### Private networking
+
+One of the great things about Fly.io is the [private networking](https://fly.io/docs/reference/private-networking/) we get for free. We'll use our machines' private IPs to define hostnames in `/etc/hosts` which our nodes will use to communicate with each other.
+
+Get the private IPs of your machines:
+
+```cmd
+fly ip private ls
+```
+```out
+ID              REGION  IP
+4d89703f427258  lhr     fdaa:3:7c6d:a7b:8f:143c:79a5:2
+080e475b1d2758  lhr     fdaa:3:7c6d:a7b:172:ac21:8674:2
+683d479cde4368  lhr     fdaa:3:7c6d:a7b:172:21da:b0bc:2
+```
+
+Ideally we'd update `/etc/hosts` directly in the Dockerfile, but Docker won't let us do this at build time. Instead, we'll create a script called `run.sh` that will add our host definitions at runtime:
+
+```sh
+#!/bin/sh
+
+cat <<EOF >> /etc/hosts
+fdaa:3:7c6d:a7b:8f:143c:79a5:2  minio1.local
+fdaa:3:7c6d:a7b:172:ac21:8674:2 minio2.local
+fdaa:3:7c6d:a7b:172:21da:b0bc:2 minio3.local
+EOF
+
+# This script comes with the minio/minio image
+/usr/bin/docker-entrypoint.sh server http://minio{1...3}.local:9000/data --console-address :9001
+```
+
+### Final deployment
+
+Now update your Dockerfile to execute `run.sh`:
+
+```docker
+FROM minio/minio
+
+ENV MINIO_SERVER_URL="http://minio1.local:9000"
+
+COPY run.sh run.sh
+ENTRYPOINT [ "/bin/sh" ]
+
+CMD [ "run.sh" ]
+```
+
+When we `fly deploy`, we should have a working multi-node MinIO deployment!
+
+If you want to see it in action, try proxying to two different machines. In one terminal:
+
+```cmd
+fly proxy 9001:9001 -s
+```
+```out
+? Select instance: lhr.my-minio.internal (fdaa:3:7c6d:a7b:172:21da:b0bc:2)
+Proxying local port 9001 to remote [fdaa:3:7c6d:a7b:172:21da:b0bc:2]:9001
+```
+
+...and in a different terminal:
+
+```cmd
+fly proxy 9002:9001 -s
+```
+```out
+? Select instance: lhr.my-minio.internal (fdaa:3:7c6d:a7b:172:ac21:8674:2)
+Proxying local port 9002 to remote [fdaa:3:7c6d:a7b:172:ac21:8674:2]:9001
+```
+
+Visit `http://localhost:9001` and `http://localhost:9002` in separate browser tabs, and log in to both with your `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`.
+
+Create a bucket in one tab and then refresh the other tab. If everything is working, you should see the bucket in both!
+
 ## What's next?
 
 This was a basic guide for getting an instance of MinIO deployed on Fly.io, scratching the surface of what you might want to do with an S3-compatible object store. You can use your MinIO bucket storage right from the web interface. Your apps can talk to it from within the same private network. [MinIO docs](https://min.io/docs/minio/linux/index.html) cover more advanced usage. 

--- a/app-guides/minio.html.markerb
+++ b/app-guides/minio.html.markerb
@@ -35,16 +35,25 @@ This just takes the MinIO image and runs it with the command `server /data --con
 Initialize the app with `fly launch`. Here we use flags to specify an app name and the organization it belongs to. The most important flag is `--no-deploy`, because we still have Things to Do before we deploy:
 
 ```cmd
-fly launch --name test-minio --org personal --no-deploy
+fly launch --name my-minio --org personal --no-deploy
 ```
 ```out
-Creating app in /Users/chris/FlyTests/test-minio
+Creating app in /Users/jfent/fly-tests/my-minio
 Scanning source code
 Detected a Dockerfile app
-Selected App Name: test-minio
+Some regions require a paid plan (bom, fra, maa).
+See https://fly.io/plans to set up a plan.
+
 ? Choose a region for deployment: London, United Kingdom (lhr)
-Created app test-minio in organization personal
+App will use 'lhr' region as primary
+
+Created app 'my-minio' in organization 'personal'
+Admin URL: https://fly.io/apps/my-minio
+Hostname: my-minio.fly.dev
 Wrote config file fly.toml
+Validating /Users/jfent/fly-tests/my-minio/fly.toml
+Platform: machines
+✓ Configuration is valid
 Your app is ready! Deploy with `flyctl deploy`
 ```
 
@@ -54,14 +63,7 @@ Your app is ready! Deploy with `flyctl deploy`
 
 There's no need for this app to be accessible from the public internet, if you run your object storage within the same [Fly IPV6 private network](https://fly.io/docs/reference/private-networking/) as the app(s) that want to connect to it.
 
-Keep the `[[services]]` block in `fly.toml`, but delete everything within it:
-
-```toml
-[[services]]
-
-```
-
-Now the Fly proxy won't pass any requests to the app from outside your private network.
+Delete the `[http_service]` block in `fly.toml`. Now the Fly proxy won't pass any requests to the app from outside your private network.
 
 ## Disk storage
 
@@ -72,24 +74,27 @@ fly vol create miniodata --region lhr
 ```
 
 ```out
-        ID: vol_w0enxv3nod1r8okp
-      Name: miniodata
-       App: test-minio
-    Region: lhr
-      Zone: 4de2
-   Size GB: 3
- Encrypted: true
-Created at: 05 Nov 22 16:13 UTC
+Warning! Every volume is pinned to a specific physical host. You should create two or more volumes per application to avoid downtime. Learn more at https://fly.io/docs/reference/volumes/
+? Do you still want to use the volumes feature? Yes
+                  ID: vol_6vjd0dkm5ny038mv
+                Name: miniodata
+                 App: my-minio
+              Region: lhr
+                Zone: cbfa
+             Size GB: 3
+           Encrypted: true
+          Created at: 13 Nov 23 12:07 UTC
+  Snapshot retention: 5
 ```
 
-We didn't specify a size, so we got the default: 3GB. 
+We didn't specify a size, so we got the default: 3GB.
 
 Tell the app to mount this volume onto its `/data` directory, by appending to `fly.toml`:
 
 ```toml
 [mounts]
-source="miniodata"
-destination="/data"
+source = "miniodata"
+destination = "/data"
 ```
 
 ## Secrets
@@ -112,7 +117,7 @@ fly deploy
 
 MinIO has a web interface. It's served on the port specified by `--console-address` in the Dockerfile, which we set to `9001`. Fly restricts access to non-standard ports, so to access this panel we need to connect to our private WireGuard network.
 
-One way to do this is to set up a [regular WireGuard tunnel](https://fly.io/docs/reference/private-networking/), and visit `http://test-minio.internal:9001` in the browser.
+One way to do this is to set up a [regular WireGuard tunnel](https://fly.io/docs/reference/private-networking/), and visit `http://my-minio.internal:9001` in the browser.
 
 A simpler way is to use flyctl's user-mode WireGuard to proxy the port to our local machine:
 
@@ -120,7 +125,7 @@ A simpler way is to use flyctl's user-mode WireGuard to proxy the port to our lo
 fly proxy 9001 
 ```
 ```out
-Proxying local port 9001 to remote [test-minio.internal]:9001
+Proxying local port 9001 to remote [my-minio.internal]:9001
 ```
 
 Leave this running and visit `localhost:9001` with the browser.
@@ -144,7 +149,7 @@ mc alias set proxy-to-minio http://localhost:9000 <ROOT-USER> <ROOT-PASS>
 If you're hooked up with WireGuard:
 
 ```cmd
-mc alias set miniotest http://test-minio.internal:9000 <ROOT-USER> <ROOT-PASS>
+mc alias set miniotest http://my-minio.internal:9000 <ROOT-USER> <ROOT-PASS>
 ```
 
 Test the alias by checking your MinIO's status:


### PR DESCRIPTION
### Summary of changes

Refresh and extend the MinIO app guide with instructions for setting up a multi-node deployment.

### Related Fly.io community and GitHub links

- https://community.fly.io/t/appkata-minio-s3-compatible-storage-with-fly/389
- https://community.fly.io/t/using-fly-for-file-storage/8299/

### Notes

I've omitted some steps that would repeat things written earlier, e.g. I don't have a section saying run `fly launch ...` or `fly secrets set MINIO_ROOT_USER=...`. Happy to add that in though if preferred.