### PR TITLE
Update Machine scale docs for fly.toml vm settings

### DIFF
--- a/apps/scale-machine.html.markerb
+++ b/apps/scale-machine.html.markerb
@@ -6,11 +6,20 @@ nav: firecracker
 order: 50
 ---
 
-[**`fly scale`**](/docs/flyctl/scale) commands apply VM memory and CPU settings to entire process groups in a Fly App. There are two subcommands for scaling these per-VM resources: `fly scale vm` applies a preset CPU/RAM combination; `fly scale memory` adjusts RAM relative to the preset's base RAM.
+You can scale the VM memory and CPU settings for entire process groups&mdash;using flyctl or with VM sizes in `fly.toml`&mdash;for apps that are managed by Fly Launch (`fly deploy` + `fly.toml`).
 
-You can scale an app even if it has crashed. Its VMs are restarted with the new specification.
+[**`fly scale`**](/docs/flyctl/scale) subcommands apply VM memory and CPU settings to Machines: `fly scale vm` applies a preset CPU/RAM combination; `fly scale memory` adjusts RAM relative to the preset's base RAM.
+
+You can scale an app even if it has crashed. Its Machines are restarted with the new specification, however, if you redeploy the app, then any VM settings in `fly.toml` take precedence.
+
+## Machine size configuration precedence
+
+1. **The `[[vm]]` section in `fly.toml`**: The `fly deploy` and `fly scale count` commands respect the VM size configurations in your app's `fly.toml` file.
+2. **Existing Machine sizes in the app:** If no VM size is set in `fly.toml`, then `fly deploy` won't change existing Machines, and `fly scale` will use existing Machines to infer new Machines sizes.
+3. **Default Machine size of `shared-cpu-1x`:** If no VM size is set in `fly.toml`, and there are no existing Machines to infer size from, then the default machine size is used.
 
 ## Check the VM resources on an app
+
 Here's a simple web app with two Machines running in different regions: two in Toronto and one in Tokyo. All the app's Machines belong to the default process group, `app`, since I didn't explicitly configure any [processes](/docs/apps/processes/). 
 
 ```cmd
@@ -44,9 +53,15 @@ NAME    COUNT   KIND    CPUS    MEMORY  REGIONS
 app     3       shared  1       256 MB  nrt,yyz(2)
 ```
 
-These Machines are running at the `shared-cpu-1x` preset scale, with a single shared vCPU and 256MB RAM. 
+These Machines are running at the `shared-cpu-1x` preset scale, with a single shared vCPU and 256MB RAM.
 
-## Select a preset CPU/RAM combination
+## Add VM sizes to `fly.toml`
+
+You can configure VM sizes for all the Machines in your app's `fly.toml` configuration file. The VM size settings [take precedence](#machine-size-configuration-precedence) when you run `fly deploy` or `fly scale count`.
+
+If you don't specify a process group in the `[[vm]]` section, then the settings apply to all process groups in your app. Add another `[[vm]]` section if you want different CPU or memory settings for specific process groups. For examples and details about settings, see [The `vm` section](/docs/reference/configuration/#the-vm-section) in the fly.toml reference.
+
+## Select a preset CPU/RAM combination with flyctl
 
 There are a number of VM size presets available. See the list of valid named presets with `fly platform vm-sizes`.
 
@@ -69,6 +84,7 @@ Scaled VM Type to 'shared-cpu-2x'
       CPU Cores: 2
          Memory: 512 MB
 ```
+
 Check that the `app` process group has had this scale applied:
 
 ```cmd
@@ -82,7 +98,7 @@ NAME    COUNT   KIND    CPUS    MEMORY  REGIONS
 app     3       shared  2       512 MB  nrt,yyz(2)
 ```
 
-You can also confirm that an individual Machine's config matches this, using `fly machine status`:
+You can also confirm that an individual Machine's config matches this, using `fly machine status <machine ID>`:
 
 ```cmd
 fly machine status 148ed599c14189
@@ -103,7 +119,7 @@ VM
 
 Looks good!
 
