### PR TITLE
Add smoke checks info to deploy and troubleshooting docs

### DIFF
--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -47,6 +47,10 @@ Machines created using `fly deploy` (or as part of a deployment during `fly laun
 
 New Machines created using `fly machine run` don't have the V2 Apps metadata, and are not automatically managed by Fly Launch (`fly deploy`), so these Machines can have their own configuration different from that of the App, and can even be based on a different Docker image.
 
+<div class="important icon">
+**Important:** We don't recommend adding unmanaged Machines to a Fly Launch app if you ever plan to scale the app to zero Machines. If you scale your Fly Launch Machines to zero, and have unmanaged Machines created with `fly machine run`, then you won't be able to deploy your app with `fly deploy` until you delete the unmanaged Machines.
+</div>
+
 ## Volume mounts and `fly deploy`
 
 If a Machine has a mounted [volume](/docs/volumes/), `fly deploy` can't be used to mount a different one. You can change the mount point at which the volume's data is available in the Machine's file system, though. This is configured in the [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) of `fly.toml`.
@@ -70,7 +74,6 @@ You can specify one of the following deployment strategies:
 * `bluegreen`: boot a new Machine alongside each running Machine in the same region, and migrate traffic to the new Machines only once all the new Machines pass health checks
 
 Learn more about [setting a deployment strategy](/docs/reference/configuration/#picking-a-deployment-strategy).
-
 
 ```cmd
 fly deploy --strategy canary
@@ -99,3 +102,12 @@ Updating existing machines in 'example-app-8803' with canary strategy
 You can [add an IP address](/docs/reference/services/#ip-addresses) to an App, for example, without redeploying.
 
 Adding a [secret](/docs/reference/secrets/) to the App does require a restart, so `fly secrets set` triggers a new deployment.
+
+## Smoke checks
+
+Smoke checks monitor Machines during deployment, for about 10 seconds after a Machine enters the started state, to make sure the Machine stays running. If a Machine is constantly restarting with a non-zero exit code during this time, then the smoke check fails and the deployment is stopped. If possible, the smoke check failure output includes an excerpt of the logs to help you diagnose the issue with your app. 
+
+## Related topics
+
+- [Fly Launch](/docs/apps/launch/)
+- [Troubleshooting your deployment](/docs/getting-started/troubleshooting/)

--- a/getting-started/troubleshooting.html.md
+++ b/getting-started/troubleshooting.html.md
@@ -156,6 +156,10 @@ fastify.listen({ port: 3000, host: '0.0.0.0' }, function (err, address) {
 
 Then make sure that the `internal_port` value in `fly.toml` is set to `3000`.
 
+## Smoke checks failing
+
+Smoke checks run during deployment to make sure that a crashing app doesn't get successfully deployed to all your app's Machines. If possible, the smoke check failure output includes an excerpt of the logs to help you diagnose the issue with your app. Common issues with new apps might include [Machine size](#out-of-memory-oom-or-high-cpu-usage), missing environment variables, or other problems with the app's configuration.
+
 ## Health checks failing
 
 We don't automatically add health checks to your `fly.toml` file when you create your app. The health checks that you subsequently add to your app can fail for a number of reasons.


### PR DESCRIPTION
### Summary of changes

- add smoke check description (and a related links section) to Deploy a Fly App doc
- add smoke check info to Troubleshooting your deployment doc

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
