### PR TITLE
add instructions to switch to shared ipv4

### DIFF
--- a/reference/services.html.markerb
+++ b/reference/services.html.markerb
@@ -59,9 +59,9 @@ The following steps should allow you to switch an app with a custom domain from 
 
 1. Add shared IPv4 via `flyctl ips allocate-v4 --shared`
 2. If you don't use a CNAME to `.fly.dev`, [add the shared ipv4 as an A record](https://fly.io/docs/apps/custom-domain/#set-the-a-record).
-3. Confirm your app works via shared IP: `curl -Iv http://<your-hostname> --resolve <your-hostname>:80:<shared ipv4 you got>`. You should receive a 301 redirect response.
+3. Confirm your app works via shared IP: `curl -Iv http://<your-hostname> --resolve <your-hostname>:80:<new-shared-ipv4>`. You should receive a 301 redirect response.
 4. Wait for DNS caches to clear. Five minutes is likely enough, but this varies wildly. This is determined by the larger of your DNS record’s TTL and that of our `<your-app>.fly.dev record`.
-5. Remove the dedicated IPv4 from the app using `fly ips release <IP-address-to-release>`. You can view your app's IP addresses using `fly ips list`.
+5. Remove the dedicated IPv4 from the app using `fly ips release <ipv4-address-to-release>`. You can view your app's IP addresses using `fly ips list`.
 6. Remove the unwanted IPv4 address from your DNS if it was set manually as an A record.
 
 ## Connection handlers

--- a/reference/services.html.markerb
+++ b/reference/services.html.markerb
@@ -49,8 +49,20 @@ fly ips allocate-v4
 
 when needed; for example, if you want your app to handle TCP directly.
 
+If your app has a shared IPv4 address and you allocate a dedicated one, the shared IPv4 is released automatically.
 
-IPv6 addresses are free. Global IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
+IPv6 addresses and shared IPv4 anycast addresses are free. Dedicated IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
+
+### Switch from dedicated IPv4 to shared IPv4
+
+The following steps should allow you to switch an app with a custom domain from a dedicated IPv4 address to a free shared IPv4 without downtime:
+
+1. Add shared IPv4 via `flyctl ips allocate-v4 --shared`
+2. If you don't use a CNAME to `.fly.dev`, [add the shared ipv4 as an A record](https://fly.io/docs/apps/custom-domain/#set-the-a-record).
+3. Confirm your app works via shared IP: `curl -Iv http://<your-hostname> --resolve <your-hostname>:80:<shared ipv4 you got>`. You should receive a 301 redirect response.
+4. Wait for DNS caches to clear. Five minutes is likely enough, but this varies wildly. This is determined by the larger of your DNS record’s TTL and that of our `<your-app>.fly.dev record`.
+5. Remove the dedicated IPv4 from the app using `fly ips release <IP-address-to-release>`. You can view your app's IP addresses using `fly ips list`.
+6. Remove the unwanted IPv4 address from your DNS if it was set manually as an A record.
 
 ## Connection handlers
 


### PR DESCRIPTION
### Summary of changes
Adds instructions for changing from a paid dedicated ipv4 address to a shared one

### Related Fly.io community and GitHub links
Adapted from @jeromegn's instructions at  https://community.fly.io/t/we-are-going-to-start-charging-for-dedicated-ipv4-in-january-1st/15970/24

### Notes
With the switch-on of actual billing for paid IPv4, there's a lot of interest in switching to free shared IPv4 addresses 
