### PR TITLE
Fix gpu model name

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -657,7 +657,7 @@ The kind of CPU to request. Valid values are `shared` and `performance`.
 
 ### `gpu_kind`
 
-The kind of GPU to request. Valid values are `a100-pcie-40gb` and `a100-pcie-80gb`.
+The kind of GPU to request. Valid values are `a100-pcie-40gb` and `a100-sxm4-80gb`.
 
 ### `host_dedication_id`
 


### PR DESCRIPTION
### Summary of changes

Typo fix for A100-SXM4-80GB GPU kind

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
