### PR TITLE
C gpu docs 2

### DIFF
--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -4,35 +4,59 @@ layout: docs
 nav: firecracker
 ---
 
+## How do I run a GPU Machine on Fly.io?
+
+A Fly GPU Machine works very similarly to a CPU-only (or "normal") Fly Machine, and has access to the same platform features by default. It boots up with GPU drivers installed and you can run `nvidia-smi` right away. So to run a Fly App that uses CUDA compute is a slight variation on running any Fly App. In a nutshell:
+
+1. Make sure GPUs are enabled on your Fly Organization.
+1. Tell the Fly Platform to provision your Machines on Fly GPU hosts.
+1. Provide a Docker image or Dockerfile for your project that installs the NVIDIA libraries your project uses, alongside the rest of your project.
+1. Carry on as you would for any Fly App, tailoring it to the needs of your application.
+
+<div class="note icon">
+**Aside:** Firecracker doesn't do GPUs, so GPU-enabled Machines run under Cloud Hypervisor instead. This means you'll see some different output in logs, but in general you don't have to think about this.
+</div>
+
 ## Placing your Machines on GPU hosts
 
-Not all of Fly.io's physical servers have GPUs attached to them, so you have to specify the GPU in the Machine configuration before the Machine is created.
+Not all of Fly.io's physical servers have GPUs attached to them, so you have to tell the platform your requirements before the Machine is created on a host.
 
-Configuration is done by different means depending on whether you're using Fly Launch to manage your app, or running Machines individually using the API or `fly machines` commands.
+Configuration is done by different means depending on whether you're using Fly Launch to manage your app, or running Machines individually using the API or the [`fly machine run` command](/docs/machines/run/).
 
-Assuming that you're going the Fly Launch way and configuring your Machines app-wide, you can include the line
+### Specify the GPU model
+
+Assuming that you're going the [Fly Launch](/docs/apps/) way and configuring your Machines app-wide, you can include a line like the following in your `fly.toml` file before running `fly deploy` for the first time:
 
 ```
 vm.size = "a100-40gb"
 ```
 
