### PR TITLE
pricing page: add L40S pricing

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -55,8 +55,10 @@ Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (se
 
 On-demand GPU pricing:
 
+* L40S: $2.50/hr per GPU
 * A100 40G PCIe: $2.50/hr per GPU
 * A100 80G SXM: $3.50/hr per GPU
+
 
 Usage terms:
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -59,7 +59,6 @@ On-demand GPU pricing:
 * A100 40G PCIe: $2.50/hr per GPU
 * A100 80G SXM: $3.50/hr per GPU
 
-
 Usage terms:
 
 * No minimum usage requirements.


### PR DESCRIPTION
### Summary of changes
We now have L40S cards. This change adds a line to our pricing page for them.