### PR TITLE
Update volumes doc to show launchv2

### DIFF
--- a/apps/volume-storage.html.markerb
+++ b/apps/volume-storage.html.markerb
@@ -11,16 +11,15 @@ Fly Volumes are local persistent storage for [Fly Machines](/docs/machines/). Le
 
 Use [Fly Launch](/docs/apps/) to create a new app with one Machine and an attached volume, and then clone the Machine to scale out.
 
-1. Launch a new app from your project source directory, and type `N` at the "deploy now?" prompt:
+1. Launch a new app from your project source directory, specifying `--no-deploy` so it does not deploy immediately:
 
     ```cmd
-    fly launch 
+    fly launch --no-deploy
     ```
 
     ```out
     ...
     Wrote config file fly.toml
-    ? Would you like to deploy now? No
     ...
     Your app is ready! Deploy with `flyctl deploy`
     ```


### PR DESCRIPTION
Not deploying as part of fly launch is now a commandline flag only, not a dialogue, so change /docs/apps/volume-storage/ to show that.

### Summary of changes

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
