### PR TITLE
API docs: Machines resource updates

### DIFF
--- a/machines/guides-examples/functions-with-machines.html.markerb
+++ b/machines/guides-examples/functions-with-machines.html.markerb
@@ -50,6 +50,8 @@ Launch a user machine by supplying a Docker image and a networking configuration
 
 <%= partial "/docs/reference/machines/launch_req" %>
 
+**Status: 200**
+
 Machines are permanent, so keep the ID from the response handy.
 
 Your users' service will boot immediately after this API call. Launch speed is a function of image size. Tiny images should boot in less than 2 seconds. Large, complex images are much slower to boot.
@@ -103,9 +105,11 @@ ID            	NAME          	REGION	STATE    	CREATED
 ```
 Here we see that one of the machine exited itself.
 
-The equivalent API call for such an overview:
+The closest equivalent API call lists all Machines in an app:
 
 <%= partial "/docs/reference/machines/list_req" %>
+
+**Status: 200**
 
 ## Delete a machine
 

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -92,7 +92,7 @@ Machines must be associated with a Fly App. App names must be unique.
 
 <%= partial "/docs/reference/machines/create_app_req" %>
 
-To segment the app into its own network, you can pass a `network` argument in the JSON body, e.g. `"network": "some-arbitrary-name"`. Any machine started in such an app will **not** be able to access other apps within their organization over the private network. However, machines within such an app can communicate to each other, and the [`fly-replay`](/docs/reference/dynamic-request-routing/) header can still be used to route requests to machines within a segmented app.
+To segment the app into its own network, you can pass a `network` argument in the JSON body, e.g. `"network": "some-arbitrary-name"`. Any Machine started in such an app will not be able to access other apps within their organization over the private network. However, Machines within such an app can communicate to each other, and the [`fly-replay`](/docs/reference/dynamic-request-routing/) header can still be used to route requests to Machines within a segmented app.
 
 ### Allocate an IP address for global request routing
 
@@ -163,7 +163,7 @@ A Fly Machine is the configuration and state for a single VM running on Fly.io. 
 
 Append parameters to filter the response.
 
-**`state`**: Filter by the state of the Machines in the app. For example, to return only machines in the `started` state: `GET /apps/my-app-name/machines?started`
+**`state`**: Filter by the state of the Machines in the app. For example, to return only Machines in the `started` state: `GET /apps/my-app-name/machines?started`
 
 **`include_deleted`**: If true, include deleted Machines in the response.
 
@@ -177,11 +177,11 @@ Append parameters to filter the response.
 
 <%= partial "/docs/reference/machines/list_resp" %>
 
-### Create a machine
+### Create a Machine
 
 `POST /apps/{app_name}/machines`
 
-Given the name of a Fly App, create a Fly Machine, given the URI of a container image, in some region (or, by default, the region closest to you) on Fly.io’s platform. If successful, that Machine will boot up by default. Create a machine without booting it by setting `skip_launch`.
+Given the name of a Fly App, create a Fly Machine, given the URI of a container image, in some region (or, by default, the region closest to you) on Fly.io’s platform. If successful, that Machine will boot up by default. Create a Machine without booting it by setting `skip_launch`.
 
 You can configure the Machine characteristics, like its CPU and memory. You can also allow connections from the internet through the Fly Proxy by [creating a Machine with services](#create-a-machine-with-services). Learn more about this behavior in the [networking section](#networking).
 
@@ -211,103 +211,9 @@ The only required parameter is `image` in the `config` object.
 
 `lsvd`: Enable Log Structured Virtual Disks for this Machine. Boolean (default: false)
 
-`skip_service_registration`: Leave this Machine disconnected from Fly.io’s request routing. This is like a combined Create and Cordon operation; register the Machine later with an Uncordon request. Useful for bluegreen deploys: bring a machine up, test it healthy, and only then let user requests hit it. Boolean (default: false)
+`skip_service_registration`: Leave this Machine disconnected from Fly.io’s request routing. This is like a combined Create and Cordon operation; register the Machine later with an Uncordon request. Useful for bluegreen deploys: bring a Machine up, test it healthy, and only then let user requests hit it. Boolean (default: false)
 
-`config`: An object defining the Machine configuration. Options:
-
-* `image`: The Docker image to run (required)
-* `guest`: An object with the following options:
-  - `cpus`: Number of vCPUs (default `1`)
-  - `memory_mb`: Memory in megabytes as multiples of 256 (default `256`)
-  - `kernel_args`: Optional array of strings. Arguments passed to the kernel
-* `auto_destroy`: Optional boolean telling the Machine to destroy itself once it's complete (default `false`)
-
-* `size`: A [named size](/docs/about/pricing/#machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
-* `env`: An object filled with key/value pairs to be set as environment variables
-* `services`: An array of objects that define a single network service. Check the [Machines networking section](#networking) for more information. Options:
-
-  - `protocol`: `tcp` or `udp`. [Learn more about running raw TCP/UDP services](https://fly.io/docs/app-guides/udp-and-tcp/).
-  - `concurrency`: load balancing concurrency settings
-      + `type`: `connections` (TCP) or `requests` (HTTP) - defaults to `connections`
-      + `soft_limit`: "ideal" service concurrency. We will attempt to spread load to keep services at or below this limit
-      + `hard_limit`: maximum allowed concurrency. We will queue or reject when a service is at this limit
-  - `internal_port`: Port the Machines VM listens on
-  - `ports`: An array of objects defining the service's ports and associated handlers. Options:
-      + `port`: Public-facing port number
-      + `handlers`: Array of [connection handlers](https://fly.io/docs/reference/services/#connection-handlers) for TCP-based services.
-
-* `processes`: An optional array of objects defining multiple processes to run within a VM. The Machine will stop if *any* process exits without error.
-  - `name`: Process name
-  - `entrypoint`: An array of strings. The process that will run
-  - `cmd`: An array of strings. The arguments passed to the entrypoint
-  - `env`: An object filled with key/value pairs to be set as environment variables
-  - `user`: An optional user that the process runs under
-
-* `schedule`: Optionally one of `hourly`, `daily`, `weekly`, `monthly`. Runs Machine at the given interval. Interval starts at time of Machine creation
-
-* `mounts`: An array of objects that reference previously created [persistent volumes](https://fly.io/docs/reference/volumes/). Currently, you may only mount *one volume* per VM.
-  - `volume`: The volume ID, visible in `fly volumes list`, i.e. `vol_2n0l3vl60qpv635d`
-  - `path`: Absolute path on the VM where the volume should be mounted. i.e. `/data`
-
-* `metrics`: An optional object defining a metrics endpoint that [Prometheus on Fly.io](https://fly.io/docs/reference/metrics/#prometheus-on-fly-io) will scrape
-  - `port`: The port that Prometheus will connect to
-  - `path`: The path that Prometheus will scrape (e.g. `/metrics`)
-
-* `checks`: An optional object that defines one or more named checks
-  - the key for each check is the check name
-  - the value for each check supports:
-      + `type`: `tcp` or `http`
-      + `port`: The port to connect to, likely should be the same as `internal_port`
-      + `interval`: The time between connectivity checks
-      + `timeout`: The maximum time a connection can take before being reported as failing its health check
-      + `method`: For http checks, the HTTP method to use to when making the request
-      + `path`: For http checks, the path to send the request to
-      + `protocol`: For http checks, whether to use `http` or `https`
-      * `tls_server_name`: If the protocol is `https`, the hostname to use for TLS certificate validation
-      + `tls_skip_verify`: For http checks with https protocol, whether or not to verify the TLS certificate
-      + `headers`: For http checks, an array of objects with string field `name` and array of strings field `values`
-
-An example of two checks:
-
-```json
-        "checks": {
-            "tcp-alive": {
-                "type": "tcp",
-                "port": 8080,
-                "interval": "15s",
-                "timeout": "10s"
-            },
-            "http-get": {
-                "type": "http",
-                "port": 8080,
-                "protocol": "http"
-                "method": "GET",
-                "path": "/",
-                "interval": "15s",
-                "timeout": "10s"
-            }
-        }
-```
-
-* `files`: An optional array of objects defining files to be written within a Machine, one of `raw_value` or `secret_name` must be provided.
-  - `guest_path`: The path in the machine where the file will be written. Must be an absolute path.
-  - `raw_value`: Contains the base64 encoded string of the file contents.
-  - `secret_name`: The name of the secret containing the base64 encoded file contents.
-
-An example of two files:
-
-```json
-        "files": [
-            {
-                "guest_path": "/path/to/hello.txt",
-                "raw_value": "aGVsbG8gd29ybGQK"
-            },
-            {
-                "guest_path": "/path/to/secret.txt",
-                "secret_name": "SUPER_SECRET"
-            }
-        ]
-```
+`config`: An object defining the Machine configuration. See todo add link.
 
 ### Create a Machine with services
 
@@ -431,7 +337,7 @@ Machine leases can be used to obtain an exclusive lock on modifying a Machine.
 
 Given the name of a Fly App and the Machine ID of a Fly Machine, instruct the Fly Proxy not to send requests to the Machine.
 
-This is useful for bluegreen deployments: cordon off a "green" Machine, update it, make sure it comes up health, and then uncordon it to make it the new "blue". You can also do this with a fresh machine, all in one shot, using the `skip_service_registration` request field of a Machine Create request.
+This is useful for bluegreen deployments: cordon off a "green" Machine, update it, make sure it comes up health, and then uncordon it to make it the new "blue". You can also do this with a fresh Machine, all in one shot, using the `skip_service_registration` request field of a Machine Create request.
 
 Returns **Status: 200 OK** on success.
 
@@ -445,6 +351,139 @@ This is useful for bluegreen deployments: cordon off a "green" Machine, update i
 
 Returns **Status: 200 OK** on success.
 
+### The `config` object properties
+
+Properties of the `config` object for Machine configuration.
+
+`image`: Required. The container registry path to the image that defines this Machine (for example, ”registry-1.docker.io/library/ubuntu:latest”).
+
+`auto_destroy`: Optional boolean telling the Machine to destroy itself once it's complete (default `false`).
+
+`checks`: An optional object that defines one or more named checks.The key for each check is the check name. The value for each check supports:
+
++ `type`: `tcp` or `http`
++ `port`: The TCP port to connect to, likely should be the same as `internal_port`.
++ `interval`: The interval, in nanoseconds, between connectivity checks
++ `timeout`: The maximum time, in nanoseconds, a connection can take before being reported as failing its health check.
++ `grace_period`: How long to wait, in nanoseconds, before we start running health checks.
++ `method`: For http checks, the HTTP method to use to when making the request.
++ `path`: For http checks, the path to send the request to.
++ `protocol`: For http checks, whether to use `http` or `https`
+* `tls_server_name`: If the protocol is `https`, the hostname to use for TLS certificate validation
++ `tls_skip_verify`: For http checks with https protocol, whether or not to verify the TLS certificate
++ `headers`: For http checks, an array of objects with string field `name` and array of strings field `values`.
+
+An example of two checks:
+
+```json
+        "checks": {
+            "tcp-alive": {
+                "type": "tcp",
+                "port": 8080,
+                "interval": "15s",
+                "timeout": "10s"
+            },
+            "http-get": {
+                "type": "http",
+                "port": 8080,
+                "protocol": "http"
+                "method": "GET",
+                "path": "/",
+                "interval": "15s",
+                "timeout": "10s"
+            }
+        }
+```
+
+`dns`: todo
+  - `skip_registration`: todo
+
+`env`: An object filled with key/value pairs to be set as environment variables.
+
+`files`: An optional array of objects defining files to be written within a Machine, one of `raw_value` or `secret_name` must be provided.
+  - `guest_path`: The path in the Machine where the file will be written. Must be an absolute path.
+  - `raw_value`: Contains the base64 encoded string of the file contents.
+  - `secret_name`: The name of the secret containing the base64 encoded file contents.
+
+An example of two files:
+
+```json
+        "files": [
+            {
+                "guest_path": "/path/to/hello.txt",
+                "raw_value": "aGVsbG8gd29ybGQK"
+            },
+            {
+                "guest_path": "/path/to/secret.txt",
+                "secret_name": "SUPER_SECRET"
+            }
+        ]
+```
+
+`guest`: Configure the resources allocated for this Machine. An object with the following options:
+  - `cpu_kind`: The type of CPU reservation to make (”shared”, ”performance", and so on).
+  - `gpu_kind`: The type of GPU reservation to make.
+  - `host_dedication_id`: todo
+  - `cpus`: The number of CPU cores this Machine should occupy when it runs. (default `1`)
+  - `kernel_args`: Optional array of strings. Arguments passed to the kernel.
+  - `memory_mb`: Memory in megabytes as multiples of 256 (default `256`)
+
+`init`: Arguments for `init`, which is Fly.io's footprint inside your Machine, and controls how your own code gets run.
+  - `exec` [string, string] ([]): The command line for the program to run once the Machine boots up. This overrides any other startup command line, either in our API or in your Docker container definition.
+  - `entrypoint` [string, string] ([]): A command line to override the ENTRYPOINT of your Docker container; another way to define the program that is going to start up when your Machine boots up.
+  - `cmd` [string, string] ([]): A command line to override the CMD of your Docker container; still another way to define the program that is going to start up when your machine boots up.
+  - `tty` bool (false): Allocate a TTY for the process we start up.
+  - `swap_size_mb` int (nil): Swap space to reserve for the Fly Machine in, you guessed it, megabytes.
+
+`metadata`: An object filled with key/value pairs for the Machine metadata.
+
+`metrics`: An optional object defining a metrics endpoint that [Prometheus on Fly.io](https://fly.io/docs/reference/metrics/#prometheus-on-fly-io) will scrape.
+
+  - `port`: The port that Prometheus will connect to
+  - `path`: The path that Prometheus will scrape (e.g. `/metrics`)
+
+`mounts`: An array of objects that reference previously created [persistent volumes](https://fly.io/docs/reference/volumes/). Currently, you may only mount *one volume* per VM.
+
+  - `volume`: The volume ID, visible in `fly volumes list`, i.e. `vol_2n0l3vl60qpv635d`
+  - `path`: Absolute path on the VM where the volume should be mounted. i.e. `/data`
+
+`processes`: An optional array of objects defining multiple processes to run within a Machine. The Machine will stop if any process exits without error.
+  - `name`: Process name.
+  - `entrypoint`: An array of strings. The process that will run.
+  - `cmd`: An array of strings. The arguments passed to the entrypoint.
+  - `env`: An object filled with key/value pairs to be set as environment variables.
+  - `exec`: todo
+  - `user`: An optional user that the process runs under.
+
+`restart`: Defines whether and how flyd restarts a Machine after its main process exits. Learn more about [Machine restart policies](/docs/machines/guides-examples/machine-restart-policy/). This object has the following options:
+  - `policy`: Required. One of "no", "on-failure", or "always".
+  - `max_retries`: The maximum number of retries when the policy is "on-failure".
+
+`size`: A [named size](/docs/about/pricing/#machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
+
+
+`schedule`: Optionally one of `hourly`, `daily`, `weekly`, `monthly`. Runs Machine at the given interval. Interval starts at time of Machine creation
+
+
+
+
+
+
+`services`contains an array of objects that define a single network service. Check the [Machines networking section](#networking) for more information.
+
+  - `protocol`: `tcp` or `udp`. [Learn more about running raw TCP/UDP services](https://fly.io/docs/app-guides/udp-and-tcp/).
+  - `concurrency`: Control Fly Proxy’s load balancing for this service.
+      + `type`: `connections` (TCP) or `requests` (HTTP) - defaults to `connections`. Determines which kind of event we count for load balancing.
+      + `soft_limit`: Ideal service concurrency. We will attempt to spread load to keep services at or below this limit. We’ll deprioritize a Machine to give other Machines a chance to absorb traffic.
+      + `hard_limit`: Maximum allowed concurrency. The limit of events at which we’ll stop routing to a Machine altogether, and, if configured to do so, potentially start up existing Machines to handle the load.
+  - `internal_port`: Port the Machines VM listens on
+  - `ports`: An array of objects defining the service's ports and associated handlers. Options:
+      + `port`: Public-facing port number
+      + `handlers`: Array of [connection handlers](https://fly.io/docs/reference/services/#connection-handlers) for TCP-based services.
+  - `auto_start`: If true, Fly Proxy starts Machines when requests for this service arrive.
+  - `auto_stop`: If true, Fly Proxy stops Machines when this service goes idle.
+  - `min_machines_running`: When `auto_start` is true, the minimum number of Machines to keep running at all times in the primary region.
+
 ## Notes on networking
 
 Machines are closed to the public internet by default. To make them accessible via the associated application, you need to:
@@ -452,7 +491,7 @@ Machines are closed to the public internet by default. To make them accessible v
 * Allocate an IP address to the Fly App
 * Add one or more `services` to the Machine config with ports and handlers, as shown in [Create a Machine with services](#create-a-machine-with-services).
 
-For an application with a single machine, all requests will be routed to that Machine. A Machine in the `stopped` state will be started up
+For an application with a single Machine, all requests will be routed to that Machine. A Machine in the `stopped` state will be started up
 automatically when a request arrives.
 
 For an application with multiple Machines *with the same configuration*, requests will be distributed across them. Warm-start behavior in this situation is not well-defined now, so should not be relied upon for apps with multiple Machines.
@@ -498,7 +537,7 @@ This table explains the possible Machine states. A Machine may only be in one st
     </tr>
     <tr>
       <td class="font-bold">destroying</td>
-      <td>User asked for the machine to be completely removed</td>
+      <td>User asked for the Machine to be completely removed</td>
     </tr>
     <tr>
       <td class="font-bold">destroyed</td>

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -10,7 +10,7 @@ This document covers usage of the Machines REST API to start, stop, update and i
 
 See all possible Machine states [in the table below](#machine-states).
 
-## API Spec
+## API spec
 
 We have a Swagger 2.0 specification available at [docs.machines.dev](https://docs.machines.dev) for the Machines API, so that you can autogenerate clients in your preferred language.
 
@@ -30,7 +30,7 @@ You can still access your Machines directly over a Wireguard VPN, and use the pr
 
 Follow the [instructions](/docs/reference/private-networking/#private-network-vpn) to set up a permanent WireGuard connection to your Fly.io [IPv6 private network](/docs/reference/private-networking/). Once you're connected, Fly internal DNS should expose the Machines API endpoint at: `http://_api.internal:4280`
 
