### PR TITLE
Move config.toml wait_timeout section with deploy

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -215,6 +215,17 @@ Whole number values, greater than or equal to one, specify exactly how many Mach
 
 Fractional values, between zero and one, provide a percentage of Machines that can be down at a time. For example, the default value of 0.33 means that a maximum of one third of your Machines can be down during a deploy.
 
+### Dealing with timeout errors while deploying a new version
+
+Every time `fly deploy` runs, it builds a new docker image, pushes it to an internal registry, and then updates or creates Machines for the app. Sometimes the image is too large, or the platform is slower than usual pulling the new image layers, triggering the default 5 minute timeout waiting for the Machine to be in a started state.
+
+The good thing is that this timeout can be controlled in two ways, with the `--wait-timeout` option, for example `fly deploy --wait-timeout=10m`, or as a more permanent `fly.toml` setting:
+
+```toml
+[deploy]
+wait_timeout = "10m"
+```
+
 ## The `env` variables section
 
 ```toml
@@ -234,16 +245,6 @@ Secrets take precedence over env variables with the same name.
 
 **Note:** In Apps V2, the [`primary_region` option](#primary-region) sets the `PRIMARY_REGION` environment variable within a Machine and overrides any value set in the `[env]` section.
 
-### Dealing with timeout errors while deploying a new version
-
-Every time `fly deploy` runs, it builds a new docker image, pushes it to an internal registry, and then updates or creates Machines for the app. Sometimes the image is too large, or the platform is slower than usual pulling the new image layers, triggering the default 5 minute timeout waiting for the Machine to be in a started state.
-
-The good thing is that this timeout can be controlled in two ways, with the `--wait-timeout` option, for example `fly deploy --wait-timeout=10m`, or as a more permanent `fly.toml` setting:
-
-```toml
-[deploy]
-wait_timeout = "10m"
-```
 
 ## The `http_service` section
 


### PR DESCRIPTION
The h3 section about the `wait_timeout` key has is logically about the `[deploy]` section, but falls under the h2 for the `[env]` section. This moves the h3 to be under the `[deploy]` h2.

### Summary of changes

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
