### PR TITLE
Rename pricing page

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -1,5 +1,5 @@
 ---
-title: Fly App Pricing
+title: Fly.io Resource Pricing
 layout: docs
 sitemap: true
 nav: firecracker


### PR DESCRIPTION
### Summary of changes
Current title is "Fly App Pricing" -- apps are neither here nor there, and there's also plan pricing on a different page, so I'm proposing "Fly.io Resource Pricing"

### Related Fly.io community and GitHub links
n/a 

### Notes
n/a
