### PR TITLE
Fix markdown link

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -279,7 +279,7 @@ We recommend setting `auto_stop_machines` and `auto_start_machines` to the same 
 
 ### `http_service.concurrency`
 
-The `http_service` concurrency section configures how to measure load for an application to inform [load balancing](/docs/reference/load-balancing) and (auto start and stop)[/docs/apps/autostart-stop/]. The `[http_service.concurrency]` section has the same settings as `[services.concurrency]`, which are:
+The `http_service` concurrency section configures how to measure load for an application to inform [load balancing](/docs/reference/load-balancing) and [auto start and stop](/docs/apps/autostart-stop/). The `[http_service.concurrency]` section has the same settings as `[services.concurrency]`, which are:
 
 * `type` specifies what metric is used to determine when to scale up and down, or when a given instance should receive more or less traffic (load balancing). The two supported values are `connections` and `requests`.
 
@@ -510,7 +510,7 @@ One use case is applications using HTTP/2, like gRPC. Fly's edge terminates TLS 
 
 ### `services.concurrency`
 
-The services concurrency sub-section configures how to measure load for an application to inform [load balancing](/docs/reference/load-balancing) and (auto start and stop)[/docs/apps/autostart-stop/].
+The services concurrency sub-section configures how to measure load for an application to inform [load balancing](/docs/reference/load-balancing) and [auto start and stop](/docs/apps/autostart-stop/).
 
 This section is a simple list of key/values, so the section is denoted with single square brackets like so:
 


### PR DESCRIPTION
### Summary of changes

<img width="777" alt="Screenshot 2023-11-22 at 16 48 46" src="https://github.com/superfly/docs/assets/3727384/93b8d7ce-5a17-460c-9a2d-3a93eb26b4d4">


`[]()` not `()[]`
