### PR TITLE
API docs: add machines api index, add dir, rename files

### DIFF
--- a/index.html.md
+++ b/index.html.md
@@ -27,7 +27,7 @@ Scale locally, or put your app next to your users in ten more cities. Either way
 
 ## Control individual VMs
 
-The Fly Launch platform-as-a-service is there to make your apps easy to launch and manage. When you outgrow its opinions, micromanage your app VMs with `fly machines` commands, or drop down a level of abstraction to the [Machines API](/docs/machines/working-with-machines/). Launch [tiny, fast-booting VMs](/docs/machines/) from your app! The perfect way to run user code, or try that sketchy TypeScript snippet ChatGPT suggested.
+The Fly Launch platform-as-a-service is there to make your apps easy to launch and manage. When you outgrow its opinions, micromanage your app VMs with `fly machines` commands, or drop down a level of abstraction to the [Machines API](/docs/machines/api/). Launch [tiny, fast-booting VMs](/docs/machines/) from your app! The perfect way to run user code, or try that sketchy TypeScript snippet ChatGPT suggested.
 
 [Learn more about Fly Machines](/docs/machines/)
 

--- a/index.html.md
+++ b/index.html.md
@@ -15,11 +15,11 @@ nav: firecracker
 
 Machines are fast-launching VMs—and the engine of the Fly.io platform.
 
-[Fly Machines](/docs/machines/working-with-machines/)
+[Fly Machines](/docs/machines/)
 
 They're also a low-level interface to deploy and scale out your application with precise control.
 
-[The Machines API](/docs/machines/)
+[The Machines API](/docs/machines/api/)
 
 ## Fly Launch
 

--- a/machines/api/apps-resource.html.markerb
+++ b/machines/api/apps-resource.html.markerb
@@ -273,6 +273,6 @@ no body
 
 ## Related topics
 
-- [Working with the Machines API](/docs/machines/working-with-machines/)
-- [Machines resource](/docs/machines/api-machines-resource/) reference
-- [Volumes resource](/docs/machines/api-volumes-resource/) reference
+- [Working with the Machines API](/docs/machines/api/working-with-machines-api/)
+- [Machines resource](/docs/machines/api/machines-resource/) reference
+- [Volumes resource](/docs/machines/api/volumes-resource/) reference

