### PR TITLE
Update UDP service doc to include the IPv6 rule does not apply to 6PN

### DIFF
--- a/app-guides/udp-and-tcp.html.markerb
+++ b/app-guides/udp-and-tcp.html.markerb
@@ -176,6 +176,10 @@ Another thing that won't impact your code that you'll need to know about is that
 
 Every Fly.io app gets an IPv6 address, and that address will work fine for the TCP side of your app, for whatever that's worth.
 
+<div class="note icon">
+This does not apply to 6PN; UDP over 6PN works just as you would expect.
+</div>
+
 ### You Might Need To Be Mindful Of MTUs
 
 An invariant on almost every network is the maximum packet size, the MTU. Typically, the MTU is 1500 bytes. If you exceed 1500 bytes, your packets will fragment. [You don't want to fragment](https://datatracker.ietf.org/doc/html/draft-mathis-frag-harmful-00).

--- a/app-guides/udp-and-tcp.html.markerb
+++ b/app-guides/udp-and-tcp.html.markerb
@@ -177,7 +177,7 @@ Another thing that won't impact your code that you'll need to know about is that
 Every Fly.io app gets an IPv6 address, and that address will work fine for the TCP side of your app, for whatever that's worth.
 
 <div class="note icon">
-This does not apply to 6PN; UDP over 6PN works just as you would expect.
+**Note:** UDP does work over [Fly.io IPv6 private networking](/docs/reference/private-networking/).
 </div>
 
 ### You Might Need To Be Mindful Of MTUs


### PR DESCRIPTION
### Summary of changes

One of our customers at the community forum wanted to use UDP over 6PN for app communication, and was confused about it working over 6PN or not as UDP services do not IPv6.

### Related Fly.io community and GitHub links
https://community.fly.io/t/internal-app-to-app-or-machine-to-machine-udp-communication/17533

### Notes
n/a
