### PR TITLE
pricing page: rework plans section for new accounts on paid hobby

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -15,9 +15,9 @@ Fly.io services are billed per organization. Organizations are administrative en
 
 ## Plans
 
-Every organization belongs to a [plan](https://fly.io/plans). New organizations start on the Hobby plan. If you need more support or compliance options, you can upgrade to a Launch, Scale, or Enterprise plan.
+Every organization belongs to a [plan](https://fly.io/plans). New organizations start on the [Hobby plan](https://fly.io/plans). If you need more support or compliance options, you can upgrade to a Launch, Scale, or Enterprise plan.
 
-All plans come with some usage included and require a [credit card](/docs/about/billing/#payment-options) on file. For details, or to select a different plan, see [Plan Pricing](https://fly.io/plans).
+All plans (except the [Legacy Hobby plan](#legacy-hobby-plan)) come with some usage included. All plans require a [credit card](/docs/about/billing/#payment-options) on file. For details, or to select a different plan, see [Plan Pricing](https://fly.io/plans).
 
 <div class="note icon">
 Regardless of which plan you're on, your organization may be subject to scaling limits to prevent abuse or to help with capacity planning. Email the address in the error message if you run into such a limit and it's getting in your way.
@@ -31,7 +31,7 @@ Once this credit is exhausted, the organization is automatically migrated to the
 
 ### Legacy Hobby plan
 
-If you were on the free Hobby plan at the time that the paid Hobby plan was introduced, you are on a legacy Hobby plan and your costs will remain the same as they were, with no monthly subscription fee and no included usage beyond the free resource allowances that apply to all plans. If you upgrade to a different plan and downgrade back to Hobby, you'll be on the current (paid) Hobby plan.
+If you were on the free Hobby plan at the time that the paid Hobby plan was introduced, you remain on a Legacy Hobby plan and your costs will remain the same as they were, with no monthly subscription fee and no included usage beyond the free resource allowances that apply to all plans. If you upgrade to a different plan and downgrade back to Hobby, you'll be on the current (paid) Hobby plan.
 
 ## Free allowances
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -9,25 +9,29 @@ nav: firecracker
 
 ## How it works
 
-Our pricing is designed to let you launch a small application for free, and scale costs affordably as your needs grow.
+Our pricing is designed to let you test us out for free, and scale costs affordably as your needs grow.
 
 Fly.io services are billed per organization. Organizations are administrative entities on Fly.io that enable you to add members, share app development environments, and manage billing separately. Billing is based on the resources provisioned for your apps, pro-rated for the time they are provisioned. Learn more about [billing](/docs/about/billing/).
 
 ## Plans
 
-All plans require a [credit card](/docs/about/billing/#payment-options). Your first organization starts on a free Hobby plan (subject to change), and any subsequent new organizations you create are on the $5/month Hobby Plan. Hobby plans are a straightforward pay-as-you-go option.
+Every organization belongs to a [plan](https://fly.io/plans). New organizations start on the Hobby plan. If you need more support or compliance options, you can upgrade to a Launch, Scale, or Enterprise plan.
 
-We don't offer a "free tier." Instead, we offer some free resource allowances that apply to all plans, including the Hobby plan, and includes enough usage per month to run a small full-stack app, full-time, for free. 
-
-If you want to scale beyond the included free resources, you can pay for just what you need at the usage-based pricing listed below.
+All plans come with some usage included and require a [credit card](/docs/about/billing/#payment-options) on file. For details, or to select a different plan, see [Plan Pricing](https://fly.io/plans).
 
 <div class="note icon">
-Your organization might be limited to prevent abuse or help with capacity planning.
+Regardless of which plan you're on, your organization may be subject to scaling limits to prevent abuse or to help with capacity planning. Email the address in the error message if you run into such a limit and it's getting in your way.
 </div>
 
-If you need more support or compliance options, you can upgrade to a [Launch, Scale, or Enterprise plan](https://fly.io/plans). These come with usage included and additional support options.
+### New customers
 
-For details and to select a different plan, see [Plan Pricing](https://fly.io/plans).
+When you sign up for a Fly.io account, we create a default ("personal") organization for you, which receives a one-time $5 sign-up credit to let you test-drive Fly.io at no cost, within a modified Hobby plan. Usage that falls outside of our free resource allowances consumes your sign-up credit. 
+
+Once this credit is exhausted, the organization is automatically migrated to the $5/month [Hobby plan](https://fly.io/plans) (we'll send you an email when it happens). There's no time limit to use up the sign-up credit and move to the paid subscription. 
+
+### Legacy Hobby plan
+
+If you were on the free Hobby plan at the time that the paid Hobby plan was introduced, you are on a legacy Hobby plan and your costs will remain the same as they were, with no monthly subscription fee and no included usage beyond the free resource allowances that apply to all plans. If you upgrade to a different plan and downgrade back to Hobby, you'll be on the current (paid) Hobby plan.
 
 ## Free allowances
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -17,21 +17,25 @@ Fly.io services are billed per organization. Organizations are administrative en
 
 Every organization belongs to a [plan](https://fly.io/plans). New organizations start on the [Hobby plan](https://fly.io/plans). If you need more support or compliance options, you can upgrade to a Launch, Scale, or Enterprise plan.
 
-All plans (except the [Legacy Hobby plan](#legacy-hobby-plan)) come with some usage included. All plans require a [credit card](/docs/about/billing/#payment-options) on file. For details, or to select a different plan, see [Plan Pricing](https://fly.io/plans).
+All plans (except the [Legacy Hobby plan](#legacy-hobby-plan)) come with some usage included; if you want to scale beyond this, you pay for just what you need at the usage-based pricing listed below. 
 
 <div class="note icon">
-Regardless of which plan you're on, your organization may be subject to scaling limits to prevent abuse or to help with capacity planning. Email the address in the error message if you run into such a limit and it's getting in your way.
+Regardless of which plan you're on, your organization may be subject to automated scaling limits to prevent abuse or to help with capacity planning. Email the address in the error message if you run into such a limit and it's getting in your way.
 </div>
+
+All plans require a [credit card](/docs/about/billing/#payment-options) on file. For details, or to select a different plan, see [Plan Pricing](https://fly.io/plans).
 
 ### New customers
 
-When you sign up for a Fly.io account, we create a default ("personal") organization for you, which receives a one-time $5 sign-up credit to let you test-drive Fly.io at no cost, within a modified Hobby plan. Usage that falls outside of our free resource allowances consumes your sign-up credit. 
+When you sign up for a Fly.io account, we create a default (“personal”) organization for you, which receives a one-time $5 sign-up credit to let you test-drive Fly.io at no cost. This organization's $5/month Hobby plan subscription does not start until the credit has been used up. Usage that falls outside of our free resource allowances consumes your sign-up credit.
 
-Once this credit is exhausted, the organization is automatically migrated to the $5/month [Hobby plan](https://fly.io/plans) (we'll send you an email when it happens). There's no time limit to use up the sign-up credit and move to the paid subscription. 
+Once this credit is exhausted, the organization is automatically migrated to the $5/month [Hobby plan](https://fly.io/plans) (we’ll send you an email when it happens). There’s no time limit to use up the sign-up credit and move to the paid subscription.
 
 ### Legacy Hobby plan
 
-If you were on the free Hobby plan at the time that the paid Hobby plan was introduced, you remain on a Legacy Hobby plan and your costs will remain the same as they were, with no monthly subscription fee and no included usage beyond the free resource allowances that apply to all plans. If you upgrade to a different plan and downgrade back to Hobby, you'll be on the current (paid) Hobby plan.
+If you were on the free Hobby plan at the time that the paid Hobby plan became the default for new users, your plan is now called the Legacy Hobby plan. Your costs stay the same as they were, with no monthly subscription fee, and no included usage beyond the free resource allowances that apply to all plans.
+
+If you upgrade to a different plan and downgrade back to Hobby, you’ll be on the current (paid) Hobby plan.
 
 ## Free allowances
 


### PR DESCRIPTION
### Summary of changes
* new orgs go on paid hobby plan
* sign-up credit for new customers before paid subscription starts
* nothing changes for orgs on existing free hobby plan

At the moment there's a preview at https://justchecking2.fly.dev/docs/about/pricing/