### PR TITLE
add a note about mixed machines in one app

### DIFF
--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -43,7 +43,7 @@ If the app to be deployed is configured with an eligible HTTP `[[services]]` sec
 
 ## Machines not managed by Fly Launch
 
-Machines created using `fly deploy` (or as part of a deployment during `fly launch`), or by `fly clone`ing such a Machine, carry a piece of metadata marking them as belonging to Fly Launch (`"fly_platform_version": "v2"`). These machines are updated as a group on all subsequent `fly deploy` commands.
+Machines created using `fly deploy` (or as part of a deployment during `fly launch`), or by `fly clone`ing such a Machine, carry a piece of metadata marking them as belonging to Fly Launch (`"fly_platform_version": "v2"`). These Machines are updated as a group on all subsequent `fly deploy` commands.
 
 New Machines created using `fly machine run`, also known as unmanaged Machines, don't have the `fly_platform_version` metadata, and are not automatically managed by Fly Launch. These unmanaged Machines can have their own configuration different from that of the App, and can even be based on a different Docker image.
 

--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -47,6 +47,10 @@ Machines created using `fly deploy` (or as part of a deployment during `fly laun
 
 New Machines created using `fly machine run` don't have the V2 Apps metadata, and are not automatically managed by Fly Launch (`fly deploy`), so these Machines can have their own configuration different from that of the App, and can even be based on a different Docker image.
 
+<div class="important icon">
+**Important:** We don't recommend adding unmanaged Machines to a Fly Launch app if you ever plan to scale the app to zero Machines. If you scale your Fly Launch Machines to zero, and have unmanaged Machines created with `fly machine run`, then you won't be able to deploy your app with `fly deploy` until you delete the unmanaged Machines.
+</div>
+
 ## Volume mounts and `fly deploy`
 
 If a Machine has a mounted [volume](/docs/volumes/), `fly deploy` can't be used to mount a different one. You can change the mount point at which the volume's data is available in the Machine's file system, though. This is configured in the [`[mounts]` section](/docs/reference/configuration/#the-mounts-section) of `fly.toml`.

--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -43,9 +43,9 @@ If the app to be deployed is configured with an eligible HTTP `[[services]]` sec
 
 ## Machines not managed by Fly Launch
 
-Machines created using `fly deploy` (or as part of a deployment during `fly launch`), or by `fly clone`ing such a Machine, carry a piece of metadata marking them as belonging to Fly Launch. These machines are updated as a group on all subsequent `fly deploy` commands, as are Machines that existed on a Machines App at the moment that it was migrated to a V2 App.
+Machines created using `fly deploy` (or as part of a deployment during `fly launch`), or by `fly clone`ing such a Machine, carry a piece of metadata marking them as belonging to Fly Launch (`"fly_platform_version": "v2"`). These machines are updated as a group on all subsequent `fly deploy` commands.
 
-New Machines created using `fly machine run` don't have the V2 Apps metadata, and are not automatically managed by Fly Launch (`fly deploy`), so these Machines can have their own configuration different from that of the App, and can even be based on a different Docker image.
+New Machines created using `fly machine run`, also known as unmanaged Machines, don't have the `fly_platform_version` metadata, and are not automatically managed by Fly Launch. These unmanaged Machines can have their own configuration different from that of the App, and can even be based on a different Docker image.
 
 <div class="important icon">
 **Important:** We don't recommend adding unmanaged Machines to a Fly Launch app if you ever plan to scale the app to zero Machines. If you scale your Fly Launch Machines to zero, and have unmanaged Machines created with `fly machine run`, then you won't be able to deploy your app with `fly deploy` until you delete the unmanaged Machines.

--- a/apps/deploy.html.markerb
+++ b/apps/deploy.html.markerb
@@ -34,7 +34,7 @@ Here's how `fly deploy` determines how to get the app's Docker image:
 
 1. If an image is specified, either with the `--image` option or in the `[build]` section of `fly.toml`, use that image, regardless of the presence of a Dockerfile in the working directory or the use of the `--dockerfile` option.
 2. Otherwise, check the [`[build]` section of `fly.toml`](/docs/reference/configuration/#the-build-section) and use the method specified there, whether it's a Dockerfile or a buildpack (but don't use buildpacks if you don't have to; they're brittle, bloated, and prone to change).
-3. Otherwise, if the `--dockerfile` flag supplies a path to a Dockerfile, use that Dockerfile to build the image. You read that right. The `--dockerfile` flag is looked at _after_ the `[build]` section of the config file. This will hopefully change soon.
+3. Otherwise, if the `--dockerfile` flag supplies a path to a Dockerfile, use that Dockerfile to build the image. You read that right. The `--dockerfile` flag is looked at _after_ the `[build]` section of the config file.
 4. Otherwise, if there's a `Dockerfile` (named exactly `Dockerfile` or `dockerfile`) in the local working directory, use that Dockerfile for the build.
 
 ## IP addresses


### PR DESCRIPTION
### Summary of changes

Add a note to the Machines not managed by Fly Launch section of the Fly Deploy doc about not being able to deploy after scaling to zero when an app has a mixture of Fly Launch-managed and unmanaged Machines.

### Related Fly.io community and GitHub links
https://github.com/superfly/flyctl/issues/2867

### Notes
n/a
