### PR TITLE
Update link for connecting LiveBook to your app on Fly

### DIFF
--- a/elixir/advanced-guides/interesting-things-with-livebook.html.md
+++ b/elixir/advanced-guides/interesting-things-with-livebook.html.md
@@ -14,7 +14,7 @@ date: 2021-06-22
 
 Livebook ends up being very flexible and powerful. Because Elixir nodes can easily be clustered together, you can run Livebook on your local machine, connect it to your Elixir servers, and do some really interesting things.
 
-Once you have [Livebook connected to your app on Fly](), you are ready to start playing!
+Once you have [Livebook connected to your app on Fly](/docs/elixir/advanced-guides/connect-livebook-to-your-app/), you are ready to start playing!
 
 ## Getting Started with Livebook
 


### PR DESCRIPTION
### Summary of changes

Update the link so it points to the page it's titled for ;)

Head to https://fly.io/docs/elixir/advanced-guides/interesting-things-with-livebook/ and see this link isn't pointing to the page getting LiveBook connected to your app on Fly.

<img width="756" alt="image" src="https://github.com/superfly/docs/assets/136013/e7789905-08fa-4ef1-b926-fb2259ac42cc">


### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