-## Add RAM
+## Add RAM with flyctl
 
 If you are happy with the provisioned CPU resources, but want more memory, then use `fly scale memory` to top up the RAM.
 
@@ -141,8 +157,7 @@ app     3       shared  2       4096 MB nrt,yyz(2)
 
 If you try to set an incompatible CPU/RAM combination through `fly scale memory`, flyctl will let you know. There's a list of allowed CPU/RAM combinations and their prices on [our Pricing page](/docs/about/pricing/). 
 
-
-## Scale by process group
+## Scale by process group with flyctl
 
 Use the `--process-group` option to specify the process group to scale, with either `fly scale vm` or `fly scale memory`.
 
@@ -197,9 +212,9 @@ web     1       shared          1       512 MB  yyz
 
 ## Machines not belonging to Fly Launch
 
-If an app has Machines not belonging to Fly Launch&mdash;that is, created using `fly machine run` or the Machines API, or `fly machine clone`d from such a Machine&mdash;`fly status` will warn you of their existence.
+If an app has Machines not belonging to Fly Launch&mdash;that is, created using `fly machine run` or the Machines API, or `fly machine clone`d from such a Machine&mdash; `fly status` will warn you of their existence.
 
-The app-wide `fly scale` commands do not apply to these Machines, but you can scale any Machine individually with `fly machine update`:
+The app-wide `fly scale` commands and any VM settings in `fly.toml` don't apply to these Machines, but you can scale any Machine individually with `fly machine update`:
 
 ```
 fly machine update --vm-size shared-cpu-2x 21781973f03e89
@@ -207,4 +222,4 @@ fly machine update --vm-memory 1024 21781973f03e89
 fly machine update --vm-cpus 2 21781973f03e89
 ```
 
-Again, if you try to set an incompatible CPU/RAM combination through `fly machine update --vm-memory` or `fly machine update --vm-cpus`, flyctl will let you know.
+Again, if you try to set an incompatible CPU/RAM combination through `fly machine update --vm-memory` or `fly machine update --vm-cpus`, flyctl will let you know. Learn more about [individual Machine sizing with flyctl and the Machines API](/docs/machines/guides-examples/machine-sizing/).

--- a/apps/scale-machine.html.markerb
+++ b/apps/scale-machine.html.markerb
@@ -6,21 +6,19 @@ nav: firecracker
 order: 50
 ---
 
-You can scale the VM memory and CPU settings for entire process groups&mdash;using flyctl or with VM sizes in `fly.toml`&mdash;for apps that are managed by Fly Launch (`fly deploy` + `fly.toml`).
-
-[**`fly scale`**](/docs/flyctl/scale) subcommands apply VM memory and CPU settings to Machines: `fly scale vm` applies a preset CPU/RAM combination; `fly scale memory` adjusts RAM relative to the preset's base RAM.
+You can scale the Machine memory and CPU settings for entire process groups for apps that are managed by Fly Launch (`fly deploy` + `fly.toml`). If you haven't defined any process groups, then commands and settings are applied to all the Machines in your app (in the default `app` process group).
 
 You can scale an app even if it has crashed. Its Machines are restarted with the new specification, however, if you redeploy the app, then any VM settings in `fly.toml` take precedence.
 
 ## Machine size configuration precedence
 
 1. **The `[[vm]]` section in `fly.toml`**: The `fly deploy` and `fly scale count` commands respect the VM size configurations in your app's `fly.toml` file.
-2. **Existing Machine sizes in the app:** If no VM size is set in `fly.toml`, then `fly deploy` won't change existing Machines, and `fly scale` will use existing Machines to infer new Machines sizes.
-3. **Default Machine size of `shared-cpu-1x`:** If no VM size is set in `fly.toml`, and there are no existing Machines to infer size from, then the default machine size is used.
+2. **Existing Machine sizes in the app:** If no VM size is set in `fly.toml`, then `fly deploy` won't change existing Machines, and `fly scale` will use existing Machines to infer new Machine sizes.
+3. **Default Machine size of `shared-cpu-1x`:** If no VM size is set in `fly.toml`, and there are no existing Machines to infer size from, then the default Machine size is used.
 
 ## Check the VM resources on an app
 
