### PR TITLE
Add Astro site docs

### DIFF
--- a/js/frameworks/astro.html.markerb
+++ b/js/frameworks/astro.html.markerb
@@ -21,7 +21,7 @@ Astro applications can to be served as either **static pages** _or_ with **serve
 
 <%= partial "partials/flyctl" %>
 
-Nexyt, if you don't already have an existing Astro application, you can create one quickly with the following command:
+Next, if you don't already have an existing Astro application, you can create one quickly with the following command:
 
 ```cmd
 npm create astro@latest

--- a/js/frameworks/astro.html.markerb
+++ b/js/frameworks/astro.html.markerb
@@ -1,0 +1,106 @@
+---
+title: "Run an Astro App"
+layout: language-and-framework-docs
+sitemap: false
+redirect_from:
+ - /docs/languages-and-frameworks/astro/
+ - /docs/getting-started/astro/
+order: 1
+---
+
+<% app_name = "hello-next" %>
+<%= partial "partials/intro", locals: { runtime: "Astro", link: "https://astro.build/" } %>
+
+You can deploy your [Astro](https://astro.build/) app on Fly with minimal effort, our CLI will do the heavy lifting. You can use your existing Astro app or you can create one from scratch.
+
+
+Astro applications can to be served as either **static pages** _or_ with **server-side rendering (SSR)**. On this page you'll find guides to deploying both varieties.
+
+
+## _Deploy a static Astro site_
+
+<%= partial "partials/flyctl" %>
+
+Nexyt, if you don't already have an existing Astro application, you can create one quickly with the following command:
+
+```cmd
+npm create astro@latest
+```
+
+Once your project is ready, you're ready to start deploying! If you don't already have a Dockerfile, `fly launch` will generate one for you, as well as prepare a `fly.toml` file.
+
+```cmd
+cd my-astro-app
+fly launch
+```
+```output
+Scanning source code
+Detected an Astro app
+Creating app in [redacted]/my-astro-app
+We're about to launch your NodeJS app on Fly.io. Here's what you're getting:
+
+Organization: Your Name                (fly launch defaults to the personal org)
+Name:         my-astro-app             (derived from your directory name)
+Region:       Seattle, Washington (US) (this is the fastest region for you)
+App Machines: shared-cpu-1x, 1GB RAM   (most apps need about 1GB of RAM)
+Postgres:     <none>                   (not requested)
+Redis:        <none>                   (not requested)
+
+? Do you want to tweak these settings before proceeding? (y/N) No
+Created app 'my-astro-app' in organization 'personal'
+Admin URL: https://fly.io/apps/my-astro-app
+Hostname: my-astro-app.fly.dev
+installing: npm install @flydotio/dockerfile@latest --save-dev
+
+...
+
+found 0 vulnerabilities
+     create  Dockerfile
+Wrote config file fly.toml
+Validating [redacted]/my-astro-app/fly.toml
+Platform: machines
+✓ Configuration is valid
+
+If you need custom packages installed, or have problems with your deployment
+build, you may need to edit the Dockerfile for app-specific changes. If you
+need help, please post on https://community.fly.io.
+
+Now: run 'fly deploy' to deploy your Astro app.
+```
+
+Finally, run the following:
+
+```cmd
+fly deploy
+```
+
+<%= partial "partials/launched" %>
+
+## _Deploy an Astro site with SSR_
+
+Astro supports server-side rendering (SSR) through the use of **adapters**. There are a handful of adapters that are officially maintained by the Astro team. When using the `@astrojs/node` adapter, Fly.io will automatically detect this during `fly launch` and if no existing Dockerfile is found, it will generate a new one with the appropriate start command and environment variables.
+
+You can add the necessary Node adapter like so:
+
+```cmd
+npx astro add node
+```
+
+Then, in your `astro.config.*` file, add the following lines:
+
+```diff
+
+import { defineConfig } from 'astro/config';
++ import node from '@astrojs/node';
+
+export default defineConfig({
++  output: 'server',
++  adapter: node({
++    mode: 'standalone',
++  }),
+});
+```
+
+## Generating your Astro Dockerfile
+
+As discussed earlier, running `fly launch` will generate a Dockerfile for you if one does not already exist. Separately, you can also generate your Dockerfile using [Dockerfile generator](https://www.npmjs.com/package/@flydotio/dockerfile). Once installed, it can be run using `npx dockerfile` for Node applications or `bunx dockerfile` for Bun applications. You'll see it referenced throughout this article for various use cases.

--- a/js/frameworks/astro.html.markerb
+++ b/js/frameworks/astro.html.markerb
@@ -11,7 +11,7 @@ order: 1
 <% app_name = "hello-next" %>
 <%= partial "partials/intro", locals: { runtime: "Astro", link: "https://astro.build/" } %>
 
-You can deploy your [Astro](https://astro.build/) app on Fly with minimal effort, our CLI will do the heavy lifting. You can use your existing Astro app or you can create one from scratch.
+You can deploy your [Astro](https://astro.build/) app on Fly.io with minimal effort, our CLI will do the heavy lifting. You can use your existing Astro app or you can create one from scratch.
 
 
 Astro applications can to be served as either **static pages** _or_ with **server-side rendering (SSR)**. On this page you'll find guides to deploying both varieties.

--- a/languages-and-frameworks/partials/_scanner_guides.html.erb
+++ b/languages-and-frameworks/partials/_scanner_guides.html.erb
@@ -1,5 +1,8 @@
 <ul style="display: grid; gap: 1px; grid-template-columns: repeat(auto-fit, 20em);">
   <li>
+    <a href="/docs/languages-and-frameworks/astro/">Astro</a>
+  </li>
+  <li>
     <a href="/docs/languages-and-frameworks/crystal/">Crystal</a>
   </li>
   <li>


### PR DESCRIPTION
### Summary of changes
Added documentation for running an Astro site on Fly.


### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
