### PR TITLE
Update Postgres upgrade doc for Flex

### DIFF
--- a/app-guides/supercronic.html.md
+++ b/app-guides/supercronic.html.md
@@ -32,13 +32,13 @@ Check out [cron.help](https://cron.help) if you need a quick crontab syntax refe
 
 ## Install `supercronic` in the container
 
-The [latest releases for supercronic](https://github.com/aptible/supercronic/releases) are on [Github](https://github.com/aptible/supercronic), where they include copy pasta 🍝instructions for getting it in your Dockerfile. As of November 2022, the current version of `supercronic` is v0.2.1. You'll want to check the [releases page](https://github.com/aptible/supercronic/releases) for the latest version, but here's what it looks like now:
+The [latest releases for supercronic](https://github.com/aptible/supercronic/releases) are on [Github](https://github.com/aptible/supercronic), where they include copy pasta 🍝instructions for getting it in your Dockerfile. As of January 2024, the current version of `supercronic` is v0.2.29. You'll want to check the [releases page](https://github.com/aptible/supercronic/releases) for the latest version, but here's what it looks like now:
 
 ```
 # Latest releases available at https://github.com/aptible/supercronic/releases
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.1/supercronic-linux-amd64 \
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
     SUPERCRONIC=supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=d7f4c0886eb85249ad05ed592902fa6865bb9d70
+    SUPERCRONIC_SHA1SUM=cd48d45c4b10f3f0bfdd3a57d054cd05ac96812b
 
 RUN curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \

--- a/app-guides/supercronic.html.md
+++ b/app-guides/supercronic.html.md
@@ -32,7 +32,7 @@ Check out [cron.help](https://cron.help) if you need a quick crontab syntax refe
 
 ## Install `supercronic` in the container
 
-The [latest releases for supercronic](https://github.com/aptible/supercronic/releases) are on [Github](https://github.com/aptible/supercronic), where they include copy pasta 🍝instructions for getting it in your Dockerfile. As of January 2024, the current version of `supercronic` is v0.2.29. You'll want to check the [releases page](https://github.com/aptible/supercronic/releases) for the latest version, but here's what it looks like now:
+The [latest releases for supercronic](https://github.com/aptible/supercronic/releases) are on [GitHhub](https://github.com/aptible/supercronic), where they include copy pasta 🍝instructions for getting it in your Dockerfile. As of January 2024, the current version of `supercronic` is v0.2.29. You'll want to check the [releases page](https://github.com/aptible/supercronic/releases) for the latest version, but here's what it looks like now:
 
 ```
 # Latest releases available at https://github.com/aptible/supercronic/releases
@@ -88,7 +88,7 @@ Then we'll need to scale the processes so that we only run one virtual machine c
 $ fly scale count cron=1 web=
 ```
 
-That's it! If all went well you now have Cron running in a `cron` process in a Fly virtual machine. When you `fly deploy` it will get the latest code changes and reboot the virtual machines.
+That's it! If all went well you now have cron running in a `cron` process in a Fly virtual machine. When you `fly deploy` it will get the latest code changes and reboot the virtual machines.
 
 # Resources
 

--- a/postgres/managing/upgrades.html.markerb
+++ b/postgres/managing/upgrades.html.markerb
@@ -5,7 +5,7 @@ layout: framework_docs
 order: 60
 ---
 
-You can upgrade a Fly Postgres cluster across minor Postgres versions with [`fly image update`](/docs/flyctl/image-update/). This updates your VMs to the [latest release](https://github.com/fly-apps/postgres-ha/releases) of the [postgres-ha](https://github.com/fly-apps/postgres-ha) app
+You can upgrade a Fly Postgres cluster across minor Postgres app versions with [`fly image update`](/docs/flyctl/image-update/). This updates your Machines to the [latest release](https://github.com/fly-apps/postgres-flex/releases) of the [postgres-flex](https://github.com/fly-apps/postgres-flex) app.
 
 Check your current image with [`fly status`](/docs/flyctl/status/):
 
@@ -19,6 +19,12 @@ And upgrade with:
 fly image update -a <postgres-app-name>
 ```
 
-The update won't go ahead if the major Postgres version in your existing Postgres app does not match that in the newest postgres-ha release.
+The update only works if the major Postgres version in your existing Postgres app matches that in the newest Postgress app release, for example `postgres-flex:15.2` to `postgres-flex:15.3`.
 
 Upgrading Postgres across major versions is more complicated, and right now the way to do this is to provision a new cluster and restore a backup of your database data into it.
+
+<div class="important note">
+**Important:** If you're running the legacy version of Fly Postgres, then you won't be able to use `fly image update` to upgrade to the new Postgres Flex app. You'll need to create a new Postgres app and import your data using the [`fly postgres import`](/docs/flyctl/postgres-import/) tool.
+
+To see your Postgres image and version, run `fly image show`. Legacy postgres images use the `flyio/postgres` repository, new Postgres Flex images use the `flyio/postgres-flex` repository.
+</div>


### PR DESCRIPTION
### Summary of changes

Updated the Postgres upgrade doc which referenced old pre-flex images/apps.
Added a note for those hoping to upgrade to Flex (you can't use the `fly image update` command for that).

### Related Fly.io community and GitHub links

Fixes #1269 

### Notes
n/a if none