-Here's a simple web app with two Machines running in different regions: two in Toronto and one in Tokyo. All the app's Machines belong to the default process group, `app`, since I didn't explicitly configure any [processes](/docs/apps/processes/). 
+Here's a simple web app with two Machines running in different regions: two in Toronto and one in Tokyo. All the app's Machines belong to the default process group, `app`, since no other [processes](/docs/apps/processes/) exist. 
 
 ```cmd
 fly status
@@ -31,13 +29,12 @@ App
   Owner    = personal                                   
   Hostname = testrun.fly.dev                                
   Image    = testrun:deployment-01GWZY7ZVJ2HNED4B0KZBPS3AQ  
-  Platform = machines                                   
 
 Machines
-ID              PROCESS VERSION REGION  STATE   HEALTH CHECKS           LAST UPDATED         
-148ed599c14189  app     3       yyz     started 1 total, 1 passing      2023-04-04T19:30:57Z
-32874400f35285  app     3       yyz     started 1 total, 1 passing      2023-04-04T19:33:44Z
-9080e6e1f94987  app     3       nrt     started 1 total, 1 passing      2023-04-04T19:31:22Z
+PROCESS	ID            	VERSION	REGION	STATE  	ROLE	CHECKS	                  LAST UPDATED
+app    	17811943f031d8	3     	yyz   	stopped	    	1 total, 1 passing      	2024-02-07T15:34:57Z
+app    	328749d3c53958	3     	yyz   	stopped	    	1 total, 1 passing      	2024-01-23T19:39:50Z
+app   	908057ef21e487	3     	nrt   	started	    	1 total, 1 passing      	2024-01-23T19:39:51Z
 ```
 
 `fly scale show` shows the CPU and RAM settings for all the Machines deployed using `fly deploy` under this app.
@@ -55,13 +52,21 @@ app     3       shared  1       256 MB  nrt,yyz(2)
 
 These Machines are running at the `shared-cpu-1x` preset scale, with a single shared vCPU and 256MB RAM.
 
-## Add VM sizes to `fly.toml`
+## Add Machine size configuration to `fly.toml`
 
