### PR TITLE
Update install-flyctl.html.markerb

### DIFF
--- a/hands-on/install-flyctl.html.markerb
+++ b/hands-on/install-flyctl.html.markerb
@@ -30,6 +30,7 @@ If not, you can run the install script:
 
 ```cmd
 curl -L https://fly.io/install.sh | sh
+{ echo 'export PATH="$PATH:$HOME/.fly/bin/"'; cat $HOME/.bashrc; } > bashrc.new && cp -pf bashrc.new $HOME/.bashrc && rm bashrc.new || echo "Some part of adding Fly.io binaries to $PATH failed!"
 ```
 If you used curl to install flyctl, then you need to add the flyctl directory to your shell rc file. Check the output of the install script for the entries to copy and paste into the file. Now you can use the `flyctl` command from any directory. Or for maximum efficiency, you can use the `fly` command! 
 


### PR DESCRIPTION
Added `bash` and bash-like shell specific modifications required to directly invoke Fly.io commands.  Input taken from https://stackoverflow.com/a/30387689/826573 for prepending to text files.

For very new people, this kind of thing can trip them up.

### Summary of changes

### Related Fly.io community and GitHub links
n/a if none

### Notes
One odd part is prepending to `.bashrc`.  This is to not conflict with `direnv`.
