### PR TITLE
Revert "Document addition of --org flag to `fly tokens create org`"

### DIFF
--- a/flyctl/cmd/flyctl_tokens_create_org.md
+++ b/flyctl/cmd/flyctl_tokens_create_org.md
@@ -12,7 +12,6 @@ flyctl tokens create org [flags]
   -h, --help              help for org
   -j, --json              JSON output
   -n, --name string       Token name (default "Org deploy token")
-  -o, --org string        The target Fly.io organization
 ~~~
 
 ## Global Options


### PR DESCRIPTION
Reverts superfly/docs#1288

docs are generated automatically!