### PR TITLE
Add notes about on-fail vs on-failure to Machine restart policy doc

### DIFF
--- a/machines/guides-examples/machine-restart-policy.html.markerb
+++ b/machines/guides-examples/machine-restart-policy.html.markerb
@@ -13,7 +13,7 @@ The restart policies are:
 
 - **`always`**: Always restart a Machine automatically and never let it enter a `stopped` state, even when the main process exits cleanly. `always` is the default when you create a Machine with `fly m run` and for Fly Postgres app Machines. Recommended for "always-on" apps with no services configured, since the Machine restarts regardless of the exit code.
 
-- **`on-fail`**: Try up to 10 times to automatically restart the Machine if it exits with a non-zero exit code, before letting it stop. Recommended for most Machines with services configured, since Fly Proxy can wake them request. `on-fail` lets Machines be restarted if they crash, and allows your app Machines to effectively scale down by exiting cleanly. `on-fail` is the default when there's no explicit restart policy in a Machine's config, such as Machines created by `fly launch` and `fly deploy`. Machines with a schedule also default to the `on-fail` restart policy.
+- **`on-fail`** (or **`on-failure`** for the Machines API and when viewed in the Machine config): Try up to 10 times to automatically restart the Machine if it exits with a non-zero exit code, before letting it stop. Recommended for most Machines with services configured, since Fly Proxy can wake them request. `on-fail` lets Machines be restarted if they crash, and allows your app Machines to effectively scale down by exiting cleanly. `on-fail` is the default when there's no explicit restart policy in a Machine's config, such as Machines created by `fly launch` and `fly deploy`. Machines with a schedule also default to the `on-fail` restart policy.
 
 ## Check a Machine's restart policy
 
@@ -75,7 +75,9 @@ Enter 'y' to apply the changes.
 
 ## Change a Machine's restart policy with the Machines API
 
-With the Machines API, you can set the restart policy, and the maximum number of retries when the policy is `on-fail`.
+With the Machines API, you can set the restart policy, and the maximum number of retries when the policy is `on-failure`. 
+
+Note that the API and the Machine config use `on-failure` instead of `on-fail`.
 
 Endpoint: `POST /apps/{app_name}/machines/{machine_id}`
 
@@ -89,4 +91,4 @@ For example:
 ...
 ```
 
-Refer to the Machines API docs for more information about [Machine update](https://docs.machines.dev/swagger/index.html#/Machines/Machines_update).
+Refer to the Machines API docs for more information about [updating a Machine](/docs/machines/working-with-machines/#update-a-machine).


### PR DESCRIPTION
### Summary of changes

- clarify when you need to use `on-failure` vs `on-fail`, API calls fail with `on-fail`

### Related Fly.io community and GitHub links
https://github.com/superfly/flyctl/issues/2844

### Notes
n/a
