### PR TITLE
Add a section on plan billing

### DIFF
--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -32,9 +32,9 @@ Running Machines are billed per second that they're running (the time they spend
 
 For example, a Machine described in your dashboard as "shared-1x-cpu@1024MB" is the “shared-cpu-1x” Machine size preset, which comes with 256MB RAM, plus additional RAM (1024MB - 256MB = 768MB). For pricing and available CPU/RAM combinations, see [Compute pricing](/docs/about/pricing/#compute).
 
-Stopped Machines are billed based on their RootFS usage per second (the time they spend in the `stopped` state) by $0.15 per GB per month.
+Stopped Machines are billed based on their root file system (rootfs) usage per second (the time they spend in the `stopped` state) by $0.15 per GB per month.
 
-For example, a Machine described in your dashboard as having 1GB of RootFS stopped for 10 days in the entire month will cost $0.05. If you have 3 stopped Machines of 1GB RootFS each stopped for 30 days it will cost $0.45 ($0.15 x 3).
+For example, a Machine described in your dashboard as having 1GB of rootfs stopped for 10 days in the entire month will cost $0.05. If you have 3 stopped Machines of 1GB rootfs each stopped for 30 days it will cost $0.45 ($0.15 x 3).
 
 ## Volume billing
 

--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -20,7 +20,7 @@ To download a past invoice, click View for the relevant cycle. You'll be sent to
 
 ## Plan billing
 
-You're charged for a plan as soon as you sign up for that plan. When you create a new organization, you are signing up for the Hobby plan. 
+You're charged for a plan as soon as you sign up for that plan. The exception is [new customers](/docs/about/pricing/#new-customers), who have a $5 sign-up credit for usage, and are only charged after that credit is used up. For existing Fly.io accounts, when you create a new organization, you are signing up for the Hobby plan. 
 
 Plan billing, and any included usage, is pro-rated over the month. For example, if you sign up for a Hobby plan on September 15th, then you'll be charged $2.50 (half of the $5/mo plan cost) right away and you'll have $2.50 of usage included up to September 30th. Then you'll be charged $5 at the start of October and have $5/mo of usage included for that billing cycle.
 
@@ -32,9 +32,9 @@ Running Machines are billed per second that they're running (the time they spend
 
 For example, a Machine described in your dashboard as "shared-1x-cpu@1024MB" is the “shared-cpu-1x” Machine size preset, which comes with 256MB RAM, plus additional RAM (1024MB - 256MB = 768MB). For pricing and available CPU/RAM combinations, see [Compute pricing](/docs/about/pricing/#compute).
 
-Stopped machines are billed based on their RootFS usage per second (the time they spend in the `stopped` state) by $0.15 per GB per month.
+Stopped Machines are billed based on their RootFS usage per second (the time they spend in the `stopped` state) by $0.15 per GB per month.
 
-For example, a Machine described in your dashboard as having 1GB of RootFS stopped for 10 days in the entire month will cost $0.05. If you have 3 stopped machines of 1GB RootFS each stopped for 30 days it will cost $0.45 ($0.15 x 3).
+For example, a Machine described in your dashboard as having 1GB of RootFS stopped for 10 days in the entire month will cost $0.05. If you have 3 stopped Machines of 1GB RootFS each stopped for 30 days it will cost $0.45 ($0.15 x 3).
 
 ## Volume billing
 
@@ -72,7 +72,7 @@ You can't use a prepaid card as a default (or saved) payment method. You can, ho
 
 ## Understand charges beyond the free allowances
 
-The prices of provisioned services are mostly fixed. If you provision Machines and leave them running all month, we’ll charge you a predictable amount for that machine.
+The prices of provisioned services are mostly fixed. If you provision Machines and leave them running all month, we’ll charge you a predictable amount for that Machine.
 
 A common reason for additional charges is extra RAM usage.
 

--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -8,9 +8,9 @@ redirect_from: /docs/about/credit-cards/
 
 Billing for Fly.io is monthly per organization. Organizations are administrative entities that enable you to add members, share app development environments, and manage billing separately.
 
-If you provision services beyond the [free allowances](/docs/about/pricing/#free-allowances), we will charge you actual money at the end of each month.
+The amount you're charged depends on your plan, and your resource usage beyond the included plan usage and [free allowances](/docs/about/pricing/#free-allowances).
 
-Refer to our [Pricing page](/docs/about/pricing/) for resource cost details.
+Refer to our [Plans page](https://fly.io/plans) and our resource [Pricing page](/docs/about/pricing/) for details.
 
 ## View invoices
 
@@ -18,13 +18,13 @@ You can view and download invoices from the Billing section of your [dashboard]
 
 To download a past invoice, click View for the relevant cycle. You'll be sent to the Stripe billing portal where you'll have the option to download the invoice.
 
-## Volume billing
+## Plan billing
 
-Volume billing is pro-rated to the hour and we subtract the free allowances first. For details, see [Volume pricing](/docs/about/pricing/#persistent-storage-volumes).
+You're charged for a plan as soon as you sign up for that plan. When you create a new organization, you are signing up for the Hobby plan. 
 
-If you create a volume, you will be charged for it. You’re billed for volumes that aren’t attached to Machines, and for volumes that are attached to Machines in any state, including stopped Machines.
+Plan billing, and any included usage, is pro-rated over the month. For example, if you sign up for a Hobby plan on September 15th, then you'll be charged $2.50 (half of the $5/mo plan cost) right away and you'll have $2.50 of usage included up to September 30th. Then you'll be charged $5 at the start of October and have $5/mo of usage included for that billing cycle.
 
-You aren't billed for the 5 days worth of [daily volume snapshots](/docs/apps/volume-manage/#restore-a-volume-from-a-snapshot) that we store for you by default.
+When you upgrade to a higher plan, your billing is pro-rated and adjusted accordingly.
 
 ## Machine billing
 
@@ -35,6 +35,14 @@ For example, a Machine described in your dashboard as "shared-1x-cpu@1024MB" is 
 Stopped machines are billed based on their RootFS usage per second (the time they spend in the `stopped` state) by $0.15 per GB per month.
 
 For example, a Machine described in your dashboard as having 1GB of RootFS stopped for 10 days in the entire month will cost $0.05. If you have 3 stopped machines of 1GB RootFS each stopped for 30 days it will cost $0.45 ($0.15 x 3).
+
+## Volume billing
+
+Volume billing is pro-rated to the hour and we subtract the free allowances first. For details, see [Volume pricing](/docs/about/pricing/#persistent-storage-volumes).
+
+If you create a volume, you will be charged for it. You’re billed for volumes that aren’t attached to Machines, and for volumes that are attached to Machines in any state, including stopped Machines.
+
+You aren't billed for the 5 days worth of [daily volume snapshots](/docs/apps/volume-manage/#restore-a-volume-from-a-snapshot) that we store for you by default.
 
 ## Free resource allowances
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -59,7 +59,7 @@ Here's the pricing for named presets and the allowed additional RAM configuratio
 
 <%= partial("shared/cpu_mem_machines_pricing") %>
 
-For stopped machines we only charge for the RootFS needed for each machine. Each 1GB of RootFS for a machine stopped for 30 days is $0.15. The amount of RootFS needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/) tweaks on the underlying file system.
+For stopped machines we only charge for the root file system (rootfs) needed for each machine. Each 1GB of rootfs for a machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/) tweaks on the underlying file system.
 
 For more details about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
 


### PR DESCRIPTION
### Summary of changes

- Add a section on Plan billing to the Billing page to clarify that we charge for monthly plans immediately on org creation from an existing account. With the exception of brand new customers with a signup credit.

- Swap the order of Machine billing and Volume billing sections.

- Change RootFS to rootfs.

### Related Fly.io community and GitHub links
- https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969

### Notes
n/a
