### PR TITLE
Add PRIMARY_REGION to documented env vars

### DIFF
--- a/reference/runtime-environment.html.md
+++ b/reference/runtime-environment.html.md
@@ -46,6 +46,9 @@ Not to be confused with the [HTTP header](/docs/reference/runtime-environment/#f
 
 ### `FLY_VM_MEMORY_MB`
 **Machine Memory**: The memory allocated to the Machine, in MB. It's the same value you'll find under https://fly.io/dashboard/personal/machines and VM Memory in the output of `fly machine status`. Learn more about [Machine sizing](/docs/machines/guides-examples/machine-sizing/).
+
+### `PRIMARY_REGION`
+**Primary Region**: This is set in your `fly.toml` or with the `--region` flag during deploys. Learn more about [configuring the primary region](/docs/reference/configuration/#primary-region).
  
 ## _Request Headers_
 


### PR DESCRIPTION
### Summary of changes
I was helping someone try to troubleshoot what was going wrong with their multi-region deployment in the community forum and realized that we set `PRIMARY_REGION`, but it wasn't documented in the env vars section.

Now it is!

### Related Fly.io community and GitHub links
https://community.fly.io/t/region-changes-erratically-cant-set-permanent-region/16488/8

### Notes
n/a if none