-You can configure VM sizes for all the Machines in your app's `fly.toml` configuration file. The VM size settings [take precedence](#machine-size-configuration-precedence) when you run `fly deploy` or `fly scale count`.
+With the `[[vm]]` section in `fly.toml`, you can set default Machine VM memory and CPU configurations, which [take precedence](#machine-size-configuration-precedence) when you run commands like `fly deploy` or `fly scale count`.
 
-If you don't specify a process group in the `[[vm]]` section, then the settings apply to all process groups in your app. Add another `[[vm]]` section if you want different CPU or memory settings for specific process groups. For examples and details about settings, see [The `vm` section](/docs/reference/configuration/#the-vm-section) in the fly.toml reference.
+If you don't include a process group in the `[[vm]]` section, then the settings apply to all process groups in your app. Add another `[[vm]]` section if you want different CPU or memory settings for specific process groups. For examples and details about settings, see [The `vm` section](/docs/reference/configuration/#the-vm-section) in the `fly.toml` reference.
 
-## Select a preset CPU/RAM combination with flyctl
+## Scale VM memory and CPU with flyctl
+
+Use [`fly scale`](/docs/flyctl/scale) subcommands to apply VM memory and CPU settings to all the Machines: `fly scale vm` applies a preset CPU/RAM combination; `fly scale memory` adjusts RAM relative to the preset's base RAM.
+
+<div class="important icon">
+**Important:** When you make changes using `fly scale vm` or `fly scale memory`, the VM settings in `fly.toml` take precedence if you redeploy the app.
+</div>
+
+### Select a preset CPU/RAM combination
 
 There are a number of VM size presets available. See the list of valid named presets with `fly platform vm-sizes`.
 
@@ -119,7 +124,7 @@ VM
 
 Looks good!
 
-## Add RAM with flyctl
+### Add RAM
 
 If you are happy with the provisioned CPU resources, but want more memory, then use `fly scale memory` to top up the RAM.
 
@@ -157,7 +162,7 @@ app     3       shared  2       4096 MB nrt,yyz(2)
 
 If you try to set an incompatible CPU/RAM combination through `fly scale memory`, flyctl will let you know. There's a list of allowed CPU/RAM combinations and their prices on [our Pricing page](/docs/about/pricing/). 
 
-## Scale by process group with flyctl
+### Scale by process group
 
 Use the `--process-group` option to specify the process group to scale, with either `fly scale vm` or `fly scale memory`.
 
@@ -212,7 +217,11 @@ web     1       shared          1       512 MB  yyz
 
 ## Machines not belonging to Fly Launch
 
-If an app has Machines not belonging to Fly Launch&mdash;that is, created using `fly machine run` or the Machines API, or `fly machine clone`d from such a Machine&mdash; `fly status` will warn you of their existence.
+If an app has Machines not belonging to Fly Launch&mdash;that is, created using `fly machine run` or the Machines API, or `fly machine clone`d from such a Machine&mdash; `fly status` will warn you of their existence:
+
+```text
+Found machines that aren't part of Fly Launch, run fly machines list to see them.
+```
 
 The app-wide `fly scale` commands and any VM settings in `fly.toml` don't apply to these Machines, but you can scale any Machine individually with `fly machine update`:
 
@@ -222,4 +231,4 @@ fly machine update --vm-memory 1024 21781973f03e89
 fly machine update --vm-cpus 2 21781973f03e89
 ```
 
-Again, if you try to set an incompatible CPU/RAM combination through `fly machine update --vm-memory` or `fly machine update --vm-cpus`, flyctl will let you know. Learn more about [individual Machine sizing with flyctl and the Machines API](/docs/machines/guides-examples/machine-sizing/).
+If you try to set an incompatible CPU/RAM combination through `fly machine update --vm-memory` or `fly machine update --vm-cpus`, flyctl will let you know. Learn more about [individual Machine sizing with flyctl and the Machines API](/docs/machines/guides-examples/machine-sizing/).

--- a/apps/scale-machine.html.markerb
+++ b/apps/scale-machine.html.markerb
@@ -6,9 +6,11 @@ nav: firecracker
 order: 50
 ---
 
-You can scale the Machine memory and CPU settings for entire process groups for apps that are managed by Fly Launch (`fly deploy` + `fly.toml`). If you haven't defined any process groups, then commands and settings are applied to all the Machines in your app (in the default `app` process group).
+You can scale Machine memory and CPU settings for entire process groups in apps that are managed by Fly Launch (`fly deploy` + `fly.toml`). If you haven't defined any process groups, then commands and settings are applied to all the Machines in your app (in the default `app` process group).
 
+<div class="note icon">
 You can scale an app even if it has crashed. Its Machines are restarted with the new specification, however, if you redeploy the app, then any VM settings in `fly.toml` take precedence.
+</div>
 
 ## Machine size configuration precedence
 
@@ -18,7 +20,7 @@ You can scale an app even if it has crashed. Its Machines are restarted with the
 
 ## Check the VM resources on an app
 
-Here's a simple web app with two Machines running in different regions: two in Toronto and one in Tokyo. All the app's Machines belong to the default process group, `app`, since no other [processes](/docs/apps/processes/) exist. 
+Here's a simple web app with three Machines running in different regions: two in Toronto and one in Tokyo. All the app's Machines belong to the default process group, `app`, since no other [processes](/docs/apps/processes/) exist. 
 
 ```cmd
 fly status
@@ -56,14 +58,24 @@ These Machines are running at the `shared-cpu-1x` preset scale, with a single sh
 
 With the `[[vm]]` section in `fly.toml`, you can set default Machine VM memory and CPU configurations, which [take precedence](#machine-size-configuration-precedence) when you run commands like `fly deploy` or `fly scale count`.
 
-If you don't include a process group in the `[[vm]]` section, then the settings apply to all process groups in your app. Add another `[[vm]]` section if you want different CPU or memory settings for specific process groups. For examples and details about settings, see [The `vm` section](/docs/reference/configuration/#the-vm-section) in the `fly.toml` reference.
+This example shows a very simple config that specifies the `shared-cpu-2x` preset with 2GB of RAM:
+
+```toml
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2gb"
+```
+
+If you don't include a process group in the `[[vm]]` section, then the settings apply to all process groups in your app. Add another `[[vm]]` section if you want different CPU or memory settings for specific process groups. 
+
+For details and more settings, see [The `vm` section](/docs/reference/configuration/#the-vm-section) in the `fly.toml` reference.
 
 ## Scale VM memory and CPU with flyctl
 
-Use [`fly scale`](/docs/flyctl/scale) subcommands to apply VM memory and CPU settings to all the Machines: `fly scale vm` applies a preset CPU/RAM combination; `fly scale memory` adjusts RAM relative to the preset's base RAM.
+Use [`fly scale`](/docs/flyctl/scale) subcommands to apply VM memory and CPU settings to all Machines: `fly scale vm` applies a preset CPU/RAM combination; `fly scale memory` sets RAM separately, for cases when the preset's RAM is not enough.
 
 <div class="important icon">
-**Important:** When you make changes using `fly scale vm` or `fly scale memory`, the VM settings in `fly.toml` take precedence if you redeploy the app.
+**Important:** If you make changes using `fly scale vm` or `fly scale memory`, the VM settings in `fly.toml` take precedence when you redeploy the app.
 </div>
 
 ### Select a preset CPU/RAM combination
@@ -128,7 +140,7 @@ Looks good!
 
 If you are happy with the provisioned CPU resources, but want more memory, then use `fly scale memory` to top up the RAM.
 
-If your app crashes with an out-of-memory error, then scale up its RAM. Flyctl restarts the Machines to use the new setting.
+If your app crashes with an out-of-memory error, then scale up its RAM. Flyctl restarts the Machines to use the new setting. Scaling memory this way lets you test your app with more or less RAM, before optionally [setting memory more permanently in `fly.toml`](#add-machine-size-configuration-to-flytoml).
 
 ```cmd
 fly scale memory 4096
@@ -217,7 +229,7 @@ web     1       shared          1       512 MB  yyz
 
 ## Machines not belonging to Fly Launch
 
-If an app has Machines not belonging to Fly Launch&mdash;that is, created using `fly machine run` or the Machines API, or `fly machine clone`d from such a Machine&mdash; `fly status` will warn you of their existence:
+If an app has Machines that don't belong to Fly Launch (in other words, if you created Machines using `fly machine run` or the Machines API), then `fly status` will warn you of their existence:
 
 ```text
 Found machines that aren't part of Fly Launch, run fly machines list to see them.

--- a/machines/guides-examples/machine-sizing.html.markerb
+++ b/machines/guides-examples/machine-sizing.html.markerb
@@ -10,7 +10,7 @@ nav: machines
 date: 2022-12-08
 ---
 
-Here are a few ways to set the size (CPU and memory) of your Machine VMs.
+Here are a few ways to set the size (CPU and memory) of your Machine VMs. This guide describes creating and sizing individual Machines with the Machines API and `fly machine` commands. For Fly Launch apps, the same general sizing rules apply, but you can also use `fly scale` commands to [update groups of Machines](/docs/apps/scale-machine/) or set a [default VM size](/docs/reference/configuration/#the-vm-section) in the `fly.toml` configuration file.
 
 ## General Rules
 
@@ -52,6 +52,7 @@ fly machine run \
     --vm-size performance-2x \
     some-savvy-image
 ```
+
 
 ## Custom Sizes
 


### PR DESCRIPTION
### Summary of changes

- add a link to Scale CPU and RAM doc to Machine sizing doc
- update Scale CPU and RAM doc with precedence info and links to `[[vm]]` section in `fly.toml`
- re-org for the different ways of configuring Machine sizes
- review both for general updates

### Related Fly.io community and GitHub links
https://community.fly.io/t/auto-scale-machine/18242

### Notes
n/a
