### PR TITLE
Add callouts explaining that volumes can't be mounted at `/`

### DIFF
--- a/apps/volume-storage.html.markerb
+++ b/apps/volume-storage.html.markerb
@@ -25,6 +25,10 @@ Use [Fly Launch](/docs/apps/) to create a new app with one Machine and an attach
       destination="/data"
     ```
 
+<aside class="callout">
+<b>Note:</b> You can't mount a volume with `destination="/"` since `/` is used for the root file system.
+</aside>
+
 1. Deploy the app:
 
     ```cmd

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -598,7 +598,7 @@ The `source` is a volume name that this app should mount. Any volume with this n
 
 ### `destination`
 
-The `destination` is the directory where the `source` volume should be mounted on the running app.
+The `destination` is the directory where the `source` volume should be mounted on the running app. This cannot be `/` since that's where the root file system is mounted.
 
 ### `processes`
 


### PR DESCRIPTION
### Summary of changes

Add a callout in the two sections discussing `[mounts]` config to explain that you can't use `destination="/"`.

### Related Fly.io community and GitHub links
https://community.fly.io/t/cant-create-a-volume-for-the-entire-filesystem/17553?u=jfent

### Notes
n/a
