### PR TITLE
Add Machines landing page

### DIFF
--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -5,7 +5,7 @@ nav: machines
 redirect_from: /docs/reference/machines/
 ---
 
-Fly Machines are fast-launching VMs that can be started and stopped at subsecond speeds and deployed in regions all over the world.
+Fly Machines are the engine of the Fly.io platform: fast-launching VMs that can be started and stopped at subsecond speeds. Control them with their fast REST API or the flyctl CLI. Or use [Fly Launch](/docs/reference/fly-launch/) for opinionated app-wide configuration and deployment.
 
 ## Learn
 
@@ -29,6 +29,8 @@ Using Machines.
 
 ## Reference
 
-Commands and APIs for volumes.
+Commands and APIs for Machines.
 
 [Machines API Spec](https://docs.machines.dev/swagger/index.html/)
+
+[flyctl commands - `fly machine`](/docs/flyctl/machine/)

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -5,153 +5,30 @@ nav: machines
 redirect_from: /docs/reference/machines/
 ---
 
-Fly Machines are:
+Fly Machines are fast-launching VMs that can be started and stopped at subsecond speeds and deployed in regions all over the world.
 
-* [The engine](https://fly.io/blog/fly-machines/) behind the Fly.io platform: super-fast lightweight VMs that,
-  once created, can be started and stopped at subsecond speeds. 
+## Learn
 
-* [A REST API](/docs/machines/working-with-machines/) you can use for precise control over groups of Machines to deploy
-  and scale out applications. 
+Understand how Machines work and other things you need to know when you have low-level control of powerful VMs on Fly.io.
 
-<section class="warning icon">
-**This is a low-level interface**.
+[Fly Machines overview](/docs/machines/overview)
 
-Use Fly Machines directly when you need to be picky about how, where, and when to start VMs on Fly.io. For most
-applications, most of the time, you don't need to be picky! You scale things up to more cores or more memory, and
-out to more regions and more VM counts. [Fly Launch](/docs/apps) does all that for you with simple syntax. 
+[Machine sizing](/docs/machines/guides-examples/machine-sizing/)
 
-🌶️ **But some applications get spicy.**🌶️ This is our spicy interface! We use it to build the orchestration
-for `fly launch`, but you can use it however you'd like. 
-</section>
+## How-Tos
 
-## Concepts
+Using Machines.
 
-### Machines
+[Run a new Machine](/docs/machines/run/)
 
-A Machine is the configuration and state for a single VM running on our platform. Every Machine will belong to a Fly App; Apps 
-can have more than one Machine. You can start a Machine right now, without configuring anything: 
+[Work with the Machines API](/docs/machines/working-with-machines)
 
-```cmd
-fly machine run --shell
-```
+[Set a Machine restart policy](/docs/machines/guides-examples/machine-restart-policy/)
 
-```output
-? Select Organization: (personal)
-Searching for image 'ubuntu' remotely...
-Image size: 30 MB
+[Run user code on Fly Machines](/docs/machines/guides-examples/functions-with-machines/)
 
-Success! A machine has been successfully launched in app flyctl-interactive-shells-g1b7jg6wpdbq0i8b8yrl4q9rlqu5pm-502673
- Machine ID: d8d9510a295118
-Connecting to fdaa:1:18:a7b:191:1aa9:a2a5:2... complete
-root@d8d9510a295118:/# uname -a
-Linux d8d9510a295118 5.15.98-fly #gf0950f1d7c SMP Sun Sep 17 02:33:12 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
-```
+## Reference
 
-Go ahead and try it! When you `run` a Machine with `--shell`, we'll make a small one, and we'll tear it down when you're done poking around.
+Commands and APIs for volumes.
 
-### Machine state
-
-The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast. Doing things like 
-that is why you'd use Fly Machines directly, rather than a [Fly App](https://fly.io/docs/apps/deploy/). 
-
-To get your head around that trick, start by understanding the lifecycle of a Fly Machine:
-
-1. You create a Fly Machine with a [Create Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_create), or 
-   with `fly machine create`. The Machine is in `created` state. This step can take some time: you're asking us to reserve space
-   for your Machine, and then fetch your container from our global registry, and build a root file system; low double digit seconds, maybe. 
-   
-2. Now that the Fly Machine exists, you can start it with a [Start Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_start), or 
-   with `fly machine start`. We boot a VM. The Machine is in `started` state. It's running. You can talk to it. This happens fast! Everything's
-   already assembled; we're just booting. Usually this takes _well under a second_.
-   
-3. You're done with the Fly Machine, so you stop it with a [Stop Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_stop), or
-  `fly machine stop`. The VM shuts down. The Machine is in `stopped` state. Its components are still assembled on our worker host, ready to start back up; if
-   you want to do that, `GOTO 2`. 
-   
-4. You're tired of the Fly Machine, and want it to go away. Send a [Delete Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_delete), or 
-   use `fly machine destroy`. We clear the resources we were holding for the Machine off our server. You can easily create and start
-   a new Machine from the same image, but it'll be slower than stopping and starting an existing Machine. 
-
-Here's [more detail on using flyctl to manage individual Machines](/docs/machines/guides-examples/machines-app-using-flyctl/).
-
-### Scaling Machines
-
-<div class="important icon">
-Remember, the ordinary way to scale an application on Fly.io is to use [Fly Launch](/docs/apps), which offers convenient
-commands to scale instances out or up. Here, we're going to scale Machines directly, in a fiddly way.
-
-Whether or not you use `fly launch` to boot up a Fly App, every Machine belongs to an "App" (an "App" is ultimately just a named 
-collection of resources, configuration, and routing rules). But you don't have to use the `fly apps` commands to manage Machines;
-you can do it directly.
-</div>
-
-Scale a workload out horizontally with `fly machine clone`:
-
-```cmd
-fly machine clone -a my-app --region ord 7811373c095228
-```
-
-```output
-Cloning machine 7811373c095228 into region ord
-Provisioning a new machine with image registry-1.docker.io/my-app/sleep:latest@sha256:597c3e
-  Machine 28749edf4047d8 has been created...
-  Waiting for machine 28749edf4047d8 to start...
-Machine has been successfully cloned!
-```
-   
-You can clone a specific Machine as many times as you like, into specific regions; you can manage each of those Machines
-individually with `fly machine stop` and `fly machine start`.
-
-Scale a Machine up vertically with `fly machine update`:
-
-```cmd
-fly machine update -a my-app --vm-memory 512M 7811373c095228
-```
-
-```output
-Configuration changes to be applied to machine: 7811373c095228 (twilight-field-6033)
-
-  	... // 12 identical lines
-  	    "cpu_kind": "shared",
-  	    "cpus": 1,
-- 	    "memory_mb": 256
-+ 	    "memory_mb": 512
-  	  },
-  	  "dns": {}
-  	}
-  	
-? Apply changes? Yes
-Updating machine 7811373c095228
-No health checks found
-Machine 7811373c095228 updated successfully!
-```
-
-Updating a Machine takes it down (like with `fly machine stop`), applies configuration changes, and brings it back up. If you're
-not changing the image, so we don't have to go fetch it from the global registry, this is fast, for the same reason `stop` and `start`
-are; we've already done the heavy lifting. 
-
-### Placement
-
-When you `create`, `run`, or `clone` a Machine, you can pick a Fly.io region to place it in. Our API will contact the Machines API
-server (we call it `flaps`, but you don't have to care), which will in turn reach out to all the worker servers we have in the region, 
-find out which ones have the requisite resources to host the Machine, and try to make a smart choice about which of those servers to 
-put the Machine in.
-
-You don't get to pick particular servers (there are ways to cheat and do it anyways, but you shouldn't want to), just the region. 
-
-If you pick a particular region, like `ord` or `yyz`, we will _only_ create the Machine in that region. 
-
-<section class="warning icon">
-**Placement can fail!** It shouldn't happen often, but we can run out of capacity in particular regions. Both flyctl and the Fly Machines 
-API are best-effort. If you're working with us at this level of control, it's on you to retry requests and ensure they go through. In exchange for
-that burden, we try to make sure the Fly Machines API is responsive, so you get quick answers.
-</section>
-
-## Recapping Fly Machine features
-
-* Manage with the Machines API or flyctl commands
-* Stop automatically when a program exits
-* Stop or start quickly, either manually or automatically based on traffic
-* Provide ephemeral storage, a blank slate on every startup 
-* Attach a volume for persistent storage
-* Place in any region
+[Machines API Spec](https://docs.machines.dev/swagger/index.html/)

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -5,15 +5,11 @@ nav: machines
 redirect_from: /docs/reference/machines/
 ---
 
-Fly Machines are fast-launching VMs. 
+Fly Machines are fast-launching VMs. They are:
 
-Machines are:
+* [The engine](https://fly.io/blog/fly-machines/) behind the Fly.io platform: once created, Machines can be started and stopped at subsecond speeds. 
 
-* [The engine](https://fly.io/blog/fly-machines/) behind the Fly.io platform: super-fast lightweight VMs that,
-  once created, can be started and stopped at subsecond speeds. 
-
-* [A REST API](/docs/machines/working-with-machines/) you can use for precise control over groups of Machines to deploy
-  and scale out applications. 
+* [A REST API](/docs/machines/working-with-machines/) you can use for precise control over groups of Machines to deploy and scale out applications. 
 
 <section class="warning icon">
 **This is a low-level interface**.

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -1,0 +1,158 @@
+---
+title: "Fly Machines overview"
+layout: docs
+nav: machines
+redirect_from: /docs/reference/machines/
+---
+
+Fly Machines are fast-launching VMs. 
+
+Machines are:
+
+* [The engine](https://fly.io/blog/fly-machines/) behind the Fly.io platform: super-fast lightweight VMs that,
+  once created, can be started and stopped at subsecond speeds. 
+
+* [A REST API](/docs/machines/working-with-machines/) you can use for precise control over groups of Machines to deploy
+  and scale out applications. 
+
+<section class="warning icon">
+**This is a low-level interface**.
+
+Use Fly Machines directly when you need to be picky about how, where, and when to start VMs on Fly.io. For most
+applications, most of the time, you don't need to be picky! You scale things up to more cores or more memory, and
+out to more regions and more VM counts. [Fly Launch](/docs/apps) does all that for you with simple syntax. 
+
+🌶️ **But some applications get spicy.**🌶️ This is our spicy interface! We use it to build the orchestration
+for `fly launch`, but you can use it however you'd like. 
+</section>
+
+## Concepts
+
+### Machines
+
+A Machine is the configuration and state for a single VM running on our platform. Every Machine will belong to a Fly App; Apps 
+can have more than one Machine. You can start a Machine right now, without configuring anything: 
+
+```cmd
+fly machine run --shell
+```
+
+```output
+? Select Organization: (personal)
+Searching for image 'ubuntu' remotely...
+Image size: 30 MB
+
+Success! A machine has been successfully launched in app flyctl-interactive-shells-g1b7jg6wpdbq0i8b8yrl4q9rlqu5pm-502673
+ Machine ID: d8d9510a295118
+Connecting to fdaa:1:18:a7b:191:1aa9:a2a5:2... complete
+root@d8d9510a295118:/# uname -a
+Linux d8d9510a295118 5.15.98-fly #gf0950f1d7c SMP Sun Sep 17 02:33:12 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+Go ahead and try it! When you `run` a Machine with `--shell`, we'll make a small one, and we'll tear it down when you're done poking around.
+
+### Machine state
+
+The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast. Doing things like 
+that is why you'd use Fly Machines directly, rather than a [Fly App](https://fly.io/docs/apps/deploy/). 
+
+To get your head around that trick, start by understanding the lifecycle of a Fly Machine:
+
+1. You create a Fly Machine with a [Create Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_create), or 
+   with `fly machine create`. The Machine is in `created` state. This step can take some time: you're asking us to reserve space
+   for your Machine, and then fetch your container from our global registry, and build a root file system; low double digit seconds, maybe. 
+   
+2. Now that the Fly Machine exists, you can start it with a [Start Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_start), or 
+   with `fly machine start`. We boot a VM. The Machine is in `started` state. It's running. You can talk to it. This happens fast! Everything's
+   already assembled; we're just booting. Usually this takes _well under a second_.
+   
+3. You're done with the Fly Machine, so you stop it with a [Stop Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_stop), or
+  `fly machine stop`. The VM shuts down. The Machine is in `stopped` state. Its components are still assembled on our worker host, ready to start back up; if
+   you want to do that, `GOTO 2`. 
+   
+4. You're tired of the Fly Machine, and want it to go away. Send a [Delete Machine request](https://docs.machines.dev/swagger/index.html#/Machines/Machines_delete), or 
+   use `fly machine destroy`. We clear the resources we were holding for the Machine off our server. You can easily create and start
+   a new Machine from the same image, but it'll be slower than stopping and starting an existing Machine. 
+
+Here's [more detail on using flyctl to manage individual Machines](/docs/machines/guides-examples/machines-app-using-flyctl/).
+
+### Scaling Machines
+
+<div class="important icon">
+Remember, the ordinary way to scale an application on Fly.io is to use [Fly Launch](/docs/apps), which offers convenient
+commands to scale instances out or up. Here, we're going to scale Machines directly, in a fiddly way.
+
+Whether or not you use `fly launch` to boot up a Fly App, every Machine belongs to an "App" (an "App" is ultimately just a named 
+collection of resources, configuration, and routing rules). But you don't have to use the `fly apps` commands to manage Machines;
+you can do it directly.
+</div>
+
+Scale a workload out horizontally with `fly machine clone`:
+
+```cmd
+fly machine clone -a my-app --region ord 7811373c095228
+```
+
+```output
+Cloning machine 7811373c095228 into region ord
+Provisioning a new machine with image registry-1.docker.io/my-app/sleep:latest@sha256:597c3e
+  Machine 28749edf4047d8 has been created...
+  Waiting for machine 28749edf4047d8 to start...
+Machine has been successfully cloned!
+```
+   
+You can clone a specific Machine as many times as you like, into specific regions; you can manage each of those Machines
+individually with `fly machine stop` and `fly machine start`.
+
+Scale a Machine up vertically with `fly machine update`:
+
+```cmd
+fly machine update -a my-app --vm-memory 512M 7811373c095228
+```
+
+```output
+Configuration changes to be applied to machine: 7811373c095228 (twilight-field-6033)
+
+  	... // 12 identical lines
+  	    "cpu_kind": "shared",
+  	    "cpus": 1,
+- 	    "memory_mb": 256
++ 	    "memory_mb": 512
+  	  },
+  	  "dns": {}
+  	}
+  	
+? Apply changes? Yes
+Updating machine 7811373c095228
+No health checks found
+Machine 7811373c095228 updated successfully!
+```
+
+Updating a Machine takes it down (like with `fly machine stop`), applies configuration changes, and brings it back up. If you're
+not changing the image, so we don't have to go fetch it from the global registry, this is fast, for the same reason `stop` and `start`
+are; we've already done the heavy lifting. 
+
+### Placement
+
+When you `create`, `run`, or `clone` a Machine, you can pick a Fly.io region to place it in. Our API will contact the Machines API
+server (we call it `flaps`, but you don't have to care), which will in turn reach out to all the worker servers we have in the region, 
+find out which ones have the requisite resources to host the Machine, and try to make a smart choice about which of those servers to 
+put the Machine in.
+
+You don't get to pick particular servers (there are ways to cheat and do it anyways, but you shouldn't want to), just the region. 
+
+If you pick a particular region, like `ord` or `yyz`, we will _only_ create the Machine in that region. 
+
+<section class="warning icon">
+**Placement can fail!** It shouldn't happen often, but we can run out of capacity in particular regions. Both flyctl and the Fly Machines 
+API are best-effort. If you're working with us at this level of control, it's on you to retry requests and ensure they go through. In exchange for that burden, we try to make sure the Fly Machines API is responsive, so you get quick answers.
+</section>
+
+## Recapping Fly Machine features
+
+* Manage with the Machines API or flyctl commands
+* Stop automatically when a program exits
+* Stop or start quickly, either manually or automatically based on traffic
+* Provide ephemeral storage, a blank slate on every startup 
+* Attach a volume for persistent storage
+* Place in any region

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -138,6 +138,9 @@
     <%= nav_link "Fly Machines", "/docs/machines/" %>
     <ul role="region" aria-label="Fly Machines">
       <li>
+        <%= nav_link "Fly Machines overview", "/docs/machines/overview/" %>
+      </li>
+      <li>
         <%= nav_link "Run a new Machine", "/docs/machines/run/" %>
       </li>
       <li>

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -1,7 +1,7 @@
 <%= partial "/docs/partials/back_to_docs" %>
 <ul class="outline-list">
   <li>
-    <%= nav_link "Fly Machines", "/docs/machines/" %>
+    <%= nav_link "Fly Machines overview", "/docs/machines/overview/" %>
   </li>
 </ul>
 

--- a/volumes/index.html.markerb
+++ b/volumes/index.html.markerb
@@ -30,5 +30,6 @@ Related how-tos:
 
 Commands and APIs for volumes.
 
-- [flyctl commands - `fly volumes`](/docs/flyctl/volumes/)
-- [Machines API - Volumes](https://docs.machines.dev/swagger/index.html#/Volumes)
+[flyctl commands - `fly volumes`](/docs/flyctl/volumes/)
+
+[Machines API - Volumes](https://docs.machines.dev/swagger/index.html#/Volumes)


### PR DESCRIPTION
### Summary of changes

- Move the Machines summary from the Machines nav index to a Machines overview page, since the index might be entirely missed
- Add a Machines landing page as the index page
- Add "fast-launching VMs"
- minor word changes

**Preview:** https://aa-docs-2.fly.dev/docs/machines/

### Related Fly.io community and GitHub links
n/a

### Notes
n/a 
