### PR TITLE
GPUs no longer require a paid plan

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -65,7 +65,7 @@ For more details about how costs are calculated, see [Machine billing](/docs/abo
 
 ### GPUs and Fly Machines
 
-Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see [Fly Machines pricing](#fly-machines)) plus the price of the attached GPU. GPU access requires a [Launch, Scale, or Enterprise plan](https://fly.io/plans).
+Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see [Fly Machines pricing](#fly-machines)) plus the price of the attached GPU.
 
 On-demand GPU pricing:
 


### PR DESCRIPTION
### Summary of changes

### Related Fly.io community and GitHub links
n/a if none

### Notes
n/a if none