--- a/machines/api/index.html.md
+++ b/machines/api/index.html.md
@@ -1,0 +1,21 @@
+---
+title: "Machines API"
+layout: docs
+nav: machines
+redirect_from: /docs/machines/working-with-machines/
+---
+
+The REST Machines API provides resources to provision and manage Fly Apps, Fly Machines, and Fly Volumes.
+
+
+* **[Working with the Machines API](/docs/machines/api/working-with-machines-api)**
+
+* **[Apps resource](/docs/machines/api/apps-resource)**
+
+* **[Machines resource](/docs/machines/api/machines-resource)**
+
+* **[Volumes resource](/docs/machines/api/volumes-resource)**
+
+API reference and OpenAPI specification:
+
+* **[Machines API Spec](https://docs.machines.dev/)**

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -1045,6 +1045,6 @@ Properties of the `config` object for Machine configuration. See [Machine proper
 
 ## Related topics
 
-- [Working with the Machines API](/docs/machines/working-with-machines/)
-- [Apps resource](/docs/machines/api-apps-resource/) reference
-- [Volumes resource](/docs/machines/api-volumes-resource/) reference
+- [Working with the Machines API](/docs/machines/api/working-with-machines-api/)
+- [Apps resource](/docs/machines/api/apps-resource/) reference
+- [Volumes resource](/docs/machines/api/volumes-resource/) reference

--- a/machines/api/volumes-resource.html.markerb
+++ b/machines/api/volumes-resource.html.markerb
@@ -686,6 +686,6 @@ Wait a few moments for the snapshot to get created and then [get the list of sna
 
 ## Related topics
 
-- [Working with the Machines API](/docs/machines/working-with-machines/)
-- [Apps resource](/docs/machines/api-apps-resource/) reference
-- [Machines resource](/docs/machines/api-machines-resource/) reference
+- [Working with the Machines API](/docs/machines/api/working-with-machines-api/)
+- [Apps resource](/docs/machines/api/apps-resource/) reference
+- [Machines resource](/docs/machines/api/machines-resource/) reference

--- a/machines/api/working-with-machines-api.html.markerb
+++ b/machines/api/working-with-machines-api.html.markerb
@@ -82,6 +82,6 @@ Authorization: Bearer <fly_api_token>
 
 ## Related topics
 
-- [Apps resource](/docs/machines/api-apps-resource/) reference
-- [Machines resource](/docs/machines/api-machines-resource/) reference
-- [Volumes resource](/docs/machines/api-volumes-resource/) reference
+- [Apps resource](/docs/machines/api/apps-resource/) reference
+- [Machines resource](/docs/machines/api/machines-resource/) reference
+- [Volumes resource](/docs/machines/api/volumes-resource/) reference

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -9,7 +9,7 @@ Fly Machines are fast-launching VMs. They are:
 
 * [The compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. Once created, Machines can be started and stopped at subsecond speeds. 
 
-* [A REST API](/docs/machines/working-with-machines/) you can use for precise control over groups of Machines to deploy and scale out applications. 
+* [A REST API](/docs/machines/api/) you can use for precise control over groups of Machines to deploy and scale out applications. 
 
 <section class="warning icon">
 **This is a low-level interface**.

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -30,10 +30,7 @@
         <%= nav_link "Update a Machine", "/docs/machines/flyctl/fly-machine-update/" %>
       </li>
       <li>
-        <%= nav_link "Working with the Machines API", "/docs/machines/working-with-machines/" %>
-      </li>
-      <li>
-        <%= nav_link "Machines API Spec", "https://docs.machines.dev/" %>
+        <%= nav_link "Machines API", "/docs/machines/api/" %>
       </li>
       <li>
         <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
@@ -43,6 +40,9 @@
       </li>
       <li>
         <%= nav_link "Machine restart policy", "/docs/machines/guides-examples/machine-restart-policy/" %>
+      </li>
+      <li>
+        <%= nav_link "Machine states", "/docs/machines/machine-states/" %>
       </li>
     </ul>
   </li>

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -34,22 +34,20 @@
 </ul>
 
 <ul class="outline-list">
-  <li>    
-    <span>
-      Machines API
-    </span>
+  <li>
+     <%= nav_link "Machines API", "/docs/machines/api" %>
     <ul>
       <li>
-        <%= nav_link "Working with the Machines API", "/docs/machines/working-with-machines/" %>
+        <%= nav_link "Working with the Machines API", "/docs/machines/api/working-with-machines-api/" %>
       </li>
       <li>
-        <%= nav_link "Apps", "/docs/machines/api-apps-resource/" %>
+        <%= nav_link "Apps", "/docs/machines/api/apps-resource/" %>
       </li>
       <li>
-        <%= nav_link "Machines", "/docs/machines/api-machines-resource/" %>
+        <%= nav_link "Machines", "/docs/machines/api/machines-resource/" %>
       </li>
       <li>
-        <%= nav_link "Volumes", "/docs/machines/api-volumes-resource/" %>
+        <%= nav_link "Volumes", "/docs/machines/api/volumes-resource/" %>
       </li>
       <li>
         <%= nav_link "Machines API Spec", "https://docs.machines.dev/#description/introduction" %>

--- a/reference/apps.html.markerb
+++ b/reference/apps.html.markerb
@@ -11,6 +11,6 @@ Every Machine on Fly.io lives in a Fly App. Anycast IPs, certificates, Fly Volum
 
 Fly Launch commands, `fly launch` and `fly deploy`, create and update an app's Machines as a unit with a single [configuration](/docs/reference/configuration/) and code base. Learn more about [Fly Launch](/docs/apps/).
 
-You can also create and configure [Machines](/docs/machines/) independently of other Machines in the same app, using `fly machine run` or the [Machines API](/docs/machines/working-with-machines/). See [Run a new Machine](/docs/machines/run/) for details about using `fly machine run`.
+You can also create and configure [Machines](/docs/machines/) independently of other Machines in the same app, using `fly machine run` or the [Machines API](/docs/machines/api/machines-resource/). See [Run a new Machine](/docs/machines/run/) for details about using `fly machine run`.
 
 Fly Apps run on flyd. Learn more about how flyd works and how it came to be in the blog post: [Carving the Scheduler Out of Our Orchestrator](https://fly.io/blog/carving-the-scheduler-out-of-our-orchestrator/).


### PR DESCRIPTION
### Summary of changes

- Add a Machines API index page
- Create an `api` directory
- rename files
- redirect "working with machines" to new index page

### Preview

https://aa-docs.fly.dev/docs/machines/api/

### Related Fly.io community and GitHub links


### Notes

