### PR TITLE
Shared IPv4 needs a cert for custom domain

### DIFF
--- a/app-guides/custom-domains-with-fly.html.md
+++ b/app-guides/custom-domains-with-fly.html.md
@@ -7,12 +7,11 @@ categories:
   - ssl
   - custom domains
   - guide
-date: 2020-07-20
 ---
 
-An application's brand is often encapsulated in its domain name and that in turn is wrapped with value. So being able to configure secure custom domains is essential.
+An application's brand is often encapsulated in its domain name, and that in turn is wrapped with value. So being able to configure secure custom domains is essential.
 
-Fly.io offers a simple command-line process for manual configuration of custom domains and a GraphQL API for people integrating Fly custom domains into their automated workflows. Here, we'll be looking at both - and answering the question, which one should you use?
+Fly.io offers a simple command-line process for manual configuration of custom domains and a GraphQL API for people integrating Fly.io custom domains into their automated workflows. Here, we'll be looking at both - and answering the question, which one should you use?
 
 ## Teaching your app about custom domains
 
@@ -24,7 +23,7 @@ If you're running your application on another provider, you will need to create 
 
 ## Creating a custom domain on Fly.io manually
 
-There's a question to ask and answer. Do you want to start accepting traffic immediately on your custom domain or do you want to have your domain ready with certificates when you set it to start accepting traffic, for example when you want to cut over from another platform to Fly.
+There's a question to ask and answer. Do you want to start accepting traffic immediately on your custom domain or do you want to have your domain ready with certificates when you set it to start accepting traffic, for example when you want to cut over from another platform to Fly.io.
 
 ### Accepting traffic immediately for the custom domain
 
@@ -38,10 +37,10 @@ It's the quickest way to get set up, but there are catches. First, it is ever so
 
 #### Option II: A and AAAA records
 
-We can skip all CNAME concerns by setting A and AAAA records on your custom domain. Run `flyctl ips list` to see your app's addresses:
+We can skip all CNAME concerns by setting A and AAAA records on your custom domain. Run `fly ips list` to see your app's addresses:
 
 ```cmd
-flyctl ips list
+fly ips list
 ```
 ```output
   TYPE   ADDRESS                                CREATED AT
@@ -56,19 +55,19 @@ Create an A record pointing to your v4 address, and an AAAA record pointing to y
 Once these settings are in place, you can add the custom domain to the application's certificates. If we are configuring example.com, then we would simply run:
 
 ```cmd
-flyctl certs create example.com
+fly certs create example.com
 ```
 
 If you are using [dedicated IPs](https://fly.io/docs/reference/services/#dedicated-ipv4) and want to add a wildcard domain, remember to place quotes around the hostname to avoid inadvertent shell expansion:
 
 ```cmd
-flyctl certs create "*.example.com"
+fly certs create "*.example.com"
 ```
 
 This will kick off the process of validating your domain and generating certificates. You can check on the progress if you run:
 
 ```cmd
-flyctl certs show example.com
+fly certs show example.com
 ```
 ```output
   Hostname                    = example.com