-### Connecting via flyctl 
+### Connecting through flyctl 
 
 You can also proxy a local port to the internal API endpoint. This section is preserved mainly for the sake of interest, as the public Machines API endpoint is simpler and more performant.
 
@@ -82,9 +82,9 @@ All requests must include the Fly API Token in the HTTP Headers as follows:
 Authorization: Bearer <fly_api_token>
 ```
 
-## Operations on Apps
+## Apps
 
-Here are some things you can do with apps:
+You can use the Apps resource to create and manage Fly Apps. A Fly App is an abstraction for a group of Machines running your code, along with the configuration, provisioned resources, and data we need to keep track of to run and route to your Machines.
 
 ### Create a Fly App
 
@@ -133,25 +133,89 @@ Machines should be stopped before attempting deletion. Append `?force=true` to t
 
 <%= partial "/docs/reference/machines/delete_app" %>
 
-## Operations on Machines
+## Machines
 
-Here are some things you can do with machines:
+A Fly Machine is the configuration and state for a single VM running on Fly.io. With the Machines resource, you can create, stop, start, update, and delete Machines.
+
+### Machine properties
+
+| Property | Description |
+| --------- | ----------- |
+| `id` | A stable identifier for the Machine. |
+| `name` | Unique name for the Machine. If omitted, one is generated for you. |
+| `state` | The current state of the Machine. See the [Machine states table](#machine-states). |
+| `region` | The region where the Machine resides, or the the target region for the Machine on create. If omitted, the Machine is placed in the same region as your WireGuard peer connection (somewhere near you). |
+| `instance_id` | An identifier for the current running/ready version of the Machine. Every Update request potentially changes the `instance_id`. |
+| `private_ip` | The [6PN IPv6 address](/docs/reference/private-networking/) of the Machine, which is where it's reachable to other Machines in the same organization and `network_id`. |
+| `config` | Object that defines the Machine configuration. |
+| `image_ref` | Object that defines the image details. |
+| `created_at` | Date and time the Machine was created. |
+| `updated_at` | Date and time the Machine was last updated. |
+| `events` | Array of objects that provide log of what's happened with this Machine. |
+| `checks` | todo |
+| `nonce` | The Machines lease nonce, if this Machine is currently leased. Also returned on Machine create if `lease_ttl` is provided. (TODO confirm) |
+
+### List all Machines for an app
+
+`GET /apps/{app_name}/machines`
+
+#### Query parameters for list Machines
+
+Append parameters to filter the response.
+
+**`state`**: Filter by the state of the Machines in the app. For example, to return only machines in the `started` state: `GET /apps/my-app-name/machines?started`
+
+**`include_deleted`**: If true, include deleted Machines in the response.
+
+**`region`**: Filter by region. For example, to return only Machines in the `yyz` region: `GET /v1/apps/my-app-name/machines?region=yyz`
+
+#### Example list Machines request
+
+<%= partial "/docs/reference/machines/list_req" %>
+
+#### Example list Machines response
+
+<%= partial "/docs/reference/machines/list_resp" %>
 
 ### Create a machine
 
-Create a Machine, which starts running immediately. This is where you configure the Machine characteristics, like its CPU and memory. You can also allow connections from the internet through the Fly Proxy. Learn more about this behavior in the [networking section](#networking).
+`POST /apps/{app_name}/machines`
 
-Following this call, you can make a [blocking API request](#wait-for-a-machine-to-reach-a-specified-state) to wait for a Machine to start.
+Given the name of a Fly App, create a Fly Machine, given the URI of a container image, in some region (or, by default, the region closest to you) on Fly.io’s platform. If successful, that Machine will boot up by default. Create a machine without booting it by setting `skip_launch`.
 
-The only required parameter is `image` in the `config` object. Other parameters:
+You can configure the Machine characteristics, like its CPU and memory. You can also allow connections from the internet through the Fly Proxy by [creating a Machine with services](#create-a-machine-with-services). Learn more about this behavior in the [networking section](#networking).
 
-`name`: Unique name for this Machine. If omitted, one is generated for you.
+<div class="important icon">
+**Important:** This request can fail, and you're responsible for handling that failure. If you ask for a large Machine, or a Machine in a region we happen to be at capacity for, you might need to retry the request, or to fall back to another region. If you're working directly with the Machines API, you're taking some responsibility for your own orchestration!
+</div>
 
-`region`: The target region. Omitting this param launches in the same region as your WireGuard peer connection (somewhere near you).
+The only required parameter is `image` in the `config` object.
+
+#### Example create Machine request
+
+<%= partial "/docs/reference/machines/create_req" %>
+
+#### Example create Machine response
+
+<%= partial "/docs/reference/machines/create_resp" %>
+
+#### Request body parameters
+
+`name`: Unique name for this Machine. If omitted, one is generated for you. String.
+
+`region`: The target region. Omitting this param launches in the same region as your WireGuard peer connection (somewhere near you). String.
+
+`lease_ttl`: Acquire a lease on the newly created Machine, waiting this many seconds before failing the request; use to create a Machine that can’t be updated by any other external process while waiting for it to come up and pass health checks. Integer.
+
+`skip_launch`: Create a Fly Machine, but don’t boot it up, leaving it in a state where it can be quickly started in response to events. Think of this as “warming the caches” on our hardware. Boolean (default: false)
+
+`lsvd`: Enable Log Structured Virtual Disks for this Machine. Boolean (default: false)
+
+`skip_service_registration`: Leave this Machine disconnected from Fly.io’s request routing. This is like a combined Create and Cordon operation; register the Machine later with an Uncordon request. Useful for bluegreen deploys: bring a machine up, test it healthy, and only then let user requests hit it. Boolean (default: false)
 
 `config`: An object defining the Machine configuration. Options:
 
-* `image`: The Docker image to run
+* `image`: The Docker image to run (required)
 * `guest`: An object with the following options:
   - `cpus`: Number of vCPUs (default `1`)
   - `memory_mb`: Memory in megabytes as multiples of 256 (default `256`)
@@ -245,26 +309,41 @@ An example of two files:
         ]
 ```
 
