### PR TITLE
Fix guide index

### DIFF
--- a/guides.html.erb
+++ b/guides.html.erb
@@ -5,20 +5,27 @@ toc: false
 nav: firecracker
 ---
 
-<h2 class="group flex items-center whitespace-pre-wrap relative mt-14 mb-6 text-navy font-heading">Example Applications</h2>
+A collection of guides and examples for working with apps and databases on Fly.io.
 
+<br><br>
 <ul>
   <li>
-    <%= nav_link "Custom Domains for SaaS", "/docs/app-guides/custom-domains-with-fly/" %>
+    <%= nav_link "Going to production", "/docs/going-to-production/" %>
+  </li>
+  <li>
+    <%= nav_link "Custom domains for SaaS", "/docs/app-guides/custom-domains-with-fly/" %>
   </li>
   <li>
     <%= nav_link "Deploy with GitHub Actions", "/docs/app-guides/continuous-deployment-with-github-actions/" %>
   </li>
   <li>
-    <%= nav_link "Run Multiple Processes", "/docs/app-guides/multiple-processes/" %>
+    <%= nav_link "Run multiple processes", "/docs/app-guides/multiple-processes/" %>
   </li>
   <li>
-    <%= nav_link "Run UDP Services", "/docs/app-guides/udp-and-tcp/" %>
+    <%= nav_link "Run UDP services", "/docs/app-guides/udp-and-tcp/" %>
+  </li>
+  <li>
+    <%= nav_link "Crontab with Supercronic", "/docs/app-guides/supercronic/" %>
   </li>
 </ul>
 


### PR DESCRIPTION
### Summary of changes

The guide index was out of date; the PR attempts to update it.

### Related Fly.io community and GitHub links
n/a

### Notes
This is a really old file. I'm not sure why 1) it's not an index under the app-guides directory, 2) why it uses nav formatting when it's not a nav partial. Can't use regular markdown in this file to fix it without changing it to `.html.md`. 
