### PR TITLE
fix Javascript/javascript --> JavaScript case typo

### DIFF
--- a/caching/full-stack.html.md
+++ b/caching/full-stack.html.md
@@ -11,7 +11,7 @@ Users prefer fast applications regardless of scale. The standard caching APIs in
 
 Responsiveness is usually a function of latency. When a user requests data, applications typically deal with:
 
-* Input lag, how long it takes something they type/clip/tap/say to appear on the screen. If your app is simple you hopefully don't have to worry about this. If you put in a load of third party javascript, it might be a problem.
+* Input lag, how long it takes something they type/clip/tap/say to appear on the screen. If your app is simple you hopefully don't have to worry about this. If you put in a load of third party JavaScript, it might be a problem.
 * The "slow" speed of light: when a user sends data to your backend, they have to wait for a light to go from their device, through their ISP (which can be frightfully slow), across the world, and into your server.
 * Data processing time: you probably have to do some computering to handle a user's request and then generate a response.
 * The speed of light again! Your server sends data, it traverses the internet, arrives at the users (frightfully slow) ISP and lands on their device.

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -35,7 +35,7 @@
         <%= nav_link "Run a Django App", "/docs/django/getting-started/" %>
       </li>
       <li>
-        <%= nav_link "Run a Javascript App", "/docs/js/" %>
+        <%= nav_link "Run a JavaScript App", "/docs/js/" %>
       </li>
       <li>
         <%= nav_link "More...", "/docs/languages-and-frameworks/" %>

--- a/rails/cookbooks/node.html.markerb
+++ b/rails/cookbooks/node.html.markerb
@@ -5,7 +5,7 @@ order: 3
 ---
 
 If your application is based on Rails 5.2 through 6.1, or is a Rails 7 app
-selecting one of the javascript options or many of the css options, you will
+selecting one of the JavaScript options or many of the css options, you will
 require Node.js to be included in your deployment image.
 
 While it is unsurprising that the slim ruby image doesn't include Nodejs by


### PR DESCRIPTION
### Summary of changes
Changed Javascript/javascript typo to JavaScript
### Related Fly.io community and GitHub links
n/a

### Notes
n/a
