### PR TITLE
Fix typo on fly-launch.html.md

### DIFF
--- a/reference/fly-launch.html.md
+++ b/reference/fly-launch.html.md
@@ -57,7 +57,7 @@ Some flyctl scanners will do some or all of this using the API.
 
 ## Deployment
 
-The `fly launch` command might deploy your new app for the first time if you accept the defaults or after you tweak the app's settings. You can stop `fly launch` from deploying the new app right away with `fly launch --no deploy`.
+The `fly launch` command might deploy your new app for the first time if you accept the defaults or after you tweak the app's settings. You can stop `fly launch` from deploying the new app right away with `fly launch --no-deploy`.
 
 Whenever you want to update your app, you'll run [`fly deploy`](/docs/flyctl/deploy/). `fly deploy` creates a new release of the app with the updated configuration, and builds and deposits the image in the Fly.io registry, if needed. Public IP addresses are provisioned if the app listens on public ports and doesn't already have them. Finally, some hardware is allocated and at least one Machine is booted up.
 


### PR DESCRIPTION
### Summary of changes

Added missing dash to `fly launch --no-deploy` mention.

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