-Example create Machine request and response on app `my-app-name`:
+### Create a Machine with services
+
+`POST /apps/{app_name}/machines`
+
+Create a Machine with services defined on app `my-app-name`. Learn more about [services and networking](#notes-on-networking).
+
+#### Example create Machine with services request
 
 <%= partial "/docs/reference/machines/launch_req" %>
+
+#### Example create Machine with services response
+
 <%= partial "/docs/reference/machines/launch_resp" %>
 
 ### Wait for a Machine to reach a specified state
 
-Wait for a Machine to reach a specific state. Specify the desired state with the `state` parameter.  See the [table below](#machine-states) for a list of possible states.  The default for this parameter is `started`.
+Wait for a Machine to reach a specific state. Specify the desired state with the `state` parameter.  See the [Machines states table](#machine-states) for a list of possible states.  The default for this parameter is `started`.
 
 This request will block for up to 60 seconds. Set a shorter timeout with the `timeout` parameter.
-
 
 <%= partial "/docs/reference/machines/wait_req" %>
 <%= partial "/docs/reference/machines/wait_resp" %>
 
 ### Get a Machine
 
-Given a machine ID, fetch details about it.
+`GET /apps/{app_name}/machines/{machine_id}`
+
+Given the name of a Fly App and a Fly Machine ID, retrieve the details of that Machine.
+
+#### Example get Machine request
 
 <%= partial "/docs/reference/machines/get_req" %>
+
+#### Example get Machine response
+
 <%= partial "/docs/reference/machines/get_resp" %>
 
 ### Update a Machine
@@ -295,11 +374,6 @@ Delete a Machine, never to be seen again. This action cannot be undone!
 
 <%= partial "/docs/reference/machines/delete_req" %>
 <%= partial "/docs/reference/machines/delete_resp" %>
-
-### List Machines for an app
-
-<%= partial "/docs/reference/machines/list_req" %>
-<%= partial "/docs/reference/machines/list_resp" %>
 
 ### Lease a Machine
 
@@ -371,6 +445,5 @@ This table explains the possible Machine states. A Machine may only be in one st
     </tr>
     </tbody>
   </table>
-
 
 Internal note: the replaced state is only possible when requesting a specific `instance_id`.

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -199,7 +199,7 @@ The only required parameter is `image` in the `config` object.
 
 <%= partial "/docs/reference/machines/create_resp" %>
 
-#### Request body parameters
+#### Create Machine request body parameters
 
 `name`: Unique name for this Machine. If omitted, one is generated for you. String.
 
@@ -348,14 +348,35 @@ Given the name of a Fly App and a Fly Machine ID, retrieve the details of that M
 
 ### Update a Machine
 
-`region` and `name` are immutable and cannot be updated. **We don't support partial updates. You're required to specify the entire config**.
+`POST /apps/{app_name}/machines/{machine_id}`
+
+Given the name of a Fly App and a Fly Machine ID, update the configuration of the Machine. If the Machine is running and the request is successful, it will reboot; if the Machine isn't running, and you don't want it to start up, set `skip_launch`.
+
+This is, in particular, how you would update the running image of a Machine (when you need to deploy new code), or roll back to a previous Machine release. It's also how you'd vertically scale an application.
+
+`region` and `name` are immutable and cannot be updated. 
+
+<div class="note icon">
+**Note:** You need to specify the entire Machine config to update a Machine; we don't support partial updates.
+</div>
+
+#### Example Machine update request
 
 <%= partial "/docs/reference/machines/update_req" %>
+
+#### Example Machine update response
+
 <%= partial "/docs/reference/machines/update_resp" %>
+
+#### Machine update request body parameters
+
+`current_version`: The latest `instance_id` value of the Machine. (todo: verify)
+
+For the rest of the parameters, see the [create Machine request body parameters](#create-machine-request-body-parameters).
 
 ### Stop a Machine
 
-Stopping a Machine will shut down the VM, but not destroy it. The VM may be started again with `machines/<id>/start`.
+Stopping a Machine will shut down the Machine, but not destroy it. The Machine may be started again with `machines/<id>/start`.
 
 <%= partial "/docs/reference/machines/stop_req" %>
 <%= partial "/docs/reference/machines/stop_resp" %>
@@ -370,31 +391,71 @@ reset to their original state so that they start clean on the next run.
 
 ### Delete a Machine permanently
 
-Delete a Machine, never to be seen again. This action cannot be undone!
+`DELETE /apps/{app_name}/machines/{machine_id}`
+
+Delete a Machine. This action cannot be undone.
+
+Given the name of a Fly App and the Machine ID of a Fly Machine, delete the Machine.
+
+#### Example Machine delete request
+
+Optionally append `?force=true` to the URI to stop a running Machine before deleting it.
 
 <%= partial "/docs/reference/machines/delete_req" %>
+
+#### Example Machine delete response
+
 <%= partial "/docs/reference/machines/delete_resp" %>
 
 ### Lease a Machine
 
 Machine leases can be used to obtain an exclusive lock on modifying a Machine.
 
+#### Example lease Machine request
+
 <%= partial "/docs/reference/machines/lease_req" %>
+
+#### Example lease Machine response
+
 <%= partial "/docs/reference/machines/lease_resp" %>
+
+#### Lease Machine request body parameters
+
+`ttl`: * (optional) How long the lease should be held for.
+
 <%= partial "/docs/reference/machines/lease" %>
+
+### Route requests away from a Machine
+
+`POST /apps/{app_name}/machines/{machine_id}/cordon`
+
+Given the name of a Fly App and the Machine ID of a Fly Machine, instruct the Fly Proxy not to send requests to the Machine.
+
+This is useful for bluegreen deployments: cordon off a "green" Machine, update it, make sure it comes up health, and then uncordon it to make it the new "blue". You can also do this with a fresh machine, all in one shot, using the `skip_service_registration` request field of a Machine Create request.
+
+Returns **Status: 200 OK** on success.
+
+### Resume request routing to a Machine
+
+`POST /apps/{app_name}/machines/{machine_id}/cordon`
+
+Given the name of a Fly App and the Machine ID of a Fly Machine, instruct the Fly Proxy to again send requests to the Machine.
+
+This is useful for bluegreen deployments: cordon off a "green" Machine, update it, make sure it comes up health, and then uncordon it to make it the new "blue". This is also how you register services for a Fly Machine created with the `skip_service_registration` request field.
+
+Returns **Status: 200 OK** on success.
 
 ## Notes on networking
 
 Machines are closed to the public internet by default. To make them accessible via the associated application, you need to:
 
 * Allocate an IP address to the Fly App
-* Adding one or more `services` to the Machine config with ports and handlers, as seen in the launch example here
+* Add one or more `services` to the Machine config with ports and handlers, as shown in [Create a Machine with services](#create-a-machine-with-services).
 
 For an application with a single machine, all requests will be routed to that Machine. A Machine in the `stopped` state will be started up
 automatically when a request arrives.
 
-For an application with multiple Machines *with the same configuration*, requests will be distributed across them. Warm-start behavior in this situation
-is not well-defined now, so should not be relied upon for apps with multiple Machines.
+For an application with multiple Machines *with the same configuration*, requests will be distributed across them. Warm-start behavior in this situation is not well-defined now, so should not be relied upon for apps with multiple Machines.
 
 Requests to Machines with *mixed* configurations will be distributed across Machines whose configurations match the request.
 For example, if 3 out of 6 Machines have service configurations set to listen on port 80, requests to port 80 will be distributed amongst those 3.
@@ -403,7 +464,7 @@ For example, if 3 out of 6 Machines have service configurations set to listen on
 
 Machines can be reached within the private network by hostname, in the format `<id>.vm.<app-name>.internal`. 
 
-So, to reach a Machine with ID `3d8d413b29d089` on an app called `my-app-name`, use hostname `3d8d413b29d089.vm.my-app-name.internal`.
+For example, to reach a Machine with ID `3d8d413b29d089` on an app called `my-app-name`, use hostname `3d8d413b29d089.vm.my-app-name.internal`.
 
 ## Machine states
 
@@ -446,4 +507,9 @@ This table explains the possible Machine states. A Machine may only be in one st
     </tbody>
   </table>
 
+TODO: why is this an "internal note"?
+
 Internal note: the replaced state is only possible when requesting a specific `instance_id`.
+
+
+

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -147,7 +147,7 @@ A Fly Machine is the configuration and state for a single VM running on Fly.io. 
 | `region` | The region where the Machine resides, or the the target region for the Machine on create. If omitted, the Machine is placed in the same region as your WireGuard peer connection (somewhere near you). |
 | `instance_id` | An identifier for the current running/ready version of the Machine. Every Update request potentially changes the `instance_id`. |
 | `private_ip` | The [6PN IPv6 address](/docs/reference/private-networking/) of the Machine, which is where it's reachable to other Machines in the same organization and `network_id`. |
-| `config` | Object that defines the Machine configuration. |
+| `config` | Object that defines the Machine configuration. See [The `config` object properties](#the-config-object-properties). |
 | `image_ref` | Object that defines the image details. |
 | `created_at` | Date and time the Machine was created. |
 | `updated_at` | Date and time the Machine was last updated. |
@@ -353,7 +353,7 @@ Returns **Status: 200 OK** on success.
 
 ### The `config` object properties
 
-Properties of the `config` object for Machine configuration.
+Properties of the `config` object for Machine configuration. Learn about [Machine properties](#machine-properties).
 
 `image`: Required. The container registry path to the image that defines this Machine (for example, ”registry-1.docker.io/library/ubuntu:latest”).
 
@@ -438,12 +438,10 @@ An example of two files:
 `metadata`: An object filled with key/value pairs for the Machine metadata.
 
 `metrics`: An optional object defining a metrics endpoint that [Prometheus on Fly.io](https://fly.io/docs/reference/metrics/#prometheus-on-fly-io) will scrape.
-
   - `port`: The port that Prometheus will connect to
   - `path`: The path that Prometheus will scrape (e.g. `/metrics`)
 
 `mounts`: An array of objects that reference previously created [persistent volumes](https://fly.io/docs/reference/volumes/). Currently, you may only mount *one volume* per VM.
-
   - `volume`: The volume ID, visible in `fly volumes list`, i.e. `vol_2n0l3vl60qpv635d`
   - `path`: Absolute path on the VM where the volume should be mounted. i.e. `/data`
 
@@ -459,15 +457,7 @@ An example of two files:
   - `policy`: Required. One of "no", "on-failure", or "always".
   - `max_retries`: The maximum number of retries when the policy is "on-failure".
 
-`size`: A [named size](/docs/about/pricing/#machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
-
-
 `schedule`: Optionally one of `hourly`, `daily`, `weekly`, `monthly`. Runs Machine at the given interval. Interval starts at time of Machine creation
-
-
-
-
-
 
 `services`contains an array of objects that define a single network service. Check the [Machines networking section](#networking) for more information.
 
@@ -476,13 +466,30 @@ An example of two files:
       + `type`: `connections` (TCP) or `requests` (HTTP) - defaults to `connections`. Determines which kind of event we count for load balancing.
       + `soft_limit`: Ideal service concurrency. We will attempt to spread load to keep services at or below this limit. We’ll deprioritize a Machine to give other Machines a chance to absorb traffic.
       + `hard_limit`: Maximum allowed concurrency. The limit of events at which we’ll stop routing to a Machine altogether, and, if configured to do so, potentially start up existing Machines to handle the load.
-  - `internal_port`: Port the Machines VM listens on
+  - `internal_port`: Port the Machine listens on.
   - `ports`: An array of objects defining the service's ports and associated handlers. Options:
-      + `port`: Public-facing port number
-      + `handlers`: Array of [connection handlers](https://fly.io/docs/reference/services/#connection-handlers) for TCP-based services.
+      + `port`: The internet-exposed port to receive traffic on; if you want HTTP traffic routed to 8080/tcp on your Machine, this would be 80.
+      + `start_port`, `end-port`: Like `port``, but allocate a range of ports to route internally, for applications that want to occupy whole port ranges.
+      + `handlers`: Array of protocol [handlers](https://fly.io/docs/reference/services/#connection-handlers) for this port. How should the Fly Proxy handle and terminate this connection. Options include `http`, `tcp`, `tls`.
+      + `force_https`: 
+      + `http_options`: todo
+      + `tls_options`: todo
+      + `proxy_proto_options`: todo
   - `auto_start`: If true, Fly Proxy starts Machines when requests for this service arrive.
   - `auto_stop`: If true, Fly Proxy stops Machines when this service goes idle.
   - `min_machines_running`: When `auto_start` is true, the minimum number of Machines to keep running at all times in the primary region.
+
+`size`: A [named size](/docs/about/pricing/#machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
+
+`standys`: todo
+
+`statics`: todo
+  - `guest_path`: todo
+  - `url_prefix`: todo
+
+`stop_config`: todo
+  - `signal`: todo
+  - `timeout`: todo
 
 ## Notes on networking
 

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -88,6 +88,8 @@ You can use the Apps resource to create and manage Fly Apps. A Fly App is an abs
 
 ### Create a Fly App
 
+`POST /apps`
+
 Machines must be associated with a Fly App. App names must be unique.
 
 <%= partial "/docs/reference/machines/create_app_req" %>
@@ -113,6 +115,8 @@ The app will answer on this IP address, and after a small delay, at `my-app-name
 
 ### Get application details
 
+`GET /apps/{app_name}`
+
 Get details about an application, like its organization slug and name. Also, to check if the app exists!
 <%= partial "/docs/reference/machines/get_app_req" %>
 <%= partial "/docs/reference/machines/get_app_resp" %>
@@ -128,6 +132,8 @@ Machines inherit secrets from the app. Existing Machines must be [updated](#upda
 For non-sensitive information, you _can_ set different environment variables per Machine at creation time.
 
 ### Delete a Fly App
+
+`DELETE /apps/{app_name}`
 
 Machines should be stopped before attempting deletion. Append `?force=true` to the URI to stop and delete immediately.
 

--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -148,11 +148,11 @@ A Fly Machine is the configuration and state for a single VM running on Fly.io. 
 | `instance_id` | An identifier for the current running/ready version of the Machine. Every Update request potentially changes the `instance_id`. |
 | `private_ip` | The [6PN IPv6 address](/docs/reference/private-networking/) of the Machine, which is where it's reachable to other Machines in the same organization and `network_id`. |
 | `config` | Object that defines the Machine configuration. See [The `config` object properties](#the-config-object-properties). |
+| `checks` | Object that provides the status of any checks. |
 | `image_ref` | Object that defines the image details. |
 | `created_at` | Date and time the Machine was created. |
 | `updated_at` | Date and time the Machine was last updated. |
 | `events` | Array of objects that provide log of what's happened with this Machine. |
-| `checks` | todo |
 | `nonce` | The Machines lease nonce, if this Machine is currently leased. Also returned on Machine create if `lease_ttl` is provided. (TODO confirm) |
 
 ### List all Machines for an app
@@ -213,7 +213,7 @@ The only required parameter is `image` in the `config` object.
 
 `skip_service_registration`: Leave this Machine disconnected from Fly.io’s request routing. This is like a combined Create and Cordon operation; register the Machine later with an Uncordon request. Useful for bluegreen deploys: bring a Machine up, test it healthy, and only then let user requests hit it. Boolean (default: false)
 
-`config`: An object defining the Machine configuration. See todo add link.
+`config`: An object defining the Machine configuration. See the [`config` object properties](#the-config-object-properties).
 
 ### Create a Machine with services
 
@@ -276,11 +276,13 @@ This is, in particular, how you would update the running image of a Machine (whe
 
 #### Machine update request body parameters
 
-`current_version`: The latest `instance_id` value of the Machine. (todo: verify)
+`current_version`: The latest `instance_id` value of the Machine.
 
 For the rest of the parameters, see the [create Machine request body parameters](#create-machine-request-body-parameters).
 
 ### Stop a Machine
+
+`POST /apps/{app_name}/machines/{machine_id}/stop`
 
 Stopping a Machine will shut down the Machine, but not destroy it. The Machine may be started again with `machines/<id>/start`.
 
@@ -288,6 +290,8 @@ Stopping a Machine will shut down the Machine, but not destroy it. The Machine m
 <%= partial "/docs/reference/machines/stop_resp" %>
 
 ### Start a Machine
+
+`POST /apps/{app_name}/machines/{machine_id}/start`
 
 Start a previously stopped Machine.  Machines that are restarted are completely
 reset to their original state so that they start clean on the next run.
@@ -315,6 +319,12 @@ Optionally append `?force=true` to the URI to stop a running Machine before dele
 
 ### Lease a Machine
 
+`GET /apps/{app_name}/machines/{machine_id}/lease`
+
+`POST /apps/{app_name}/machines/{machine_id}/lease`
+
+`DELETE /apps/{app_name}/machines/{machine_id}/lease`
+
 Machine leases can be used to obtain an exclusive lock on modifying a Machine.
 
 #### Example lease Machine request
@@ -327,7 +337,7 @@ Machine leases can be used to obtain an exclusive lock on modifying a Machine.
 
 #### Lease Machine request body parameters
 
-`ttl`: * (optional) How long the lease should be held for.
+`ttl`: int (nil) - How long the lease should be held for. Optional.
 
 <%= partial "/docs/reference/machines/lease" %>
 
@@ -353,25 +363,25 @@ Returns **Status: 200 OK** on success.
 
 ### The `config` object properties
 
-Properties of the `config` object for Machine configuration. Learn about [Machine properties](#machine-properties).
+Properties of the `config` object for Machine configuration. Learn about all the [Machine properties](#machine-properties).
 
-`image`: Required. The container registry path to the image that defines this Machine (for example, ”registry-1.docker.io/library/ubuntu:latest”).
+`image`: string - Required. The container registry path to the image that defines this Machine (for example, ”registry-1.docker.io/library/ubuntu:latest”).
 
-`auto_destroy`: Optional boolean telling the Machine to destroy itself once it's complete (default `false`).
+`auto_destroy`: bool (false) - If true, the Machine destroys itself once it's complete.
 
-`checks`: An optional object that defines one or more named checks.The key for each check is the check name. The value for each check supports:
+`checks`: An optional object that defines one or more named checks. The key for each check is the check name. The value for each check supports:
 
-+ `type`: `tcp` or `http`
-+ `port`: The TCP port to connect to, likely should be the same as `internal_port`.
-+ `interval`: The interval, in nanoseconds, between connectivity checks
-+ `timeout`: The maximum time, in nanoseconds, a connection can take before being reported as failing its health check.
-+ `grace_period`: How long to wait, in nanoseconds, before we start running health checks.
-+ `method`: For http checks, the HTTP method to use to when making the request.
-+ `path`: For http checks, the path to send the request to.
-+ `protocol`: For http checks, whether to use `http` or `https`
-* `tls_server_name`: If the protocol is `https`, the hostname to use for TLS certificate validation
-+ `tls_skip_verify`: For http checks with https protocol, whether or not to verify the TLS certificate
-+ `headers`: For http checks, an array of objects with string field `name` and array of strings field `values`.
++ `type`: string (nil) - `tcp` or `http`.
++ `port`: int (nil) - The TCP port to connect to, likely should be the same as `internal_port`.
++ `interval`: int (nil) - The interval, in nanoseconds, between connectivity checks
++ `timeout`: int (nil) - The maximum time, in nanoseconds, a connection can take before being reported as failing its health check.
++ `grace_period`: int (nil) - How long to wait, in nanoseconds, before we start running health checks.
++ `method`: string (nil) - For http checks, the HTTP method to use to when making the request.
++ `path`: string (nil) - For http checks, the path to send the request to.
++ `protocol`: string (nil) - For http checks, whether to use `http` or `https`
+* `tls_server_name`: string (nil) - If the protocol is `https`, the hostname to use for TLS certificate validation
++ `tls_skip_verify`: bool (false) - For http checks with https protocol, whether or not to verify the TLS certificate
++ `headers`: {string: [string, string]} ({}) - For http checks, an array of objects with string field `name` and array of strings field `values`.
 
 An example of two checks:
 
@@ -395,15 +405,15 @@ An example of two checks:
         }
 ```
 
-`dns`: todo
-  - `skip_registration`: todo
+`dns`
+  - `skip_registration`: If true, do not register the machine's 6PN IP with the internal DNS system.
 
-`env`: An object filled with key/value pairs to be set as environment variables.
+`env`: {string:string} ({}) - An object filled with key/value pairs to be set as environment variables.
 
 `files`: An optional array of objects defining files to be written within a Machine, one of `raw_value` or `secret_name` must be provided.
-  - `guest_path`: The path in the Machine where the file will be written. Must be an absolute path.
-  - `raw_value`: Contains the base64 encoded string of the file contents.
-  - `secret_name`: The name of the secret containing the base64 encoded file contents.
+  - `guest_path`: string - The path in the Machine where the file will be written. Must be an absolute path.
+  - `raw_value`: string - Contains the base64 encoded string of the file contents.
+  - `secret_name`: string - The name of the secret containing the base64 encoded file contents.
 
 An example of two files:
 
@@ -421,75 +431,81 @@ An example of two files:
 ```
 
 `guest`: Configure the resources allocated for this Machine. An object with the following options:
-  - `cpu_kind`: The type of CPU reservation to make (”shared”, ”performance", and so on).
-  - `gpu_kind`: The type of GPU reservation to make.
-  - `host_dedication_id`: todo
-  - `cpus`: The number of CPU cores this Machine should occupy when it runs. (default `1`)
+  - `cpu_kind`: string (nil) - The type of CPU reservation to make (”shared”, ”performance", and so on).
+  - `gpu_kind`: string (nil) - The type of GPU reservation to make.
+  - `host_dedication_id`: The ID of the host dedication (group of dedicated hosts) on which to create this Machine. (beta)
+  - `cpus`: int (nil) - The number of CPU cores this Machine should occupy when it runs. (default `1`)
   - `kernel_args`: Optional array of strings. Arguments passed to the kernel.
-  - `memory_mb`: Memory in megabytes as multiples of 256 (default `256`)
+  - `memory_mb`: int (nil) - Memory in megabytes as multiples of 256 (default `256`)
 
 `init`: Arguments for `init`, which is Fly.io's footprint inside your Machine, and controls how your own code gets run.
-  - `exec` [string, string] ([]): The command line for the program to run once the Machine boots up. This overrides any other startup command line, either in our API or in your Docker container definition.
-  - `entrypoint` [string, string] ([]): A command line to override the ENTRYPOINT of your Docker container; another way to define the program that is going to start up when your Machine boots up.
-  - `cmd` [string, string] ([]): A command line to override the CMD of your Docker container; still another way to define the program that is going to start up when your machine boots up.
-  - `tty` bool (false): Allocate a TTY for the process we start up.
-  - `swap_size_mb` int (nil): Swap space to reserve for the Fly Machine in, you guessed it, megabytes.
+  - `exec`: [string, string] ([]) - The command line for the program to run once the Machine boots up. This overrides any other startup command line, either in our API or in your Docker container definition.
+  - `entrypoint`: [string, string] ([]) - A command line to override the ENTRYPOINT of your Docker container; another way to define the program that is going to start up when your Machine boots up.
+  - `cmd`: [string, string] ([]) - A command line to override the CMD of your Docker container; still another way to define the program that is going to start up when your machine boots up.
+  - `tty`: bool (false) - Allocate a TTY for the process we start up.
+  - `swap_size_mb`: int (nil) -Swap space to reserve for the Fly Machine in, you guessed it, megabytes.
 
-`metadata`: An object filled with key/value pairs for the Machine metadata.
+`metadata`: {string:string} ({}) - An object filled with key/value pairs for the Machine metadata. We use metadata internally for routing, process groups, and clusters.
 
 `metrics`: An optional object defining a metrics endpoint that [Prometheus on Fly.io](https://fly.io/docs/reference/metrics/#prometheus-on-fly-io) will scrape.
-  - `port`: The port that Prometheus will connect to
-  - `path`: The path that Prometheus will scrape (e.g. `/metrics`)
+  - `port`: int - Required. The port that Prometheus will connect to.
+  - `path`: string - Required. The path that Prometheus will scrape (e.g. `/metrics`).
 
-`mounts`: An array of objects that reference previously created [persistent volumes](https://fly.io/docs/reference/volumes/). Currently, you may only mount *one volume* per VM.
-  - `volume`: The volume ID, visible in `fly volumes list`, i.e. `vol_2n0l3vl60qpv635d`
-  - `path`: Absolute path on the VM where the volume should be mounted. i.e. `/data`
+`mounts`: An array of objects that reference previously created [persistent volumes](https://fly.io/docs/reference/volumes/). Currently, you may only mount one volume per Machine.
+  - `name`: string - Required. The name of the Volume to attach.
+  - `path`: string - Required. Absolute path on the VM where the volume should be mounted. For example,  `/data`.
+  - `volume`: int (nil) - The volume ID, visible in `fly volumes list`, i.e. `vol_2n0l3vl60qpv635d`.
+
 
 `processes`: An optional array of objects defining multiple processes to run within a Machine. The Machine will stop if any process exits without error.
-  - `name`: Process name.
   - `entrypoint`: An array of strings. The process that will run.
   - `cmd`: An array of strings. The arguments passed to the entrypoint.
   - `env`: An object filled with key/value pairs to be set as environment variables.
-  - `exec`: todo
-  - `user`: An optional user that the process runs under.
+  - `exec`: An array of strings. The command to run for Machines in this process group on startup.
+  - `user`: string (nil) - An optional user that the process runs under.
 
 `restart`: Defines whether and how flyd restarts a Machine after its main process exits. Learn more about [Machine restart policies](/docs/machines/guides-examples/machine-restart-policy/). This object has the following options:
-  - `policy`: Required. One of "no", "on-failure", or "always".
-  - `max_retries`: The maximum number of retries when the policy is "on-failure".
+  - `policy`: string - Required. One of "no", "on-failure", or "always".
+  - `max_retries`: int (nil) - The maximum number of retries when the policy is "on-failure".
 
-`schedule`: Optionally one of `hourly`, `daily`, `weekly`, `monthly`. Runs Machine at the given interval. Interval starts at time of Machine creation
+`schedule`: string (nil) - Optionally one of `hourly`, `daily`, `weekly`, `monthly`. Runs Machine at the given interval. Interval starts at time of Machine creation
 
 `services`contains an array of objects that define a single network service. Check the [Machines networking section](#networking) for more information.
 
-  - `protocol`: `tcp` or `udp`. [Learn more about running raw TCP/UDP services](https://fly.io/docs/app-guides/udp-and-tcp/).
+  - `protocol`: string - Required. `tcp` or `udp`. [Learn more about running raw TCP/UDP services](https://fly.io/docs/app-guides/udp-and-tcp/).
+  - `internal_port`: int - Required. Port the Machine listens on.
   - `concurrency`: Control Fly Proxy’s load balancing for this service.
-      + `type`: `connections` (TCP) or `requests` (HTTP) - defaults to `connections`. Determines which kind of event we count for load balancing.
-      + `soft_limit`: Ideal service concurrency. We will attempt to spread load to keep services at or below this limit. We’ll deprioritize a Machine to give other Machines a chance to absorb traffic.
-      + `hard_limit`: Maximum allowed concurrency. The limit of events at which we’ll stop routing to a Machine altogether, and, if configured to do so, potentially start up existing Machines to handle the load.
-  - `internal_port`: Port the Machine listens on.
-  - `ports`: An array of objects defining the service's ports and associated handlers. Options:
-      + `port`: The internet-exposed port to receive traffic on; if you want HTTP traffic routed to 8080/tcp on your Machine, this would be 80.
-      + `start_port`, `end-port`: Like `port``, but allocate a range of ports to route internally, for applications that want to occupy whole port ranges.
+      + `type`: string - `connections` (TCP) or `requests` (HTTP). Default is `connections`. Determines which kind of event we count for load balancing.
+      + `soft_limit`: int (nil) - Ideal service concurrency. We will attempt to spread load to keep services at or below this limit. We’ll deprioritize a Machine to give other Machines a chance to absorb traffic.
+      + `hard_limit`: int (nil) - Maximum allowed concurrency. The limit of events at which we’ll stop routing to a Machine altogether, and, if configured to do so, potentially start up existing Machines to handle the load.
+  - `ports`: MachinePort - An array of objects defining the service's ports and associated handlers. Options:
+      + `port`: int (nil) - The internet-exposed port to receive traffic on; if you want HTTP traffic routed to 8080/tcp on your Machine, this would be 80.
+      + `start_port`, `end-port`: int (nil) - Like `port``, but allocate a range of ports to route internally, for applications that want to occupy whole port ranges.
       + `handlers`: Array of protocol [handlers](https://fly.io/docs/reference/services/#connection-handlers) for this port. How should the Fly Proxy handle and terminate this connection. Options include `http`, `tcp`, `tls`.
-      + `force_https`: 
-      + `http_options`: todo
-      + `tls_options`: todo
-      + `proxy_proto_options`: todo
-  - `auto_start`: If true, Fly Proxy starts Machines when requests for this service arrive.
-  - `auto_stop`: If true, Fly Proxy stops Machines when this service goes idle.
-  - `min_machines_running`: When `auto_start` is true, the minimum number of Machines to keep running at all times in the primary region.
+      + `force_https`: bool (false) - If true, force HTTP to HTTPS redirects.
+      + `http_options`: Fiddly HTTP options (if you don’t know you need them, you don’t), including:
+        - `compress`: bool (false) to enable HTTP compression
+        - `response`: ({"headers": {string:string}} (nil)) for HTTP headers to set on responses.
+      + `tls_options`:  Fiddly TLS options (if you don’t know you need to mess with these, you don’t need to), including:
+        - `alpn`: [string, string] ([]) : ALPN protocols to present TLS clients (for instance, [“h2”, “http/1.1”]).
+        - `versions`: [string, string] ([]) : TLS versions to allow (for instance, [“TLSv1.2”, “TLSv1.3”]).
+      + `proxy_proto_options`: Configure the version of the PROXY protocol that your app accepts. Version 1 is the default.
+        - `version`: A string to indicate that the TCP connection uses PROXY protocol version 2. The default when not set is version 1.
+  - `auto_start`: bool (false) - If true, Fly Proxy starts Machines when requests for this service arrive.
+  - `auto_stop`: bool (false) - If true, Fly Proxy stops Machines when this service goes idle.
+  - `min_machines_running`: int (nil) - When `auto_start` is true, the minimum number of Machines to keep running at all times in the primary region.
 
 `size`: A [named size](/docs/about/pricing/#machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
 
-`standys`: todo
+`standbys`: Standbys enable a Machine to be a standby for another. In the event of a hardware failure, the standby machine will be started. Only for Machines without `services`. Array of strings representing the Machine IDs of Machines watch (act as standby for).
 
-`statics`: todo
-  - `guest_path`: todo
-  - `url_prefix`: todo
+`statics`: Optionally serve static files.
+  - `guest_path`: string - Required. The path inside the Machines where the files to serve are located.
+  - `url_prefix`: string - Required. The URL prefix under which to serve the static files.
 
-`stop_config`: todo
-  - `signal`: todo
-  - `timeout`: todo
+`stop_config`: MachineStopConfig (nil) - Configure graceful shutdown of the Machine.
+  - `signal`: string (nil) - the name of the signal to send to the entrypoint process on the Machine to initiate shutdown.
+  - `timeout`: int (nil) - how long in nanoseconds to wait, after signaling the entrypoint process, before hard-shutdown of the Machine.
 
 ## Notes on networking
 
@@ -552,10 +568,3 @@ This table explains the possible Machine states. A Machine may only be in one st
     </tr>
     </tbody>
   </table>
-
-TODO: why is this an "internal note"?
-
-Internal note: the replaced state is only possible when requesting a specific `instance_id`.
-
-
-

--- a/reference/machines/_create_req.erb
+++ b/reference/machines/_create_req.erb
@@ -1,0 +1,25 @@
+```
+curl -i -X POST \\
+    -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \\
+    "${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines" \\
+  -d '{
+        "config": {
+            "init": {
+            "exec": [
+                "/bin/sleep",
+                "inf"
+            ]
+            },
+            "image": "registry-1.docker.io/library/ubuntu:latest",
+            "auto_destroy": true,
+            "restart": {
+            "policy": "always"
+            },
+            "guest": {
+            "cpu_kind": "shared",
+            "cpus": 1,
+            "memory_mb": 256
+            }
+        }
+      }
+```

--- a/reference/machines/_create_resp.erb
+++ b/reference/machines/_create_resp.erb
@@ -1,0 +1,51 @@
+**Status: 200 OK**
+
+```json
+{
+  "id": "1857156b526dd8",
+  "name": "aged-thunder-7371",
+  "state": "created",
+  "region": "ord",
+  "image_ref": {
+    "registry": "registry-1.docker.io",
+    "repository": "library/ubuntu",
+    "tag": "latest",
+    "digest": "sha256:c9cf959fd83770dfdefd8fb42cfef0761432af36a764c077aed54bbc5bb25368",
+    "labels": {
+      "org.opencontainers.image.ref.name": "ubuntu",
+      "org.opencontainers.image.version": "22.04"
+    }
+  },
+  "instance_id": "01HEPA330HZ37A78TK080NAK1M",
+  "private_ip": "fdaa:ff:ff:a7b:195:e229:8038:2",
+  "created_at": "2023-11-08T01:52:30Z",
+  "updated_at": "2023-11-08T01:52:30Z",
+  "config": {
+    "init": {
+      "exec": [
+        "/bin/sleep",
+        "inf"
+      ]
+    },
+    "image": "registry-1.docker.io/library/ubuntu:latest",
+    "auto_destroy": true,
+    "restart": {
+      "policy": "always"
+    },
+    "guest": {
+      "cpu_kind": "shared",
+      "cpus": 1,
+      "memory_mb": 256
+    },
+    "dns": {}
+  },
+  "events": [
+    {
+      "type": "launch",
+      "status": "created",
+      "source": "user",
+      "timestamp": 1699408350300
+    }
+  ]
+}
+```

--- a/reference/machines/_delete_req.erb
+++ b/reference/machines/_delete_req.erb
@@ -3,7 +3,3 @@ curl -i -X DELETE \\
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \\
     "${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines/24d896dec64879" 
 ```
-
-Optionally append `?force=true` to the URI to kill a running machine.
-
-**Status: 200**

--- a/reference/machines/_delete_resp.erb
+++ b/reference/machines/_delete_resp.erb
@@ -1,3 +1,4 @@
+**Status: 200 OK**
 
 ```json
 {

--- a/reference/machines/_get_req.erb
+++ b/reference/machines/_get_req.erb
@@ -4,4 +4,3 @@ curl -i -X GET \\
     "${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589" 
 
 ```
-**Status: 200**

--- a/reference/machines/_get_resp.erb
+++ b/reference/machines/_get_resp.erb
@@ -1,101 +1,35 @@
+**Status: 200 OK**
 
 ```json
 {
-  "id": "73d8d46dbee589",
-  "name": "quirky-machine",
-  "state": "stopped",
-  "region": "cdg",
-  "instance_id": "01G3SHPT434MNW8TS4ENX11RQY",
-  "private_ip": "fdaa:0:3ec2:a7b:5adc:6068:5b85:2",
-  "config": {
-    "env": {
-      "APP_ENV": "production"
+    "id": "a5c5de9ce64ca12",
+    "name": "aged-wind-2649",
+    "state": "started",
+    "region": "ord",
+    "image_ref": {
+      "registry": "registry-1.docker.io",
+      "repository": "rebelthor/sleep",
+      "tag": "latest",
+      "digest": "sha256:597c3e12f830132be2aa69b4c0deccb0657ea4253e6d59c6f38e41e9f69a0add"
     },
-    "init": {
-      "exec": null,
-      "entrypoint": null,
-      "cmd": null,
-      "tty": false
-    },
-    "image": "flyio/fastify-functions",
-    "metadata": null,
-    "restart": {
-      "policy": ""
-    },
-    "services": [
+    "instance_id": "1RREBN3T5K95DK9IVP4XHTTPEY2",
+    "private_ip": "fdaa:0:18:a7b:196:e274:9ce1:2",
+    "created_at": "2023-10-31T02:30:10Z",
+    "updated_at": "2023-10-31T02:35:26Z",
+    "config": { /* Fly Machine Config */ },
+    "events": [
       {
-        "internal_port": 8080,
-        "ports": [
-          {
-            "handlers": [
-              "tls",
-              "http"
-            ],
-            "port": 443
-          },
-          {
-            "handlers": [
-              "http"
-            ],
-            "port": 80
-          }
-        ],
-        "protocol": "tcp"
-      }
-    ],
-    "guest": {
-      "cpu_kind": "shared",
-      "cpus": 1,
-      "memory_mb": 256
-    }
-  },
-  "image_ref": {
-    "registry": "registry-1.docker.io",
-    "repository": "flyio/fastify-functions",
-    "tag": "latest",
-    "digest": "sha256:e15c11a07e1abbc50e252ac392a908140b199190ab08963b3b5dffc2e813d1e8",
-    "labels": {
-    }
-  },
-  "created_at": "2022-05-23T22:48:21Z",
-  "events": [
-    {
-      "type": "exit",
-      "status": "stopped",
-      "request": {
-        "exit_event": {
-          "exit_code": 127,
-          "exited_at": 1653346105255,
-          "guest_exit_code": 0,
-          "guest_signal": -1,
-          "oom_killed": false,
-          "requested_stop": false,
-          "restarting": false,
-          "signal": -1
-        },
-        "restart_count": 0
+        "type": "start",
+        "status": "started",
+        "source": "flyd",
+        "timestamp": 1698719726615
       },
-      "source": "flyd",
-      "timestamp": 1653346106636
-    },
-    {
-      "type": "update",
-      "status": "replacing",
-      "source": "user",
-      "timestamp": 1653346105801
-    },
-    {
-      "type": "start",
-      "status": "started",
-      "source": "flyd",
-      "timestamp": 1653346103201
-    },
-    {
-      "type": "launch",
-      "status": "created",
-      "source": "user",
-      "timestamp": 1653346101403
-    }
-  ]
+      {
+        "type": "launch",
+        "status": "created",
+        "source": "user",
+        "timestamp": 1698719723203
+      }
+    ]
 }
 ```

--- a/reference/machines/_launch_req.erb
+++ b/reference/machines/_launch_req.erb
@@ -44,4 +44,3 @@ curl -i -X POST \\
     }'
 
 ```
-**Status: 200**

--- a/reference/machines/_launch_resp.erb
+++ b/reference/machines/_launch_resp.erb
@@ -1,3 +1,4 @@
+**Status: 200 OK**
 
 ```json
 {

--- a/reference/machines/_lease.erb
+++ b/reference/machines/_lease.erb
@@ -1,11 +1,19 @@
 #### How to use the provided `nonce`
+
 Add the `fly-machine-lease-nonce` header to all subsequent API calls.
+
+For example:
+
 ```
 curl -i -X POST \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \
     "${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines/3d8d413b29d089/stop"
 ```
+
 #### Release the lease
+
+For example:
+
 ```
 curl -i -X DELETE \
     -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" -H "fly-machine-lease-nonce: fed368b018e9" \

--- a/reference/machines/_lease_req.erb
+++ b/reference/machines/_lease_req.erb
@@ -6,4 +6,3 @@ curl -i -X POST \
         "ttl": 500
     }'
 ```
-* `ttl` (optional) how long the lease should be held for

--- a/reference/machines/_lease_resp.erb
+++ b/reference/machines/_lease_resp.erb
@@ -1,4 +1,5 @@
-**Status: 201**
+**Status: 201 Created**
+
 ```json
 {
   "status":"success",
@@ -9,7 +10,9 @@
   }
 }
 ```
-**Status: 409**
+
+**Status: 409 Conflict**
+
 ```json
 {
   "status":"error",

--- a/reference/machines/_list_req.erb
+++ b/reference/machines/_list_req.erb
@@ -4,4 +4,3 @@ curl -i -X GET \\
     "${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines" 
 
 ```
-**Status: 200**

--- a/reference/machines/_list_resp.erb
+++ b/reference/machines/_list_resp.erb
@@ -1,41 +1,75 @@
+**Status: 200 OK**
 
 ```json
 [
   {
-    "id": "73d8d46dbee589",
-    "name": "quirky-machine",
+    "id": "a5c5de9ce64ca12",
+    "name": "aged-wind-2649",
     "state": "started",
-    "region": "cdg",
-    "instance_id": "01G3SHPT434MNW8TS4ENX11RQY",
-    "private_ip": "fdaa:0:3ec2:a7b:5adc:6068:5b85:2",
-    "config": {
-      "env": {
-        "APP_ENV": "production"
-      },
-      "init": {
-        "exec": null,
-        "entrypoint": null,
-        "cmd": null,
-        "tty": false
-      },
-      "image": "flyio/fastify-functions:latest",
-      "metadata": {
-      },
-      "restart": {
-        "policy": "",
-        "max_retries": 3
-      },
-      "size": "shared-cpu-1x"
-    },
+    "region": "ord",
     "image_ref": {
       "registry": "registry-1.docker.io",
-      "repository": "flyio/fastify-functions",
+      "repository": "rebelthor/sleep",
       "tag": "latest",
-      "digest": "sha256:e15c11a07e1abbc50e252ac392a908140b199190ab08963b3b5dffc2e813d1e8",
-      "labels": {
-      }
+      "digest": "sha256:597c3e12f830132be2aa69b4c0deccb0657ea4253e6d59c6f38e41e9f69a0add"
     },
-    "created_at": "2022-05-23T22:48:21Z"
-  }
-]
+    "instance_id": "1RREBN3T5K95DK9IVP4XHTTPEY2",
+    "private_ip": "fdaa:0:18:a7b:196:e274:9ce1:2",
+    "created_at": "2023-10-31T02:30:10Z",
+    "updated_at": "2023-10-31T02:35:26Z",
+    "config": { /* Fly Machine Config */ },
+    "events": [
+      {
+        "type": "start",
+        "status": "started",
+        "source": "flyd",
+        "timestamp": 1698719726615
+      },
+      {
+        "type": "launch",
+        "status": "created",
+        "source": "user",
+        "timestamp": 1698719723203
+      }
+    ]
+  },
+  {
+    "id": "9c487adb2596113",
+    "name": "summer-sun-916",
+    "state": "started",
+    "region": "ord",
+    "image_ref": {
+      "registry": "registry.fly.io",
+      "repository": "teamcoco",
+      "digest": "sha256:5615ef423504d56ae345ccff9db54796d589965da953297f5785042df0628452"
+    },
+    "instance_id": "CS69NJ993EYP6VHYFXVJ9H0OBJS",
+    "private_ip": "fdaa:0:18:a7b:8ba9:8eb:6d2c:2",
+    "created_at": "2023-10-12T21:22:58Z",
+    "updated_at": "2023-10-12T21:23:16Z",
+    "config": { /* Fly Machine Config */ },
+    "events": [
+      {
+        "type": "start",
+        "status": "started",
+        "source": "flyd",
+        "timestamp": 1697145796337
+      },
+      {
+        "type": "launch",
+        "status": "created",
+        "source": "user",
+        "timestamp": 1697145792765
+      }
+    ],
+    "checks": [
+      {
+        "name": "servicecheck-00-tcp-8080",
+        "status": "passing",
+        "output": "Success",
+        "updated_at": "2023-10-12T21:23:26.014Z"
+      }
+    ]
+  },
+
 ```


### PR DESCRIPTION
### Summary of changes

Take some Machines API content (from @ tqbf)  and meld it into the existing [Operations on Machines](https://fly.io/docs/machines/working-with-machines/#operations-on-machines) section of the api docs. Including:
  - update some response examples
  - add some intro content
  - add missing params
  - add endpoints for all sections

Plus:
- create some tables for some parameters/properties
- compare both docs and specs and add missing params and descriptions
- add some example requests

Todo:
- [x] search and fill in all "todo"s that I added
- [x] add types and defaults
- [ ] add speed info?
- [ ] add error codes

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none

## Preview

https://aa-docs.fly.dev/docs/machines/working-with-machines/
