### PR TITLE
Remove leftover symbol from pricing page

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -33,7 +33,7 @@ For details and to select a different plan, see [Plan Pricing](https://fly.io/pl
 
 Resources included for free on all plans:
 
-* Up to 3 shared-cpu-1x 256mb VMs<sup><strong><small>†</small></strong></sup>
+* Up to 3 shared-cpu-1x 256mb VMs
 * 3GB persistent volume storage (total)
 * 160GB outbound data transfer
 


### PR DESCRIPTION
### Summary of changes

Remove a symbol leftover from a previous PR that removed the note it pointed to . oops.

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
