### PR TITLE
Add links from pricing to billing

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -43,7 +43,7 @@ Additional resources are billed at the usage-based pricing detailed below.
 
 ### Fly Machines
 
-Pricing for [Fly Machines](/docs/machines/) VMs, which are also the virtual-machine building blocks of [Fly Launch](/docs/apps/) and [Fly Postgres](/docs/postgres/) apps. 
+Pricing for [Fly Machines](/docs/machines/) VMs, which are also the virtual-machine building blocks of [Fly Launch](/docs/apps/) and [Fly Postgres](/docs/postgres/) apps.
 
 <%= partial("shared/cpu_mem_machines_pricing") %>
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -43,9 +43,11 @@ Additional resources are billed at the usage-based pricing detailed below.
 
 ### Fly Machines
 
-Pricing for [Fly Machines](/docs/machines/) VMs, which are also the virtual-machine building blocks of [Fly Launch](/docs/apps/) and [Fly Postgres](/docs/postgres/) apps.
+Pricing for [Fly Machines](/docs/machines/) VMs, which are also the virtual-machine building blocks of [Fly Launch](/docs/apps/) and [Fly Postgres](/docs/postgres/) apps. 
 
 <%= partial("shared/cpu_mem_machines_pricing") %>
+
+For more detail about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
 
 ### GPUs and Fly Machines
 
@@ -72,7 +74,7 @@ Reserved and dedicated options:
 * Free: 3GB of total provisioned capacity per organization
 * $0.15/GB per month of provisioned capacity
 
-Volume billing is pro-rated to the hour.
+[Volume billing](/docs/about/billing/#volume-billing) is pro-rated to the hour.
 
 You'll be charged for volumes that you create, whether they are attached to a Machine or not, including when an attached Machine is stopped.
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -47,7 +47,7 @@ Pricing for [Fly Machines](/docs/machines/) VMs, which are also the virtual-mach
 
 <%= partial("shared/cpu_mem_machines_pricing") %>
 
-For more detail about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
+For more details about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
 
 ### GPUs and Fly Machines
 


### PR DESCRIPTION
### Summary of changes

Add some links from the pricing page to the new billing page

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