-in `fly.toml` before running `fly deploy` for the first time. The `a100-40gb` preset specifies a `a100-pcie-40gb` GPU with the `performance-8x` CPU config and 32GB RAM. You can tailor your resources using the [`[[vm]]` table](https:///docs/reference/configuration/#the-vm-section) in `fly.toml`.
+The `a100-40gb` preset is the `a100-pcie-40gb` GPU with the `performance-8x` CPU config and 32GB RAM. You can tailor your resources using the [`[[vm]]` table](https:///docs/reference/configuration/#the-vm-section) in `fly.toml`.
 
-But you're not done! For `fly deploy` to succeed in provisioning your Machine(s), the app's `primary_region` must match a region that hosts the kind of GPU you're asking for. At the time of writing, `a100-pcie-40gb` GPUs are only available in `ord`. So specify the region in `fly.toml` :
+Run `fly platform vm-sizes` to get the list of presets, and [check out the pricing](https:///docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
+
+### Specify the region
+But you're not done! For `fly deploy` to succeed in provisioning your Machine(s), the app's `primary_region` must match a region that hosts the kind of GPU you're asking for. At the time of writing, `a100-pcie-40gb` GPUs are only available in `ord`. Set the initial region in `fly.toml`:
 
 ```
 primary_region = "ord"  # If you change this, ensure it's to a region that offers the GPU model you want
 ```
 
-GPU models are located in different regions, so you'll likely have to destroy any existing Machines before you can redeploy using a different GPU spec.
+Currently GPUs are available in the following regions:
 
-Run `fly platform vm-sizes` to get the list of presets, and [check out the pricing](https:///docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
+- `a100-40gb`: `ord`
+- `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
+
+
+### Change GPU model
+GPU models are located in different regions, so you'll likely have to destroy any existing Machines before redeploying using a different GPU spec.
+
 
 ## Choosing a Docker base image
 
-Many open-source inference projects have ready-made Docker images (ollama, basaran, localai [https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu)).
+Many open-source ML projects have ready-made Docker images; for example: [Ollama](https://ollama.ai/blog/ollama-is-now-available-as-an-official-docker-image), [Basaran](https://github.com/hyperonym/basaran), [LocalAI](https://localai.io/basics/getting_started/). Check out [GitHub `fly-apps` repos with the `gpu` topic](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu) for some examples.
 
-If you're building your own image, choose a base image that[ NVIDIA supports](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements); `ubuntu:22.04` is a solid choice that's compatible with the CUDA driver GPU Machines use. You can  launch a vanilla Ubuntu image and run `nvidia-smi` with no further setup.
+If you're building your own image, choose a base image that [NVIDIA supports](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements); `ubuntu:22.04` is a solid choice that's compatible with the CUDA driver GPU Machines use. You can launch a vanilla Ubuntu image and run `nvidia-smi` with no further setup.
 
 From there, install whatever packages your project needs. This will include some libraries from NVIDIA if you want to do something more than admire the output of `nvidia-smi`.
 
@@ -40,7 +64,7 @@ From there, install whatever packages your project needs. This will include some
 
 You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries)—`libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler)  for compiling stuff with CUDA support.
 
-In general, you'll install NVIDIA libs using your Linux package manager, but in a Python environment it's possible to skip system-wide installation and use pip packages instead.
+In general, you'll install NVIDIA libs using your Linux package manager. In a Python environment it's possible to skip system-wide installation and use pip packages instead.
 
 Tips:
 
@@ -58,16 +82,18 @@ Machine learning tends to involve large quantities of data. We're working with a
 - The root file system of a Fly Machine is ephemeral -- it's reset from its Docker image on every restart. It's also limited to 50GB on GPU-enabled Machines.
 - Fly Volumes are limited to 500GB, and are attached to a physical server. The Machine must run on the same hardware as the volume it mounts.
 
-Unless you've got a constant workload, you'll likely want to shut down GPU Machines when they're not needed—either manually with `fly machine stop`, or using the Fly Proxy autostop and autostart features—to save money. Saving data on a persistent Fly Volume saves having to download large amounts of data, or reconstitute a large Docker image into a rootfs, whenever the Machine restarts. You'll probably want to store models, at least, on a volume.
+Unless you've got a constant workload, you'll likely want to shut down GPU Machines when they're not needed&mdash;either manually with `fly machine stop`, or using the Fly Proxy autostop and autostart features&mdash;to save money. Saving data on a persistent Fly Volume saves having to download large amounts of data, or reconstitute a large Docker image into a rootfs, whenever the Machine restarts. You'll probably want to store models, at least, on a volume.
 
 ## Using swap
 
-It's frustrating to lose work because your process ran out of memory. You can enable swap on a Fly Machine simply by including a line like the following in `fly.toml`:
+Designing your workload and provisioning appropriate resources for it are the first line of defence against losing work by running out of memory (system RAM or VRAM). 
+
+You can also enable swap for system RAM on a Fly Machine, simply by including a line like the following in `fly.toml`:
 
 ```
 swap_size_mb = 32768    # This enables 32GB swap
 ```
 
-Keep in mind that this consumes the commensurate amount of space on the Machine's  root file system, leaving less capacity for whatever else you want to store there.
+Keep in mind that this consumes the commensurate amount of space on the Machine's root file system, leaving less capacity for whatever else you want to store there.
 
-If you need more RAM and fastest performance, also scale up with `fly scale memory`.
+If you need more system RAM and fastest performance, also scale up with `fly scale memory`.

--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -1,0 +1,73 @@
+---
+title: Getting Started with Fly GPUs
+layout: docs
+nav: firecracker
+---
+
+## Placing your Machines on GPU hosts
+
+Not all of Fly.io's physical servers have GPUs attached to them, so you have to specify the GPU in the Machine configuration before the Machine is created.
+
+Configuration is done by different means depending on whether you're using Fly Launch to manage your app, or running Machines individually using the API or `fly machines` commands.
+
+Assuming that you're going the Fly Launch way and configuring your Machines app-wide, you can include the line
+
+```
+vm.size = "a100-40gb"
+```
+
+in `fly.toml` before running `fly deploy` for the first time. The `a100-40gb` preset specifies a `a100-pcie-40gb` GPU with the `performance-8x` CPU config and 32GB RAM. You can tailor your resources using the [`[[vm]]` table](https:///docs/reference/configuration/#the-vm-section) in `fly.toml`.
+
+But you're not done! For `fly deploy` to succeed in provisioning your Machine(s), the app's `primary_region` must match a region that hosts the kind of GPU you're asking for. At the time of writing, `a100-pcie-40gb` GPUs are only available in `ord`. So specify the region in `fly.toml` :
+
+```
+primary_region = "ord"  # If you change this, ensure it's to a region that offers the GPU model you want
+```
+
+GPU models are located in different regions, so you'll likely have to destroy any existing Machines before you can redeploy using a different GPU spec.
+
+Run `fly platform vm-sizes` to get the list of presets, and [check out the pricing](https:///docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
+
+## Choosing a Docker base image
+
+Many open-source inference projects have ready-made Docker images (ollama, basaran, localai [https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu)).
+
+If you're building your own image, choose a base image that[ NVIDIA supports](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements); `ubuntu:22.04` is a solid choice that's compatible with the CUDA driver GPU Machines use. You can  launch a vanilla Ubuntu image and run `nvidia-smi` with no further setup.
+
+From there, install whatever packages your project needs. This will include some libraries from NVIDIA if you want to do something more than admire the output of `nvidia-smi`.
+
+## Installing NVIDIA libraries
+
+You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries)—`libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler)  for compiling stuff with CUDA support.
+
+In general, you'll install NVIDIA libs using your Linux package manager, but in a Python environment it's possible to skip system-wide installation and use pip packages instead.
+
+Tips:
+
+-  Be deliberate about how much cruft you put in your Docker image. Avoid meta-packages like `cuda-runtime-*`.
+- `cuda-libraries-12-2` is a convenient, but bulky, start. Once you know what libs are needed at build and runtime, please pick accordingly to optimize final image size.
+- Use multi-stage docker builds as much as possible.
+
+To install packages from NVIDIA repos, you'll need the `ca-certificates` and `cuda-keyring` packages first.
+
+## Where to store data
+
+Machine learning tends to involve large quantities of data. We're working with a few constraints:
+
+- Large Docker images (many gigabytes) can be very unwieldy to push and pull, particularly over large geographical distances.
+- The root file system of a Fly Machine is ephemeral -- it's reset from its Docker image on every restart. It's also limited to 50GB on GPU-enabled Machines.
+- Fly Volumes are limited to 500GB, and are attached to a physical server. The Machine must run on the same hardware as the volume it mounts.
+
+Unless you've got a constant workload, you'll likely want to shut down GPU Machines when they're not needed—either manually with `fly machine stop`, or using the Fly Proxy autostop and autostart features—to save money. Saving data on a persistent Fly Volume saves having to download large amounts of data, or reconstitute a large Docker image into a rootfs, whenever the Machine restarts. You'll probably want to store models, at least, on a volume.
+
+## Using swap
+
+It's frustrating to lose work because your process ran out of memory. You can enable swap on a Fly Machine simply by including a line like the following in `fly.toml`:
+
+```
+swap_size_mb = 32768    # This enables 32GB swap
+```
+
+Keep in mind that this consumes the commensurate amount of space on the Machine's  root file system, leaving less capacity for whatever else you want to store there.
+
+If you need more RAM and fastest performance, also scale up with `fly scale memory`.

--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -6,7 +6,7 @@ nav: firecracker
 
 ## How do I run a GPU Machine on Fly.io?
 
-A Fly GPU Machine works very similarly to a CPU-only (or "normal") Fly Machine, and has access to the same platform features by default. It boots up with GPU drivers installed and you can run `nvidia-smi` right away. So to run a Fly App that uses CUDA compute is a slight variation on running any Fly App. In a nutshell:
+A Fly GPU Machine works very similarly to a CPU-only (or "normal") Fly Machine, and has access to the same platform features by default. It boots up with GPU drivers installed and you can run `nvidia-smi` right away. So running a Fly App that uses CUDA compute is a slight variation on running any Fly App. In a nutshell:
 
 1. Make sure GPUs are enabled on your Fly Organization.
 1. Tell the Fly Platform to provision your Machines on Fly GPU hosts.
@@ -31,9 +31,9 @@ Assuming that you're going the [Fly Launch](/docs/apps/) way and configuring you
 vm.size = "a100-40gb"
 ```
 
-The `a100-40gb` preset is the `a100-pcie-40gb` GPU with the `performance-8x` CPU config and 32GB RAM. You can tailor your resources using the [`[[vm]]` table](https:///docs/reference/configuration/#the-vm-section) in `fly.toml`.
+The `a100-40gb` preset is the `a100-pcie-40gb` GPU with the `performance-8x` CPU config and 32GB RAM. You can exert more granular control over resources using the [`[[vm]]` table](https:///docs/reference/configuration/#the-vm-section) in `fly.toml`.
 
-Run `fly platform vm-sizes` to get the list of presets, and [check out the pricing](https:///docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
+Run `fly platform vm-sizes` to get the list of presets, and [check out the pricing page](https:///docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
 
 ### Specify the region
 But you're not done! For `fly deploy` to succeed in provisioning your Machine(s), the app's `primary_region` must match a region that hosts the kind of GPU you're asking for. At the time of writing, `a100-pcie-40gb` GPUs are only available in `ord`. Set the initial region in `fly.toml`:
@@ -64,12 +64,12 @@ From there, install whatever packages your project needs. This will include some
 
 You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries)—`libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler)  for compiling stuff with CUDA support.
 
-In general, you'll install NVIDIA libs using your Linux package manager. In a Python environment it's possible to skip system-wide installation and use pip packages instead.
+In general, you'll install NVIDIA libs using your Linux package manager. In a Python environment, it's possible to skip system-wide installation and use pip packages instead.
 
 Tips:
 
 -  Be deliberate about how much cruft you put in your Docker image. Avoid meta-packages like `cuda-runtime-*`.
-- `cuda-libraries-12-2` is a convenient, but bulky, start. Once you know what libs are needed at build and runtime, please pick accordingly to optimize final image size.
+- `cuda-libraries-12-2` is a convenient, but bulky, start. Once you know what libs are needed at build and runtime, pick accordingly to optimize final image size.
 - Use multi-stage docker builds as much as possible.
 
 To install packages from NVIDIA repos, you'll need the `ca-certificates` and `cuda-keyring` packages first.
@@ -82,7 +82,7 @@ Machine learning tends to involve large quantities of data. We're working with a
 - The root file system of a Fly Machine is ephemeral -- it's reset from its Docker image on every restart. It's also limited to 50GB on GPU-enabled Machines.
 - Fly Volumes are limited to 500GB, and are attached to a physical server. The Machine must run on the same hardware as the volume it mounts.
 
-Unless you've got a constant workload, you'll likely want to shut down GPU Machines when they're not needed&mdash;either manually with `fly machine stop`, or using the Fly Proxy autostop and autostart features&mdash;to save money. Saving data on a persistent Fly Volume saves having to download large amounts of data, or reconstitute a large Docker image into a rootfs, whenever the Machine restarts. You'll probably want to store models, at least, on a volume.
+Unless you've got a constant workload, you'll likely want to shut down GPU Machines when they're not needed&mdash;either manually with `fly machine stop`, or using the Fly Proxy autostop and autostart features&mdash;to save money. Saving data on a persistent Fly Volume means you don't have to download large amounts of data, or reconstitute a large Docker image into a rootfs, whenever the Machine restarts. You'll probably want to store models, at least, on a volume.
 
 ## Using swap
 

--- a/gpus/gpu-quickstart.html.markerb
+++ b/gpus/gpu-quickstart.html.markerb
@@ -1,7 +1,7 @@
 ---
 title: Fly GPUs quickstart
 layout: docs
-sitemap: false
+toc: false
 nav: firecracker
 ---
 

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -1,0 +1,47 @@
+---
+title: Fly GPUs
+layout: docs
+nav: firecracker
+---
+
+Fly.io has GPUs! If you have workloads that would benefit from GPU acceleration, Fly GPU Machines may be for you.
+
+<div class="important icon">
+Fly GPUs are only available to vetted orgs right now. Sign up [here](https://fly.io/gpu)! If you leave a good explanation on the waitlist of who you are and what you want to build with GPUs, you'll hear from us pretty quickly.
+</div>
+
+## What can I use Fly GPUs for?
+
+Fly GPUs are the NVIDIA A100 40G PCIe and A100 80G SXM. These units are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory.
+
+Right now each Fly GPU Machine uses a single full GPU. This is well suited to inference and maybe a smidgen of fine tuning. Training large models from scratch requires much beefier resources.
+
+Fly GPUs can be used for rendering, but are not optimized for it the way desktop GPUs are. The A100 is heavy on the tensor cores and has [no RT cores for ray tracing, and no NVENC video encoder](https://images.nvidia.com/aem-dam/en-zz/Solutions/data-center/nvidia-ampere-architecture-whitepaper.pdf).
+
+## How do I run a GPU Machine on Fly.io?
+
+A Fly GPU Machine works very similarly to a CPU-only (AKA "normal") Fly Machine, and has access to the same platform features by default. It boots up with GPU drivers installed and you can run `nvidia-smi` right away. So to run a Fly App that uses CUDA compute is a slight variation on running any Fly App. In a nutshell:
+
+1. Make sure GPUs are enabled on your Fly Organization.
+1. Tell the Fly Platform to provision your Machines on Fly GPU hosts.
+1. Provide a Docker image or Dockerfile for your project that includes the NVIDIA libraries your project uses, alongside the rest of your project .
+1. Carry on as you would for any Fly App, tailoring it to the needs of your application.
+
+<div class="note icon">
+**Aside:** Firecracker doesn't do GPUs, so GPU-enabled Machines run under Cloud Hypervisor instead. This means you'll see some different output in logs, but in general you don't have to think about this.
+</div>
+
+See the [GPU Quickstart](https://fly.io/docs/gpus/gpu-quickstart/) to get off the ground fast, or read more practicalities in [Getting started with Fly GPUs](/docs/gpus/getting-started-gpus/).
+
+
+
+
+## Examples
+
+Here's some more inspiration for your GPU Machines project:
+
+- [Python GPU Dev Machine](/docs/gpus/python-gpu-example/)
+- [Elixir Llama2-13b on Fly.io GPUs](https://gist.github.com/chrismccord/59a5e81f144a4dfb4bf0a8c3f2673131)
+- [Fly.io CUDA example](https://gist.github.com/dangra/f8123001fe0f2453a8cd638b89738465)
+- [Deploying CLIP on Fly.io](https://gist.github.com/simonw/52c7734e34cac2b26ea1378845674edc)
+- [Github `fly-apps` repos with the `gpu` topic](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu)

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -12,29 +12,13 @@ Fly GPUs are only available to vetted orgs right now. Sign up [here](https://fly
 
 ## What can I use Fly GPUs for?
 
-Fly GPUs are the NVIDIA A100 40G PCIe and A100 80G SXM. These units are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory.
+Fly GPUs are the NVIDIA A100 40G PCIe and A100 80G SXM ([datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf)). These units are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory.
 
-Right now each Fly GPU Machine uses a single full GPU. This is well suited to inference and maybe a smidgen of fine tuning. Training large models from scratch requires much beefier resources.
+Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to inference and maybe a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
 
 Fly GPUs can be used for rendering, but are not optimized for it the way desktop GPUs are. The A100 is heavy on the tensor cores and has [no RT cores for ray tracing, and no NVENC video encoder](https://images.nvidia.com/aem-dam/en-zz/Solutions/data-center/nvidia-ampere-architecture-whitepaper.pdf).
 
-## How do I run a GPU Machine on Fly.io?
-
-A Fly GPU Machine works very similarly to a CPU-only (AKA "normal") Fly Machine, and has access to the same platform features by default. It boots up with GPU drivers installed and you can run `nvidia-smi` right away. So to run a Fly App that uses CUDA compute is a slight variation on running any Fly App. In a nutshell:
-
-1. Make sure GPUs are enabled on your Fly Organization.
-1. Tell the Fly Platform to provision your Machines on Fly GPU hosts.
-1. Provide a Docker image or Dockerfile for your project that includes the NVIDIA libraries your project uses, alongside the rest of your project .
-1. Carry on as you would for any Fly App, tailoring it to the needs of your application.
-
-<div class="note icon">
-**Aside:** Firecracker doesn't do GPUs, so GPU-enabled Machines run under Cloud Hypervisor instead. This means you'll see some different output in logs, but in general you don't have to think about this.
-</div>
-
-See the [GPU Quickstart](https://fly.io/docs/gpus/gpu-quickstart/) to get off the ground fast, or read more practicalities in [Getting started with Fly GPUs](/docs/gpus/getting-started-gpus/).
-
-
-
+Go to the [GPU Quickstart](https://fly.io/docs/gpus/gpu-quickstart/) to get off the ground fast, or read more practicalities in [Getting started with Fly GPUs](/docs/gpus/getting-started-gpus/).
 
 ## Examples
 
@@ -44,4 +28,4 @@ Here's some more inspiration for your GPU Machines project:
 - [Elixir Llama2-13b on Fly.io GPUs](https://gist.github.com/chrismccord/59a5e81f144a4dfb4bf0a8c3f2673131)
 - [Fly.io CUDA example](https://gist.github.com/dangra/f8123001fe0f2453a8cd638b89738465)
 - [Deploying CLIP on Fly.io](https://gist.github.com/simonw/52c7734e34cac2b26ea1378845674edc)
-- [Github `fly-apps` repos with the `gpu` topic](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu)
+- [GitHub `fly-apps` repos with the `gpu` topic](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu)

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -2,6 +2,7 @@
 title: Fly GPUs
 layout: docs
 nav: firecracker
+toc: false
 ---
 
 Fly.io has GPUs! If you have workloads that would benefit from GPU acceleration, Fly GPU Machines may be for you.
@@ -12,11 +13,13 @@ Fly GPUs are only available to vetted orgs right now. Sign up [here](https://fly
 
 ## What can I use Fly GPUs for?
 
-Fly GPUs are the NVIDIA A100 40G PCIe and A100 80G SXM ([datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf)). These units are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory.
+Fly GPUs are currently either the NVIDIA A100 40G PCIe or A100 80G SXM ([datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf)). A100 units are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory.
 
-Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to inference and maybe a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
+The A100 is heavy on the tensor cores and has [no RT cores for ray tracing, and no NVENC video encoder](https://images.nvidia.com/aem-dam/en-zz/Solutions/data-center/nvidia-ampere-architecture-whitepaper.pdf).
 
-Fly GPUs can be used for rendering, but are not optimized for it the way desktop GPUs are. The A100 is heavy on the tensor cores and has [no RT cores for ray tracing, and no NVENC video encoder](https://images.nvidia.com/aem-dam/en-zz/Solutions/data-center/nvidia-ampere-architecture-whitepaper.pdf).
+We have some all-rounder L40S cards coming ([datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413)), still good for your AI workloads but equipped with both RT cores and NVENC.
+
+Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to rendering, encoding, inference, and maybe a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
 
 Go to the [GPU Quickstart](https://fly.io/docs/gpus/gpu-quickstart/) to get off the ground fast, or read more practicalities in [Getting started with Fly GPUs](/docs/gpus/getting-started-gpus/).
 

--- a/gpus/python-gpu-example.html.md
+++ b/gpus/python-gpu-example.html.md
@@ -1,0 +1,242 @@
+---
+title: Python GPU Dev Machine 
+layout: docs
+nav: firecracker
+---
+
+The goal: a CUDA-enabled Python template environment on a Fly GPU Machine, for working with ML models.
+
+We'll start with a minimal Ubuntu Linux, add a non-root user, and set up a Python virtual environment for a project, with Jupyter Notebook installed. NVIDIA libraries needed for the project can be installed to the persistent disk as needed, using pip.
+
+## Deployment to Fly.io
+### Create a Fly App
+```cmd
+ fly apps create <app-name>
+```
+
+### Clone the example repo
+```cmd
+git clone git@github.com:fly-apps/python_gpu_example.git && cd python_gpu_example
+```
+
+### Edit app configuration in `fly.toml`
+* At the least, change `app` to match the name of the app you just created.
+* Edit `primary_region` if wanted -- make sure to choose a region in which GPU Machines are available. Check the [docs](https://fly.io/docs/gpus/gpu-quickstart/) for GPU regions.
+* Optionally, change the NONROOT_USER `build.arg` -- if you do, also edit the `destination` of the volume mount in `mounts` to match.
+* Optionally, tweak `swap_size_mb`.
+
+### Deploy
+
+```cmd
+ fly deploy
+```
+ 
+ The `fly deploy` command launches the app, provisioning initial resources on first run. In this case, it creates one Fly Machine VM and one Fly Volume. When an app is configured to use a volume, `fly deploy` does not create a redundant or standby Machine.
+
+## Using the Machine
+
+### Jupyter notebook
+
+The easiest way to visit a private Fly App with the browser is with `fly proxy` command, which proxies a local port to a Machine.
+
+Run `fly logs` to find a line like 
+
+```
+http://127.0.0.1:8888/tree?token=c5fe8a87d8c00dd16637f0d4a1d8df7e3590c6a6064bbb6b
+```
+
+from Jupyter. Visit that link in the browser and you can start up a notebook.
+
+
+### Terminal
+
+Connect to the Machine using `fly ssh console`. To activate the configured venv, do the following:
+
+```
+# su pythonuser
+$ cd ~/project/
+$ source ~/project-venv/bin/activate 
+```
+
+Then you can install new pip packages to the persistent volume, download models, and run the Python REPL or execute scripts.
+
+To deactivate the venv, type `deactivate`. To drop back to the root user, hit <kbd>CTRL-D</kbd>.
+
+As the root user, you can use apt to manage system-wide software. Anything you install with apt is installed to the Machine's root file system, which means it disappears when the Machine next shuts down, so if you find yourself doing this, remember to add them to the Dockerfile, ready to be built into the image on the next deployment.
+
+## Fly.io-specific things
+Fly Launch doesn't have a scanner that will set this up just how we want, so the prep looks a lot like preparing a Docker container. We're configuring and running a Fly Machine instead, of course
+* We'll use `fly deploy` to launch the Machine using configuration stored in the Fly Launch app config file, `fly.toml`
+* Persistent storage is provided by a Fly Volume attached to the Machine
+* Fly GPU Machines come configured to use their GPU hardware, with NVIDIA drivers installed. You can launch a vanilla Ubuntu image and run nvidia-smi with no further setup
+* This project makes use of Fly.io IPv6 private networking. It could also be configured with a Fly Proxy service so it's available via a public Anycast or private Flycast IP address
+
+## General considerations
+There's no one right way to set up a project like this. Here are some of the considerations that went into the example:
+
+### Data storage
+Machine learning tends to involve large quantities of data. We're working with a few constraints:
+* Large Docker images (many gigabytes) can be very unwieldy to push and pull, particularly over large geographical distances.
+* The root file system of a Fly Machine is ephemeral&mdash;it's reset from its Docker image on every restart. It's also limited to 50GB on GPU-enabled Machines.
+* Fly Volumes are limited to 500GB, and are attached to a physical server. The Machine must run on the same hardware as the volume it mounts.
+
+We want to shut down GPU Machines when they're not needed, either manually with `fly machine stop`, or using the Fly Proxy autostop and autostart features, so it's not desirable to download many GB of models or libraries whenever the Machine restarts. 
+
+The compromise we use here is to generate a sub-1GB Docker image and store the project's pip packages and any downloaded data on the Fly Volume. This keeps all pip dependencies together in one venv for easy coordination and flexibility. With a well-established workload, you might make a different calculation; maybe all the projects deps actually fit in a manageable Docker image, and you can dispense with the volume storage, or some packages can we installed system-wide with apt, leaving less to manage with pip.
+
+### Compute
+The GPUs available at this time are `a100-sxm4-80gb` and `a100-pcie-40gb`, and you can use one GPU per Machine. We're not currently looking at model training on a massive scale; with careful design we can certainly do some reasonable inference on a single one of these cards. Here we're looking at running models manually so we'll stick with a single Machine, but an obvious use for Fly GPU Machines is as a "stateless" service for an app whose front end and any other components run on cheaper CPU-only Machines. This allows for independent horizontal scaling of front and back ends, as well as traffic-based capacity scaling by starting and stopping Machines.
+
+At this time, Fly GPU Machines are provisioned with the `performance-8x` CPU config and 32GB RAM by default. Playing very crudely with a language model, I found it easy to out-of-memory kill my Jupyter (Python) kernel with 32GB of RAM. If you need more RAM and fastest performance, scale up with `fly scale memory`, but losing work is annoying, so it's worth enabling swap.
+
+## Implementation specifics
+
+### App configuration
+The example `fly.toml` file does the following:
+
+* Sets the name of the app to deploy to. 
+* Sets the app's primary region, where `fly deploy` will put the initial Machine. Deployment will fail if this region doesn't have GPUs available (or is out of capacity).
+* Specifies Machine resources (most crucially a GPU) using a preset (`a100-40gb`).
+* Configures swap.
+* Sets a build argument that the Dockerfile uses to set the name of the non-root user.
+* Configures a volume mount. `fly deploy` provisions a new volume on first run (or when there's no Machine or Volume present on the app). You can specify the size for the initial volume here if desired.
+
+```toml
+app = "cgpu-allinone"   # Change this to your app's name
+primary_region = "ord"  # If you change this, ensure it's to a region that offers GPUs
+vm.size = "a100-40gb"   # A shorthand for the size preset in the [[vm]] section
+swap_size_mb = 32768    # This enables 32GB swap
+
+[build]
+  [build.args]
+    NONROOT_USER = "pythonuser" # Access this value in the Dockerfile using `ARG NONROOT_USER`
+
+# Use a volume to store LLMs or any big file that doesn't fit in a Docker image
+# This whole volume will be the non-root user's home directory
+[mounts]
+source = "data"
+destination = "/home/pythonuser"   # Make sure this matches the value of the NONROOT_USER build arg
+# initial_size = "50gb"            # Uncomment to set the size for the volume created on first deployment
+```
+
+### The Docker image
+
+Ready-made Docker images exist for many ML-related projects. There is a CUDA-enabled Jupyter Docker image, but it's kind of a black box and it's not maintained by the Jupyter folks, though they link to it. 
+
+Here we'll go step by step from a small Ubuntu image, installing and configuring a Python development environment that can use the GPU's CUDA capabilities, kind of like we would with a normal computer.
+
+Here's a summary of what the Dockerfile does;
+
+* Uses Ubuntu 22.04 as a base image, as it's compatible with the NVIDIA drivers on Fly Machines.
+* Installs system-wide packages with the apt package manager: python3, python3-pip, python3-venv, python3-wheel, git, nano (substitute your favourite terminal-compatible text editor here).
+* Adds a non-root user to own the Python venv and run things. Gets the name for this user from a `[build.arg]` set in `fly.toml`.
+* Copies the scripts for root and the user to run at startup.
+* CMD invokes the first script with the non-root user name as argument.
+
+```Dockerfile
+FROM ubuntu:22.04
+RUN apt update -q && apt install -y python3 python3-pip python3-venv python3-wheel git nano && \
+    apt clean && rm -f /var/lib/apt/lists/*_*
+
+ARG NONROOT_USER
+RUN echo "User will be $NONROOT_USER"
+ENV PYTHON_USER=$NONROOT_USER
+
+# Create unprivileged user with a home dir and using bash
+RUN useradd -ms /bin/bash $PYTHON_USER
+
+COPY --chmod=0755 ./entrypoint.sh ./entrypoint.sh
+COPY --chown=$PYTHON_USER:$PYTHON_USER --chmod=0755 ./post-initialization.sh ./post-initialization.sh
+# If you have a requirements.txt for the project, uncomment this and
+# adjust post-initialization.sh to use it
+# COPY --chown=$PYTHON_USER:$PYTHON_USER requirements.txt .
+
+# CMD ["sleep", "inf"]
+CMD ["/bin/bash", "-c", "./entrypoint.sh $PYTHON_USER"]
+```
+
+### Entrypoint script
+When this Machine boots, it runs the script `entrypoint.sh` as root. 
+
+This script gives the non-root user (whose username is set to `pythonuser` via a build argument in `fly.toml`) ownership of the non-root user's home directory to that user. This is necessary, because we're mounting a Fly Volume over that point in the Machine file system.
+
+Then it runs `nvidia-smi` to make sure the GPU drivers are loaded and the device is ready for the non-root user to use.
+
+Then it runs the next script (`post-initialization.sh`) as the non-root (`pythonuser`) user.
+
+You could instead have it run `sleep inf` here, and `fly ssh console` into the Machine after deployment to finish setting up the environment on the persistent volume.
+
+```bash
+#!/bin/bash
+
+USERNAME=$1
+
+echo "Inside entrypoint script."
+chown $USERNAME:$USERNAME /home/$USERNAME
+nvidia-smi # This seems to initialize the driver so that non-root user can use the GPU
+
+echo "About to run post-initialization script as $USERNAME."
+su -c "bash ./post-initialization.sh" $USERNAME
+```
+
+### Post-initialization script
+This script, `post-initialization.sh`, runs as the non-root user. It activates a virtual environment for the project and runs Jupyter from a project directory. It also puts some things on the persistent home directory, if they're absent. More specifically, it does this:
+
+* Ensures there's a dir called `~/project` with a Python virtual environment created
+* Activates this venv
+* Uses the presence or absence of the `jupyter` pip package as a proxy for whether it's the first run or not (if there was a venv, then it's not the first run, but it checks anyway). If Jupyter isn't installed, it installs it. Tailor this to whatever pip packages you want. If you want to run Jupyter on boot, `jupyter` is the only package you absolutely need here. You can install more pip packages persistently straight from the Jupyter notebook interface.
+* Starts a Jupyter server on the Machine's private IPv6 address so it's only accessible using Fly.io private networking--i.e. over a WireGuard connection (including user-mode WireGuard with the `fly proxy` command)
+  
+```bash
+#!/bin/bash
+
+PROJECT_DIR="project"
+VENV_DIR="$PROJECT_DIR-venv"
+
+echo "Running post-initialization script as $USER."
+echo "Entering $USER's home dir"
+cd ~
+echo "Creating venv dir for $PROJECT_DIR if it doesn't exist"
+mkdir -p $VENV_DIR 
+echo "Creating venv in $VENV_DIR if it doesn't exist"
+
+if [ ! -f "$VENV_DIR/pyvenv.cfg" ]; then
+    echo "No 'pyvenv.cfg' file found in $VENV_DIR; creating a venv"
+    python3 -m venv $VENV_DIR
+fi
+
+echo "Activating venv in $VENV_DIR"
+source $VENV_DIR/bin/activate
+
+echo "Creating dir $PROJECT_DIR if it doesn't exist"
+mkdir -p $PROJECT_DIR && cd $PROJECT_DIR
+# If you want to get project Python deps using requirements.txt, uncomment this and 
+# adjust the Dockerfile to copy the file into the image
+# cp /requirements.txt .
+
+# The following only installs pip packages if Jupyter isn't yet installed; 
+# essentially on first boot.
+if pip show jupyter &> /dev/null; then
+    echo "Jupyter is installed with pip."
+else
+    echo "Installing packages with pip"
+    # Uncomment to use requirements.txt. You can also install more packages
+    # after deployment. This Python venv lives on the persistent Fly Volume.
+    # pip install -r requirements.txt
+
+    # Install from scratch without a requirements.txt; some examples:
+    pip install jupyter 
+    # pip install numpy torch # numpy isn't getting installed as a dep of torch so do it explicitly
+    # pip install diffusers transformers accelerate # HuggingFace libs for specific projects
+fi
+
+echo "Starting Jupyter notebook server!"
+jupyter notebook --ip $FLY_PRIVATE_IP --no-browser
+
+# If you don't want Jupyter, use the `sleep inf` command instead, and 
+# `fly ssh console` into the Machine to interact with it.
+# sleep inf
+```
+
+
+This example project is meant to be a transparent template you can build on. Tailor this script to install different packages, use different directories, install from `requirements.txt`, or even skip Jupyter and use the `sleep inf` command to keep the Machine running so you can `fly ssh console` in and just work from the terminal or the Python REPL.

--- a/gpus/python-gpu-example.html.md
+++ b/gpus/python-gpu-example.html.md
@@ -4,14 +4,14 @@ layout: docs
 nav: firecracker
 ---
 
-The goal: a CUDA-enabled Python template environment on a Fly GPU Machine, for working with ML models.
+This is a worked example for a CUDA-enabled Python template environment on a Fly GPU Machine, for working with ML models.
 
 We'll start with a minimal Ubuntu Linux, add a non-root user, and set up a Python virtual environment for a project, with Jupyter Notebook installed. NVIDIA libraries needed for the project can be installed to the persistent disk as needed, using pip.
 
 ## Deployment to Fly.io
 ### Create a Fly App
 ```cmd
- fly apps create <app-name>
+fly apps create <app-name>
 ```
 
 ### Clone the example repo

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -94,6 +94,22 @@
 </ul>
 <ul class="outline-list">
   <li>
+    <%= nav_link "Fly GPUs", "/docs/gpus/" %>
+    <ul role="region" aria-label="Fly Apps">
+      <li>
+        <%= nav_link "GPU Quickstart", "/docs/gpus/gpu-quickstart/" %>
+      </li>
+       <li>
+        <%= nav_link "Getting Started with GPU Machines", "/docs/gpus/getting-started-gpus/" %>
+      </li>
+      <li>
+        <%= nav_link "Python GPU Dev Machine", "/docs/gpus/python-gpu-example/" %>
+      </li>
+    </ul>
+  </li>
+</ul>
+<ul class="outline-list">
+  <li>
     <%= nav_link "Databases & Storage", "/docs/database-storage-guides/" %>
     <ul role="region" aria-label="Databases & Storage">
       <li>


### PR DESCRIPTION
### Summary of changes

* Added a section for GPUs in the main docs sidebar
* Added a docs index page for GPUs (which would get nicer card-style links to content when we start doing cards in docs)
* Wrote up some practical observations in a Getting Started with Fly GPUs doc
* Stole some material from the GPU Quickstart doc for the Getting Started doc, but did not yet massage the Quickstart to tidy things up.
* Adapted, fairly roughly, the README from my [Python example repo](https://github.com/fly-apps/python_gpu_example) into an example doc.