### PR TITLE
Update supercronic app guide

### DIFF
--- a/app-guides/supercronic.html.md
+++ b/app-guides/supercronic.html.md
@@ -32,13 +32,13 @@ Check out [cron.help](https://cron.help) if you need a quick crontab syntax refe
 
 ## Install `supercronic` in the container
 
-The [latest releases for supercronic](https://github.com/aptible/supercronic/releases) are on [Github](https://github.com/aptible/supercronic), where they include copy pasta 🍝instructions for getting it in your Dockerfile. As of November 2022, the current version of `supercronic` is v0.2.1. You'll want to check the [releases page](https://github.com/aptible/supercronic/releases) for the latest version, but here's what it looks like now:
+The [latest releases for supercronic](https://github.com/aptible/supercronic/releases) are on [Github](https://github.com/aptible/supercronic), where they include copy pasta 🍝instructions for getting it in your Dockerfile. As of January 2024, the current version of `supercronic` is v0.2.29. You'll want to check the [releases page](https://github.com/aptible/supercronic/releases) for the latest version, but here's what it looks like now:
 
 ```
 # Latest releases available at https://github.com/aptible/supercronic/releases
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.1/supercronic-linux-amd64 \
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
     SUPERCRONIC=supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=d7f4c0886eb85249ad05ed592902fa6865bb9d70
+    SUPERCRONIC_SHA1SUM=cd48d45c4b10f3f0bfdd3a57d054cd05ac96812b
 
 RUN curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
@@ -82,10 +82,10 @@ Now that we've added `supercronic` to our `Dockerfile`, put the `crontab` at the
 $ fly deploy
 ```
 
-Then we'll need to scale the processes so that we only run one virtual machine container with the `cron` process. Be sure to change `web` to whatever number you had before.
+Then we'll need to scale the processes so that we only run one virtual machine container with the `cron` process.
 
 ```
-$ fly scale count cron=1 web=
+$ fly scale count -g cron 1
 ```
 
 That's it! If all went well you now have Cron running in a `cron` process in a Fly virtual machine. When you `fly deploy` it will get the latest code changes and reboot the virtual machines.


### PR DESCRIPTION
### Summary of changes
- Updated supercronic link for the latest version
- Fixed `fly scale count` command syntax

### Related Fly.io community and GitHub links
n/a

### Notes
The `fly scale count` syntax is taken from the current version of `flyctl`, `v0.1.143`
