### PR TITLE
Minor update to Postgres snapshot restore

### DIFF
--- a/postgres/managing/backup-and-restore.html.markerb
+++ b/postgres/managing/backup-and-restore.html.markerb
@@ -111,7 +111,7 @@ Save your credentials in a secure place, you won't be able to see them again!
 This provisions and launches a new Fly Postgres database server with the specified snapshot.
 
 <div class="important icon">
-  <b>Important:</b> The volume provisioned for the new Fly Postgres application must be equal or greater size than the volume from where the snapshot was taken.
+  <b>Important:</b> The size of the volume provisioned for the new Fly Postgres application must be equal to or greater than the volume from where the snapshot was taken.
 </div>
 
 ## Connect the Restored Database

--- a/postgres/managing/backup-and-restore.html.markerb
+++ b/postgres/managing/backup-and-restore.html.markerb
@@ -110,6 +110,10 @@ Save your credentials in a secure place, you won't be able to see them again!
 
 This provisions and launches a new Fly Postgres database server with the specified snapshot.
 
+<div class="important icon">
+  <b>Important:</b> The volume provisioned for the new Fly Postgres application must be equal or greater size than the volume from where the snapshot was taken.
+</div>
+
 ## Connect the Restored Database
 
 Detach the web application from the current Postgres cluster:


### PR DESCRIPTION
### Summary of changes
Adding a minor update to the instructions to restore a Postgres snapshot. There was a post in the community forum from an user getting an error creating a new Postgres app by restoring from a snapshot.
The problem was the size for the provisioned volume for the new Postgres app being smaller than the original volume.


### Related Fly.io community and GitHub links
 https://community.fly.io/t/restoring-postgres-snapshot-fails-restore-volume-size-must-be-at-least-10gb/17937

### Notes
n/a
