### PR TITLE
chore: organize databases section

### DIFF
--- a/database-storage-guides.html.md
+++ b/database-storage-guides.html.md
@@ -46,11 +46,22 @@ If your application calls for a different solution, you can deploy it yourself a
 
 If you want a fully managed database or storage solution for your Fly Apps, there are many great options, including:
 
+### MySQL
+
+- [PlanetScale Serverless MySQL](https://planetscale.com/) ([guide to use with Fly Apps](/docs/app-guides/planetscale/))
+
+### Object Storage
+
+- [MinIO Hosted Object Storage](https://min.io/)
+
+### Postgres
+
 - [Crunchy Bridge Managed Postgres](https://www.crunchydata.com/products/crunchy-bridge) (on AWS, Azure, GCP, or Heroku)
 - [Neon Serverless Postgres](https://neon.tech/)
-- [PlanetScale Serverless MySQL](https://planetscale.com/) ([guide to use with Fly Apps](/docs/app-guides/planetscale/))
 - [Supabase Postgres](https://supabase.com/database)
-- [MinIO Hosted Object Storage](https://min.io/)
+
+### Other
+
 - [Fauna](https://fauna.com/) ([guide to use with Fly Apps](/docs/app-guides/fauna/))
 
 ## Other Places


### PR DESCRIPTION
### Summary of changes

I found the database section a bit confusing, because at first I thought Minio, Planetscale, and Neon all did the same thing. In fact, Minio is an object storage system, and Planetscale/Neon are database systems. I wanted to offer a quick PR to organize this section and sort it to make it a bit easier to navigate, and to illustrate how many diverse options for storage there are on Fly.

#### Changelog

- chore: organize sections for database options by technology
- chore: organize database sections lexicographically

### Related Fly.io community and GitHub links
n/a

### Notes
n/a
