### PR TITLE
Fix litefs -config flag usage

### DIFF
--- a/litefs/config.html.markerb
+++ b/litefs/config.html.markerb
@@ -22,7 +22,9 @@ LiteFS will search the following paths to find the config file:
 You can also explicitly set the config path using a command line flag:
 
 ```sh
-litefs -config /path/to/litefs.yml
+litefs mount -config /path/to/litefs.yml
+
+litefs run -config /path/to/litefs.yml
 ```
 
 ## Environment Variables


### PR DESCRIPTION
### Summary of changes
Adds the subcommand to the `-config` example.

### Related Fly.io community and GitHub links
Fixes https://github.com/superfly/docs/issues/1155

### Notes
n/a if none
