### PR TITLE
Update docs on regional failover - set top-level primary_region as well

### DIFF
--- a/postgres/advanced-guides/high-availability-and-global-replication.html.markerb
+++ b/postgres/advanced-guides/high-availability-and-global-replication.html.markerb
@@ -53,7 +53,7 @@ If you haven't already pulled down your `fly.toml` configuration file, you can d
 fly config save --app <app-name>
 ```
 
-Now, let's open up the `fly.toml` file and set the `PRIMARY_REGION` [top-level config setting](https://fly.io/docs/reference/configuration/#primary-region) and environment variable to our target region. In this example, we are looking to move leadership into the `lax` region.
+Now, let's open up the `fly.toml` file and set the [`primary_region`](https://fly.io/docs/reference/configuration/#primary-region) and the `PRIMARY_REGION` environment variable to our target region. In this example, we are looking to move leadership into the `lax` region.
 ```toml
 primary_region = "lax"
 

--- a/postgres/advanced-guides/high-availability-and-global-replication.html.markerb
+++ b/postgres/advanced-guides/high-availability-and-global-replication.html.markerb
@@ -26,7 +26,7 @@ Provisioning a new machine with image registry-1.docker.io/flyio/postgres:14...
 Machine has been successfully cloned!
 ```
 
-This will clone the spec from the source machine and use it to create the new replica in a desired region.  
+This will clone the spec from the source machine and use it to create the new replica in a desired region.
 
 
 ## Performing a failover
@@ -46,15 +46,17 @@ Failover complete
 
 ## Performing a regional failover
 
-There may be situations where you want to move leadership into a completely new region.  While this process is a bit more involved, you can achieve this by performing the steps below.  
+There may be situations where you want to move leadership into a completely new region.  While this process is a bit more involved, you can achieve this by performing the steps below.
 
 If you haven't already pulled down your `fly.toml` configuration file, you can do so by running:
 ```
 fly config save --app <app-name>
 ```
 
-Now, let's open up the `fly.toml` file and set the `PRIMARY_REGION` environment variable to our target region. In this example, we are looking to move leadership into the `lax` region. 
+Now, let's open up the `fly.toml` file and set the `PRIMARY_REGION` [top-level config setting](https://fly.io/docs/reference/configuration/#primary-region) and environment variable to our target region. In this example, we are looking to move leadership into the `lax` region.
 ```toml
+primary_region = "lax"
+
 [env]
 PRIMARY_REGION = "lax"
 ```
@@ -70,7 +72,7 @@ e784927ad23583  registry-1.docker.io  flyio/postgres  14.4  v0.0.32 sha256:9daaa
 148e275b1d1d89  registry-1.docker.io  flyio/postgres  14.4  v0.0.32 sha256:9daaa15119742e5777f5480ef476024e8827016718b5b020ef33a5fb084b60e8
 ```
 
-Take note of the version specified within the `Tag` column, we will be using this in our next command. 
+Take note of the version specified within the `Tag` column, we will be using this in our next command.
 
 **Warning: This deploy process will result in a small amount of downtime.  Once the PRIMARY_REGION change has been deployed, your cluster will become read-only until the failover process completes.**
 
@@ -78,7 +80,7 @@ Take note of the version specified within the `Tag` column, we will be using thi
 fly deploy . --image flyio/postgres:<tag> --strategy=immediate
 ```
 
-Once the deploy process has completed, we can now work to transfer leadership into our new region.
+Once the deploy process has completed, we can now work to transfer leadership into our new region. Ensure the new region has at least three healthy replicas to maintain quorum (see above on how to add more replicas), then:
 ```cmd
 fly pg failover
 ```
@@ -89,7 +91,7 @@ Performing a failover
 Failover complete
 ```
 
-That's it! You should now run `fly status` to verify your changes. 
+That's it! You should now run `fly status` to verify your changes.
 
 ## Connecting to read replicas
 
@@ -112,14 +114,14 @@ class Fly
     primary = ENV["PRIMARY_REGION"]
     current = ENV["FLY_REGION"]
     db_url = ENV["DATABASE_URL"]
-    
+
     if primary.blank? || current.blank? || primary == current
       return db_url
     end
-    
+
     u = URI.parse(db_url)
     u.port = 5433
-    
+
     return u.to_s
   end
 end


### PR DESCRIPTION
### Summary of changes
Mention that when doing a regional failover the top-level primary_region must be set - this was noted by a support customer and we verified this experimentally.

### Related Fly.io community and GitHub links
n/a

### Notes
On tests, if only the environment variable is set, then failover doesn't happen at all.
