### PR TITLE
Add auto extend volumes to docs

### DIFF
--- a/machines/working-with-machines.html.markerb
+++ b/machines/working-with-machines.html.markerb
@@ -480,8 +480,10 @@ An example of two files:
 `mounts`: An array of objects that reference previously created [persistent volumes](https://fly.io/docs/reference/volumes/). Currently, you may only mount one volume per Machine.
   - `name`: string - Required. The name of the Volume to attach.
   - `path`: string - Required. Absolute path on the Machine where the volume should be mounted. For example,  `/data`.
+  - `extend_threshold_percent`: int - The threshold of storage used on a volume, by percentage, that triggers extending the volume’s size by the value of `add_size_gb`.
+  - `add_size_gb`: int - The increment, in GB, by which to extend the volume after reaching the auto_extend_size_threshold. Required with auto_extend_size_increment. Required with `extend_threshold_percent`.
+  - `size_gb_limit`: int - The total amount, in GB, to extend a volume. Optional with auto_extend_size_increment. Optional with `extend_threshold_percent`.
   - `volume`: int (nil) - The volume ID, visible in `fly volumes list`, i.e. `vol_2n0l3vl60qpv635d`.
-
 
 `processes`: An optional array of objects defining multiple processes to run within a Machine. The Machine will stop if any process exits without error.
   - `entrypoint`: An array of strings. The process that will run.

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -611,6 +611,33 @@ This value is only used by `fly launch` and `fly deploy` commands in case they n
 
 The value can be a string with units, like `initial_size = "30GB"` for example. The value can also be an integer, like `initial_size = 30` for example, with GB as the default unit.
 
+### `auto_extend_size_threshold`
+
+Optional. The threshold of storage used on a volume, by percentage, that triggers extending the volume's size by the value of `auto_extend_size_increment`.
+
+### `auto_extend_size_increment`
+
+The increment, in GB, by which to extend the volume after reaching the `auto_extend_size_threshold`. Required with `auto_extend_size_increment`.
+
+### `auto_extend_size_limit`
+
+The total amount, in GB, to extend a volume. Optional with `auto_extend_size_increment`.
+
+### Auto extend volume size configuration
+
+You can optionally configure volumes to automatically extend when they reache a usage threshold.
+
+For example, the following config extends the size of the volume by 1GB when it reaches 80% capacity. The volume extensions are limited to 5GB in total. `auto_extend_size_limit` is optional.
+
+```toml
+[[mounts]]
+  source = "data"
+  destination = "/data"
+  auto_extend_size_threshold = 80
+  auto_extend_size_increment = "1GB"
+  auto_extend_size_limit = "5GB"
+  ```
+
 ## The `vm` section
 
 This section defines the compute requirements for the Machines used for the application.

--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -44,6 +44,8 @@ Volumes are, by default, created with encryption-at-rest enabled for additional 
 
 The default volume size is 3GB when you create a volume with the `fly volumes create` command, and when you use the `fly launch` command to [launch an app with a volume](/docs/apps/volume-storage/#launch-a-new-app-with-a-fly-volume). The maximum volume size is 500GB.
 
+You can extend a volume's size&mdash;either [manually](/docs/apps/volume-manage/#extend-a-volume) or [automatically](/docs/reference/configuration/#the-mounts-section)&mdash;to make it larger, but you can't shrink a volume.
+
 ## Volume forks
 
 When you [fork a volume](/docs/apps/volume-manage/#create-a-copy-of-a-volume-fork-a-volume), you create a new volume with an exact copy of the data from the source volume to use for testing, backups, or whatever you like. The new volume is in the same region, but on a different physical host, and is not attached to a Machine. The new volume and the source volume are independent, and changes to their contents are not synchronized.


### PR DESCRIPTION
### Summary of changes

Add info about auto extending volumes to:

- fly.toml config
- Machines API docs
- volumes overview

### Related Fly.io community and GitHub links

https://community.fly.io/t/auto-extend-volume-size-after-a-certain-threshold/16326
https://community.fly.io/t/auto-extend-volumes-fly-toml-edition/16558
https://github.com/superfly/flyctl/pull/3021


### Notes

n/a
