### PR TITLE
Update docs for --rm option restart policy defaults

### DIFF
--- a/machines/guides-examples/machine-restart-policy.html.markerb
+++ b/machines/guides-examples/machine-restart-policy.html.markerb
@@ -9,7 +9,7 @@ The Machine restart policy defines whether and how flyd restarts a Machine after
 
 The restart policies are:
 
-- **`no`**: Never try to restart a Machine automatically when its main process exits, whether that’s on purpose or on a crash.
+- **`no`**: Never try to restart a Machine automatically when its main process exits, whether that’s on purpose or on a crash. `no` is the default when you use the `--rm` option to create a Machine with `fly m run` that auto-destroys on exit.
 
 - **`always`**: Always restart a Machine automatically and never let it enter a `stopped` state, even when the main process exits cleanly. `always` is the default when you create a Machine with `fly m run` and for Fly Postgres app Machines. Recommended for "always-on" apps with no services configured, since the Machine restarts regardless of the exit code.
 

--- a/machines/run.html.md
+++ b/machines/run.html.md
@@ -231,11 +231,15 @@ A Machine's [restart policy](/docs/machines/guides-examples/machine-restart-poli
 
 This policy does not apply when a Machine is stopped from outside, such as when you use the [fly machine stop](/docs/flyctl/machine-stop) command.
 
-Set it using the `--restart` option. Options are `no`, `always`, and `on-fail`; the default for a Machine created using `fly machine run` is `always`.
+Set it using the `--restart` option. Options are `no`, `always`, and `on-fail`. 
 
-## Remove the Machine when it exits
+The default restart policy for a Machine created using `fly machine run` is `always`, unless you use the [`--rm` option](#automatically-destroy-the-machine-when-it-exits), in which case the default is `no`.
 
-By default, when a Machine is `stopped`, its file system is reset using its config and Docker image, and it sits ready to be `started` again. Use the `--rm` flag to cause the Machine to instead be removed.
+## Automatically destroy the Machine when it exits
+
+By default, when a Machine is `stopped`, its file system is reset using its config and Docker image, and it sits ready to be `started` again. Use the `--rm` flag to cause the Machine to instead be destroyed when it stops.
+
+The default [restart policy](#set-a-restart-policy-on-process-exit) for a Machine created with `fly machine run --rm` is `no`, to ensure that flyd doesn't ignore the exit code and restart the Machine.
 
 ## Mount a Fly Volume
 


### PR DESCRIPTION
### Summary of changes

- update the run a Machine doc to clarify that the `--rm` option destroys the Machine. And that the default restart policy for Machines created with `--rm` is `no`.
- update the restart policy doc for same

### Related Fly.io community and GitHub links
https://github.com/superfly/flyctl/pull/3086

### Notes
n/a