@@ -93,19 +92,19 @@ This process allows certificates to be issued before the domain is live and acce
 The process starts with adding the certificate to the application like so:
 
 ```cmd
-flyctl certs create example.com
+fly certs create example.com
 ```
 
 Again, if you are creating a wildcard domain, remember to place quotes around the hostname to avoid inadvertent shell expansion:
 
 ```cmd
-flyctl certs create "*.example.com"
+fly certs create "*.example.com"
 ```
 
 Now we have created the certificate, we need to ask for the CNAME entry that has to be set up. For this, we run `fly certs show`:
 
 ```cmd
-flyctl certs show example.com
+fly certs show example.com
 ```
 ```output
   Hostname                    = example.com
@@ -131,23 +130,23 @@ DNS Validation Instructions = CNAME _acme-challenge.example.com => example.com.o
 
 Basically, the Validation Hostname, when looked up, should send requests to the Validation Target, a Fly-generated validation service. To do this, add the contents of the Validation Instructions to your DNS records; that is create a CNAME record which points the _acme-challenge subdomain to the Validation target.
 
-Once you have done that, wait as the validation and certificate issuing happens (check in with `flyctl certs check`). When complete, you'll be able to turn on the traffic whenever you are ready. You'll be able to do that either by setting the CNAME or by setting the A and AAAA records as described previously.
+Once you have done that, wait as the validation and certificate issuing happens (check in with `fly certs check`). When complete, you'll be able to turn on the traffic whenever you are ready. You'll be able to do that either by setting the CNAME or by setting the A and AAAA records as described previously.
 
 ### Other commands
 
-Finally, we should point out the other `flyctl certs` commands which you will want to use.
+Finally, we should point out the other `fly certs` commands which you will want to use.
 
-* `flyctl certs list` - Lists the hostnames which have been added to an application and for which certificates may have been obtained.
-* `flyctl certs check hostname` - Triggers a check on the domain validation and DNS configuration for the given host and return results in the same format as `flyctl certs show`.
-* `flyctl certs delete hostname` - Removes the hostname from the application, dropping the certificates in the process.
+* `fly certs list` - Lists the hostnames which have been added to an application and for which certificates may have been obtained.
+* `fly certs check hostname` - Triggers a check on the domain validation and DNS configuration for the given host and return results in the same format as `fly certs show`.
+* `fly certs delete hostname` - Removes the hostname from the application, dropping the certificates in the process.
 
 ## Automating the certificate process
 
-To illustrate how to automate the certificates API, we are going to show the `flyctl` command line and the equivalent GraphQL request, wrapped in a compact easy-to-read Node application from our [fly-examples/hostnamesapi](https://github.com/fly-apps/hostnamesapi) repository.
+To illustrate how to automate the certificates API, we are going to show the flyctl command and the equivalent GraphQL request, wrapped in a compact easy-to-read Node application from our [fly-examples/hostnamesapi](https://github.com/fly-apps/hostnamesapi) repository.
 
 ### GraphQL API Notes
 
-**Endpoints**: The Endpoint for the Fly API is `https://api.fly.io/graphql`. 
+**Endpoints**: The Endpoint for the Fly.io GraphQL API is `https://api.fly.io/graphql`. 
 
 **Authentication**: All queries require an API token which be obtained by signing into the [Fly.io web dashboard](https://fly.io/dashboard/apps/), selecting **Account** ➡︎ **Settings** ➡︎ **Access Tokens** ➡︎ **Create Access Token**. Create a new token and carefully note the value; we suggest placing it in an environment variable such as `FLY_API_TOKEN` so it can be passed to applications. When used with the API, the token should be passed in an `Authorization` header with the value `Bearer <token value>`.
 
@@ -155,7 +154,7 @@ To illustrate how to automate the certificates API, we are going to show the `fl
 
 ### Listing all the hosts of an application
 
-**With Flyctl**: `flyctl certs list`
+**With flyctl**: `fly certs list`
 
 **With GraphQL**: The example is in the repository as [getcerts.js](https://github.com/fly-apps/hostnamesapi/blob/master/getcerts.js). This request takes the application name as a parameter.
 
@@ -200,7 +199,7 @@ This lists every host associated with the application. Each host may have up to 
 
 ### Creating a certificate for an application
 
-**With Flyctl**: `flyctl certs create <hostname>`
+**With flyctl**: `fly certs create <hostname>`
 
 **With GraphQL**: The example is [addcert.js](https://github.com/fly-apps/hostnamesapi/blob/master/getcerts.js). This request takes the application id and hostname as parameters.
 
@@ -253,7 +252,7 @@ The returned data here includes all the values needed to configure DNS records f
 
 ### Reading a certificate from an application
 
-**With Flyctl**: `flyctl certs show hostname`
+**With flyctl**: `fly certs show hostname`
 
 **With GraphQL**: The example is [getcert.js](https://github.com/fly-apps/hostnamesapi/blob/master/getcert.js). This request takes the application name and hostname as parameters.
 
@@ -325,7 +324,7 @@ Most of the output duplicates the details from adding a certificate, including t
 
 ### Checking a certificate
 
-**With Flyctl**: `flyctl certs check hostname`
+**With flyctl**: `fly certs check hostname`
 
 **With GraphQL**: The example is [checkcert.js](https://github.com/fly-apps/hostnamesapi/blob/master/checkcert.js). This request takes the application name and hostname as parameters. It is essentially the same as reading the certificate, but the presence of a request for the certificate's check value will start a validation process. The output is similar too.
 
@@ -358,11 +357,9 @@ query($appName: String!, $hostname: String!) {
 }
 ```
 
-
 ### Deleting a certificate
 
-
-**With Flyctl**: `flyctl certs delete hostname`
+**With flyctl**: `fly certs delete hostname`
 
 **With GraphQL**: The example is [deletecert.js](https://github.com/fly-apps/hostnamesapi/blob/master/deletecert.js). This request takes the application name and hostname as parameters and will remove the hostname from the application.
 
@@ -428,5 +425,4 @@ You can then verify that the change has propagated and the TXT record is no long
 
 ## Wrapping up
 
-You have everything you need to either hand assign a custom domain to your Fly.io application or to create your own automated multi-domain proxy. Let your ideas take flight with Fly.io.
-
+You have everything you need to either hand assign a custom domain to your Fly.io application or to create your own automated multi-domain proxy.

--- a/app-guides/custom-domains-with-fly.html.md
+++ b/app-guides/custom-domains-with-fly.html.md
@@ -19,7 +19,7 @@ Your application code needs to know how to accept custom domains and adjust the 
 
 When users make requests, their browser sends a `Host` header you can use to alter the behavior of your application. When you run your app server on Fly.io directly, just get the contents of the `Host` header to identify a request.
 
-If you're running your application on another provider, you will need to create a proxy application (like [NGINX](/docs/app-guides/global-nginx-proxy/)) to route traffic through Fly. Your application can then use the `X-Forwarded-Host` header to determine how to handle requests.
+If you're running your application on another provider, you will need to create a proxy application (like [NGINX](/docs/app-guides/global-nginx-proxy/)) to route traffic through Fly.io. Your application can then use the `X-Forwarded-Host` header to determine how to handle requests.
 
 ## Creating a custom domain on Fly.io manually
 
@@ -83,7 +83,7 @@ fly certs show example.com
   Status                      = Ready
 ```
 
-Configured should be true and Status will show ready when the certificates are available. The Issued field will show which types of certificates are available - RSA and/or ECDSA. Once they are issued, you'll be ready to run with your custom domain.
+`Configured` should be true and `Status` will show `Ready` when the certificates are available. The `Issued` field shows which types of certificates are available: RSA and/or ECDSA. Once they are issued, you'll be ready to run with your custom domain.
 
 ### Configuring certificates before accepting traffic
 
@@ -120,7 +120,7 @@ fly certs show example.com
   Status                      = 
 ```
 
-The specific part to focus in here are the DNS Validation fields:
+The specific part to focus on here are the `DNS Validation` fields:
 
 ```
 DNS Validation Instructions = CNAME _acme-challenge.example.com => example.com.o055.flydns.net.
@@ -128,13 +128,13 @@ DNS Validation Instructions = CNAME _acme-challenge.example.com => example.com.o
   DNS Validation Target       = example.com.o055.flydns.net
 ```
 
-Basically, the Validation Hostname, when looked up, should send requests to the Validation Target, a Fly-generated validation service. To do this, add the contents of the Validation Instructions to your DNS records; that is create a CNAME record which points the _acme-challenge subdomain to the Validation target.
+Basically, the `Validation Hostname`, when looked up, should send requests to the `Validation Target`, a Fly.io-generated validation service. To do this, add the contents of the `Validation Instructions` to your DNS records; that is create a CNAME record which points the `_acme-challenge` subdomain to the `Validation Target`.
 
 Once you have done that, wait as the validation and certificate issuing happens (check in with `fly certs check`). When complete, you'll be able to turn on the traffic whenever you are ready. You'll be able to do that either by setting the CNAME or by setting the A and AAAA records as described previously.
 
 ### Other commands
 
-Finally, we should point out the other `fly certs` commands which you will want to use.
+Finally, we should point out the other `fly certs` commands.
 
 * `fly certs list` - Lists the hostnames which have been added to an application and for which certificates may have been obtained.
 * `fly certs check hostname` - Triggers a check on the domain validation and DNS configuration for the given host and return results in the same format as `fly certs show`.

--- a/apps/custom-domain.html.markerb
+++ b/apps/custom-domain.html.markerb
@@ -29,9 +29,12 @@ You'll need to configure the A record with your DNS provider. You need to add in
 
 ## Get certified
 
-To enable HTTPS on the domain, you need to get a certificate. Fly.io does that for you automatically.
+You'll need an SSL certificate for your domain if your app:
 
-It starts with creating a certificate for your custom domain with the `fly certs add` command. For example:
+1. should accept HTTPS connections, or
+1. uses a shared IPv4 [anycast address](https://fly.io/docs/reference/services/#ip-addresses). The Fly Proxy uses the cert to associate the custom domain name with your app for routing purposes.
+
+Create a certificate for your custom domain with the `fly certs add` command. For example:
 
 ```cmd
 fly certs add example.com

--- a/reference/services.html.markerb
+++ b/reference/services.html.markerb
@@ -55,14 +55,17 @@ IPv6 addresses and shared IPv4 anycast addresses are free. Dedicated IPv4 addres
 
 ### Switch from dedicated IPv4 to shared IPv4
 
-The following steps should allow you to switch an app with a custom domain from a dedicated IPv4 address to a free shared IPv4 without downtime:
+The following steps should allow you to switch an app with a custom domain from a dedicated IPv4 address to a free shared IPv4 without downtime. 
 
-1. Add shared IPv4 via `flyctl ips allocate-v4 --shared`
-2. If you don't use a CNAME to `.fly.dev`, [add the shared ipv4 as an A record](https://fly.io/docs/apps/custom-domain/#set-the-a-record).
+1. Add a shared IPv4 address via `flyctl ips allocate-v4 --shared`
+2. If you don't use a CNAME to `.fly.dev`, [add the shared IPv4 as an A record](https://fly.io/docs/apps/custom-domain/#set-the-a-record).
 3. Confirm your app works via shared IP: `curl -Iv http://<your-hostname> --resolve <your-hostname>:80:<new-shared-ipv4>`. You should receive a 301 redirect response.
-4. Wait for DNS caches to clear. Five minutes is likely enough, but this varies wildly. This is determined by the larger of your DNS record’s TTL and that of our `<your-app>.fly.dev record`.
-5. Remove the dedicated IPv4 from the app using `fly ips release <ipv4-address-to-release>`. You can view your app's IP addresses using `fly ips list`.
-6. Remove the unwanted IPv4 address from your DNS if it was set manually as an A record.
+4. If you are using a custom domain and don't already have an SSL certificate for this app, [create one](https://fly.io/docs/apps/custom-domain/#get-certified). The cert is required for routing to your app via the custom domain, even for HTTP connections.
+5. Wait for DNS caches to clear. Five minutes is likely enough, but this varies wildly. This is determined by the larger of your DNS record’s TTL and that of our `<your-app>.fly.dev` record.
+6. Remove the dedicated IPv4 from the app using `fly ips release <ipv4-address-to-release>`. You can view your app's IP addresses using `fly ips list`.
+7. Remove the unwanted IPv4 address from your DNS if it was set manually as an A record.
+
+If you do not have a custom domain (your app is accessed by its `.fly.dev` address), you don't have to change any DNS records yourself, and you don't need to add your own SSL cert.
 
 ## Connection handlers
 

--- a/reference/services.html.markerb
+++ b/reference/services.html.markerb
@@ -37,8 +37,6 @@ If you want to allocate a shared IPv4 to an app without a public IPv4 address, t
 fly ips allocate-v4 --shared
 ```
 
-This command will fail if the app has a dedicated IPv4 address. You can release an IP with `fly ips release <address>`.
-
 ### Dedicated IPv4
 
 Allocating a dedicated IPv4 anycast address is now opt-in only, but can still be done manually with


### PR DESCRIPTION
### Summary of changes
When an app uses shared IPv4, Fly Proxy needs an SSL cert to know which app to route a custom domain address to, even if HTTPS isn't used. This PR adds this info to:
* https://fly.io/docs/reference/services/ (instructions for moving to shared ipv4)
* https://fly.io/docs/apps/custom-domain/
* https://fly.io/docs/app-guides/custom-domains-with-fly/

Also did minor cleanup and corrected out-of-date statement that allocating shared IPv4 would fail if dedicated IPv4 was present.

### Related Fly.io community and GitHub links
https://community.fly.io/t/new-shared-ipv4-connection-reset-by-peer/17567
