### PR TITLE
regions, monitor, vm no longer have doc pages

### DIFF
--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -60,7 +60,7 @@
       </li>
       <li>
         <%= flyctl_nav_link "View or update App image", "/docs/flyctl/image/" %>
-      </li>      
+      </li>
       <li>
         <%= flyctl_nav_link "Manage IP addresses", "/docs/flyctl/ips/" %>
       </li>
@@ -69,9 +69,6 @@
       </li>
       <li>
         <%= flyctl_nav_link "View App logs", "/docs/flyctl/logs/" %>
-      </li>
-      <li>
-        <%= flyctl_nav_link "Monitor deployments", "/docs/flyctl/monitor/" %>
       </li>
       <li>
         <%= flyctl_nav_link "Manage Organizations", "/docs/flyctl/orgs/" %>
@@ -90,9 +87,6 @@
       </li>
       <li>
         <%= flyctl_nav_link "Manage Redis instances", "/docs/flyctl/redis/" %>
-      </li>
-      <li>
-        <%= flyctl_nav_link "Selecting Regions", "/docs/flyctl/regions/" %>
       </li>
       <li>
         <%= flyctl_nav_link "Manage App releases", "/docs/flyctl/releases/" %>
@@ -123,9 +117,6 @@
       </li>
       <li>
         <%= flyctl_nav_link "Check flyctl version", "/docs/flyctl/version/" %>
-      </li>
-      <li>
-        <%= flyctl_nav_link "Manage VM instances", "/docs/flyctl/vm/" %>
       </li>
       <li>
         <%= flyctl_nav_link "Manage Disks", "/docs/flyctl/volumes/" %>


### PR DESCRIPTION
a few of our doc pages in the sidebar no longer exist: https://fly.io/docs/flyctl/

so we might as well remove the links.