### PR TITLE
Put http headers and env vars into separate pages

### DIFF
--- a/django/getting-started/index.html.md
+++ b/django/getting-started/index.html.md
@@ -140,7 +140,7 @@ By default, Django is configured for local development. The [How to Deploy Djang
 However, for demonstration purposes, we can take some shortcuts.
 
 First, in the [`hello_django/settings.py`](https://github.com/fly-apps/hello-django/blob/main/hello_django/settings.py) file update the `ALLOWED_HOSTS` configuration to accept
-a host on which it's deployed. Use the [`FLY_APP_NAME`](https://fly.io/docs/reference/runtime-environment/#fly_app_name)
+a host on which it's deployed. Use the [`FLY_APP_NAME`](https://fly.io/docs/machines/runtime-environment/#fly_app_name)
 environment variable for that:
 
 ```python

--- a/machines/runtime-environment.html.md
+++ b/machines/runtime-environment.html.md
@@ -2,7 +2,7 @@
 title: The Machine Runtime Environment
 layout: docs
 nav: firecracker
-redirect_from: /docs/reference/runtime-environment/
+redirect_from: /docs/machines/runtime-environment/
 ---
 
 Environment variables make several kinds of information available within a Machine's runtime environment. The values come from three sources:

--- a/machines/runtime-environment.html.md
+++ b/machines/runtime-environment.html.md
@@ -31,7 +31,7 @@ Not to be confused with the [HTTP header](/docs/networking/request-headers/#fly-
 **IPV6 public IP**: The full public outbound IPV6 address for this Machine. Read more in the [Network Services](/docs/networking/services/#outbound-ip-addresses) section.
 
 ### `FLY_IMAGE_REF`
-**Docker image reference**: The name of the Docker image running this container. `registry.fly.io/my-app-name:deployment-01H9RK9EYO9PGNBYAKGXSHV0PH` is an example of the Docker Image Reference's format.
+**Docker image reference**: The name of the Docker image used to create the Machine. `registry.fly.io/my-app-name:deployment-01H9RK9EYO9PGNBYAKGXSHV0PH` is an example of the Docker Image Reference's format.
 
 Useful if your app needs to launch Machine instances of itself to scale background workers to zero and back, as in [Rails Background Jobs with Fly Machines](https://fly.io/ruby-dispatch/rails-background-jobs-with-fly-machines/).
 

--- a/networking/request-headers.html.md
+++ b/networking/request-headers.html.md
@@ -1,0 +1,38 @@
+---
+title: Request headers
+layout: docs
+nav: firecracker
+---
+
+Request headers carry information that is specific to the incoming request and its path taken to the application. Request headers are added by the HTTP handler service.
+
+## Request Headers
+
+### `Fly-Client-IP`
+**Client IP Address**: The IP address the Fly Proxy accepted a connection from. This will be the client making the initial request and as such, will also appear at the start of the `X-Forwarded-For` addresses. 
+
+### `Fly-Forwarded-Port`
+**Original connection port**: This header is always set by the Fly Proxy and denotes the actual port that the client connected to the Fly edge node which is then forwarded to the application instance.
+
+### `Fly-Region`
+**Edge Node Region**: This header is a three letter region code which represents the region that the connection was accepted in and routed from.
+
+Not to be confused with the [environment variable](/docs/reference/runtime-environment/#fly_region) `FLY_REGION`, which is where the application is running.
+
+### `X-Forwarded-For`
+**Client and Proxy List**: This is a comma separated list comprising of the client that originated the request and the proxy servers the request passed through. For example, "77.97.0.98, 77.83.142.33" contains the client and the one proxy it passed through.
+
+MDN has [full documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) for this header.
+
+### `X-Forwarded-Proto`
+**Original client protocol**: The protocol which the client used to make the request. Either `http` or `https`.
+
+### `X-Forwarded-Port`
+**Original connection port**: This header may be set by the client and should denote the port that the client set out to connect to.
+
+### `X-Forwarded-SSL`
+**SSL Status**: This indicates if the client connected over SSL. Its value can be either `on` or `off`. 
+
+## Request and Response Headers
+### `Via`
+**Proxy Route**: This header, added by proxies, shows the path taken, and protocols used, by the connection. MDN has [full documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Via) for this header. For example, a connection through the Fly edge may show `2 fly.io` in the field, denoting that version 2 of HTTP was used by the connection as it passed through the Fly Proxy.

--- a/networking/request-headers.html.md
+++ b/networking/request-headers.html.md
@@ -17,7 +17,7 @@ Request headers carry information that is specific to the incoming request and i
 ### `Fly-Region`
 **Edge Node Region**: This header is a three letter region code which represents the region that the connection was accepted in and routed from.
 
-Not to be confused with the [environment variable](/docs/reference/runtime-environment/#fly_region) `FLY_REGION`, which is where the application is running.
+Not to be confused with the [environment variable](/docs/machines/runtime-environment/#fly_region) `FLY_REGION`, which is where the application is running.
 
 ### `X-Forwarded-For`
 **Client and Proxy List**: This is a comma separated list comprising of the client that originated the request and the proxy servers the request passed through. For example, "77.97.0.98, 77.83.142.33" contains the client and the one proxy it passed through.

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -129,15 +129,22 @@ The `force_https` configuration option automatically redirects HTTP to HTTPS. Wh
 
 ## Outbound IP addresses
 
-VMs have IPv6 addresses from which they make requests to the wider Internet without going through the Fly Proxy.
+Fly Machiness have IPv6 addresses from which they make requests to the wider Internet without going through the Fly Proxy.
 
-We don’t offer static IPs or regional IP ranges, and we discourage the use of our outbound IPs to bypass firewalls. A VM's outbound IP is liable to change without notice. This shouldn't be a daily occurrence, but it will happen if a VM is moved for whatever reason, such as a load-balancing of Fly Machines between servers in one region.
+We don’t offer static IPs or regional IP ranges, and we discourage the use of our outbound IPs to bypass firewalls. A Machine's outbound IP is liable to change without notice. This shouldn't be a daily occurrence, but it will happen if a Machine is moved for whatever reason, such as a load-balancing of Fly Machines between servers in one region.
 
 If you depend on knowing this address for some reason, it's up to you to monitor it for changes.
 
-### Find your VM's outbound IP
+### Find your Machine's outbound IP
 
-Use `fly ssh console -s` to get an interactive shell on the VM of your choice, and call out to an external service that'll tell you your IP. For example:
+The Machine's outbound IPv6 address is available in the `FLY_PUBLIC_IP` [environment variable](/docs/reference/runtime-environment/). Use `fly ssh console -s` to get an interactive shell on the Machine of your choice.
+
+```
+/ # echo $FLY_PUBLIC_IP
+2605:4c40:92:520a:0:8c93:3d8a:1
+```
+
+You can also call out to an external service that'll tell you your IP. For example:
 
 ```
 / # curl text.ipv6.wtfismyip.com
@@ -151,6 +158,6 @@ or
 "2605:4c40:92:520a:0:8c93:3d8a:1"
 ```
 
-So this VM's outbound IPv6 address is `2605:4c40:92:520a:0:8c93:3d8a:1`.
+So this Machine's outbound IPv6 address is `2605:4c40:92:520a:0:8c93:3d8a:1`.
 
-You may have to install software on the VM to use `dig` or `curl`. On Debian, `dig` belongs to the `dnsutils` package.
+You may have to install software on the Machine to use `dig` or `curl`. On Debian, `dig` belongs to the `dnsutils` package.

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -137,7 +137,7 @@ If you depend on knowing this address for some reason, it's up to you to monitor
 
 ### Find your Machine's outbound IP
 
-The Machine's outbound IPv6 address is available in the `FLY_PUBLIC_IP` [environment variable](/docs/reference/runtime-environment/). Use `fly ssh console -s` to get an interactive shell on the Machine of your choice.
+The Machine's outbound IPv6 address is available in the `FLY_PUBLIC_IP` [environment variable](/docs/machines/runtime-environment/). Use `fly ssh console -s` to get an interactive shell on the Machine of your choice.
 
 ```
 / # echo $FLY_PUBLIC_IP

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -33,7 +33,7 @@
         <%= nav_link "Machines API", "/docs/machines/api/" %>
       </li>
        <li>
-        <%= nav_link "The Machine Runtime Environment", "/docs/reference/runtime-environment/" %>
+        <%= nav_link "The Machine Runtime Environment", "/docs/machines/runtime-environment/" %>
       </li>
       <li>
         <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -32,6 +32,9 @@
       <li>
         <%= nav_link "Machines API", "/docs/machines/api/" %>
       </li>
+       <li>
+        <%= nav_link "The Machine Runtime Environment", "/docs/reference/runtime-environment/" %>
+      </li>
       <li>
         <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
       </li>
@@ -193,6 +196,9 @@
         <%= nav_link "More About Custom Domains and SSL Certificates", "/docs/networking/custom-domains-with-fly/" %>
       </li>
       <li>
+        <%= nav_link "Request headers", "/docs/networking/request-headers/" %>
+      </li>
+      <li>
         <%= nav_link "Run UDP Services", "/docs/networking/udp-and-tcp/" %>
       </li>
       <li>
@@ -267,9 +273,6 @@
       </li>
       <li>
         <%= nav_link "Regions", "/docs/reference/regions/" %>
-      </li>
-      <li>
-        <%= nav_link "Runtime Environment", "/docs/reference/runtime-environment/" %>
       </li>
       <li>
         <%= nav_link "Build Secrets", "/docs/reference/build-secrets/" %>

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -235,11 +235,11 @@ wait_timeout = "10m"
   S3_BUCKET = "my-app-production"
 ```
 
-This optional section allows setting non-sensitive information as environment variables in the application's [runtime environment](/docs/reference/runtime-environment/).
+This optional section allows setting non-sensitive information as environment variables in the application's [runtime environment](/docs/machines/runtime-environment/).
 
 For sensitive information, such as credentials or passwords, use the [secrets CLI command](/docs/reference/secrets).
 
-Env variable names are strictly case-sensitive and cannot begin with `FLY_` (as this could clash with the [runtime environment](/docs/reference/runtime-environment)). Env values can only be strings.
+Env variable names are strictly case-sensitive and cannot begin with `FLY_` (as this could clash with the [runtime environment](/docs/machines/runtime-environment)). Env values can only be strings.
 
 Secrets take precedence over env variables with the same name.
 

--- a/reference/index.html.md
+++ b/reference/index.html.md
@@ -40,7 +40,7 @@ An explanation of how Fly.io's proxy distributes traffic to your application ins
 * [**Monorepo and Multi-Environment Deployments**](/docs/reference/monorepo/):
 The command options you can use with flyctl to build and deploy multiple apps from a monorepo or deploy an app to multiple targets.
 
-* [**Runtime Environment**](/docs/reference/runtime-environment/):
+* [**Runtime Environment**](/docs/machines/runtime-environment/):
 The environment variables that are set when an App runs on Fly.io and the request headers which provide Apps with information about incoming connections.
 
 * [**Secrets - Build time**](/docs/reference/build-secrets/):

--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -65,4 +65,4 @@ You can see which regions your app is running in with [`fly status`](https://fly
 
 [Fly Volumes](/docs/volumes/) and [Fly Machines](/docs/machines/) are tied to the region they're created in.
 
-When an application instance is started, the three-letter name for the region it's running in is stored in the Machine's `FLY_REGION`  environment variable. This, along with other [Runtime Environment](/docs/reference/runtime-environment/) information, is visible to your app running on that instance.
+When an application instance is started, the three-letter name for the region it's running in is stored in the Machine's `FLY_REGION`  environment variable. This, along with other [Runtime Environment](/docs/machines/runtime-environment/) information, is visible to your app running on that instance.

--- a/reference/runtime-environment.html.md
+++ b/reference/runtime-environment.html.md
@@ -1,90 +1,52 @@
 ---
-title: The Fly Runtime Environment
+title: The Machine Runtime Environment
 layout: docs
-sitemap: false
 nav: firecracker
+redirect_from: /docs/reference/runtime-environment/
 ---
 
-When a Fly application is running, various information about the runtime environment is made available to it. Environment variables carry information that is generally applicable to the instance. These values come from three sources.
+Environment variables make several kinds of information available within a Machine's runtime environment. The values come from three sources:
 
 * [Secrets](/docs/reference/secrets)
-* The application's [env variable settings](/docs/reference/configuration/#the-env-variables-section) in fly.toml
-* The Fly infrastructure, as detailed below.
+* [Environment variable settings](/docs/reference/configuration/#the-env-variables-section) from the Machine config
+* Fly.io infrastructure, as detailed below
 
-Request headers carry information that is specific to the incoming request and its path taken to the application. Request headers are added by the HTTP handler service.
-
-## _Environment Variables_
+## Environment Variables
 
 ### `FLY_APP_NAME`
-**Application Name**: Each application running on Fly has a unique Application Name. This identifies the application for the user and can also identify instances of the application running on Fly's 6PN networking. For example, `syd.$FLY_APP_NAME.internal` can refer to an instance of the app running. Read more about [6PN Naming](/docs/networking/private-networking/#fly-io-internal-addresses) in the [Private Networking](/docs/networking/private-networking/) docs.
-
-### `FLY_ALLOC_ID`
-**Allocation ID**: Each instance of an application running on Fly has a unique Allocation ID. This can be used, for example, to distinguish between instances running in the same region. `b996131a-5bae-215b-d0f1-2d75d1a8812b` is an example of the Allocation ID's format.
-
-### `FLY_REGION`
-**Region name**: The three-letter name of the region the application instance is running in. Details of current regions are listed in the [Regions](/docs/regions/) page. As an example, "ams" is the region name for Amsterdam.
-
-Not to be confused with the [HTTP header](/docs/reference/runtime-environment/#fly-region) `Fly-Region`, which is where the connection was accepted from.
-
-### `FLY_PUBLIC_IP`
-**IPV6 Public IP**: The full public IPV6 for this instance. Read more in the [Network Services](/docs/networking/services/) section.
-
-### `FLY_IMAGE_REF`
-**Docker Image Reference**: The name of the Docker image running this container. Useful if your application needs to launch Machine instances of itself to scale up-or-down. Read about how [a Rails app runs Machines for scale-to-zero background workers](https://fly.io/ruby-dispatch/rails-background-jobs-with-fly-machines/). `registry.fly.io/my-app-name:deployment-01H9RK9EYO9PGNBYAKGXSHV0PH` is an example of the Docker Image Reference's format.
+**App name**: Each app running on Fly.io has a unique app name. This identifies the app for the user, and can also identify its Machines on their IPv6 private network, using internal DNS. For example, `syd.$FLY_APP_NAME.internal` can refer to the app's Machines running in the `syd` region. Read more about [6PN Naming](/docs/networking/private-networking/#fly-io-internal-addresses) in the [Private Networking](/docs/networking/private-networking/) docs.
 
 ### `FLY_MACHINE_ID`
-**Machine ID**: The unique ID that flyctl commands and the Machines API use to identify a Machine. You can find it in the [logs](/docs/flyctl/logs/).
+**Machine ID**: The Machine's unique ID on the Fly.io platform. This is the ID you use to target the Machine using flyctl and the Machines API. You can also see it in the [log](/docs/flyctl/logs/) messages emitted by the Machine.
+
+### `FLY_ALLOC_ID`
+**Allocation ID**: Same as the `FLY_MACHINE_ID`.
+
+### `FLY_REGION`
+**Region name**: The three-letter name of the region the Machine is running in. Details of current regions are listed in the [Regions](/docs/regions/) page. As an example, "ams" is the region name for Amsterdam.
+
+Not to be confused with the [HTTP header](/docs/networking/request-headers/#fly-region) `Fly-Region`, which is where the connection was accepted from.
+
+### `FLY_PUBLIC_IP`
+**IPV6 public IP**: The full public outbound IPV6 address for this Machine. Read more in the [Network Services](/docs/networking/services/#outbound-ip-addresses) section.
+
+### `FLY_IMAGE_REF`
+**Docker image reference**: The name of the Docker image running this container. `registry.fly.io/my-app-name:deployment-01H9RK9EYO9PGNBYAKGXSHV0PH` is an example of the Docker Image Reference's format.
+
+Useful if your app needs to launch Machine instances of itself to scale background workers to zero and back, as in [Rails Background Jobs with Fly Machines](https://fly.io/ruby-dispatch/rails-background-jobs-with-fly-machines/).
 
 ### `FLY_MACHINE_VERSION`
-**Machine Configuration Version**: The version associated to a specific Machine configuration. When you update a Machine's configuration (including when you update its Docker image), it gets a new `FLY_MACHINE_VERSION`. You can also find this value under the name `Instance ID` in the output of `fly machine status`. Changing the Machine's metadata however doesn't trigger a new version.
+**Machine configuration version**: A version identifier associated with a specific Machine configuration. When you update a Machine's configuration (including when you update its Docker image), it gets a new `FLY_MACHINE_VERSION`. Changing the Machine's metadata using the metadata endpoint of the Machines API doesn't trigger a new version. You can also find this value under the name `Instance ID` in the output of `fly machine status`.
 
 ### `FLY_PRIVATE_IP`
-**Private IPv6 Address**: The IPv6 address of the Machine on its [6PN private network](/docs/networking/private-networking/).
+**Private IPv6 address**: The IPv6 address of the Machine on its [6PN private network](/docs/networking/private-networking/).
 
 ### `FLY_PROCESS_GROUP`
-**Process Group**: The [process group](/docs/apps/processes) associated with the Machine. 
+**Process group**: The Fly Launch [process group](/docs/apps/processes) associated with the Machine, if any. 
 
 ### `FLY_VM_MEMORY_MB`
-**Machine Memory**: The memory allocated to the Machine, in MB. It's the same value you'll find under https://fly.io/dashboard/personal/machines and VM Memory in the output of `fly machine status`. Learn more about [Machine sizing](/docs/machines/guides-examples/machine-sizing/).
+**Machine memory**: The memory allocated to the Machine, in MB. It's the same value you'll find under https://fly.io/dashboard/personal/machines and VM Memory in the output of `fly machine status`. Learn more about [Machine sizing](/docs/machines/guides-examples/machine-sizing/).
 
 ### `PRIMARY_REGION`
-**Primary Region**: This is set in your `fly.toml` or with the `--region` flag during deploys. Learn more about [configuring the primary region](/docs/reference/configuration/#primary-region).
+**Primary region**: This is set in your `fly.toml` or with the `--region` flag during deploys. Learn more about [configuring the primary region](/docs/reference/configuration/#primary-region).
  
-## _Request Headers_
-
-### `Fly-Client-IP`
-**Client IP Address**: The IP address Fly accepted a connection from. This will be the client making the initial request and as such, will also appear at the start of the `X-Forwarded-For` addresses. 
-
-### `Fly-Forwarded-Port`
-**Original connection port**: This header is always set by Fly and denotes the actual port that the client connected to the Fly edge node which is then forwarded to the application instance.
-
-### `Fly-Region`
-**Edge Node Region**: This header is a three letter region code which represents the region that the connection was accepted in and routed from. 
-
-Not to be confused with the [environment variable](/docs/reference/runtime-environment/#fly_region) `FLY_REGION`, which is where the application is running.
-
-### `X-Forwarded-For`
-**Client and Proxy List**: This is a comma separated list comprising of the client that originated the request and the proxy servers the request passed through. For example, "77.97.0.98, 77.83.142.33" contains the client and the one proxy it passed through.
-
-MDN has [full documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) for this header.
-
-### `X-Forwarded-Proto`
-**Original client protocol**: The protocol which the client used to make the request. Either `http` or `https`.
-
-### `X-Forwarded-Port`
-**Original connection port**: This header may be set by the client and should denote the port that the client set out to connect to.
-
-### `X-Forwarded-SSL`
-**SSL Status**: This indicates if the client connected over SSL. Its value can be either `on` or `off`. 
-
-## _Request and Response Headers_
-
-### `Via`
-**Proxy Route**: This header, added by proxies, shows the path taken, and protocols used, by the connection. MDN has [full documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Via) for this header. For example, a connection through the Fly edge may show `2 fly.io` in the field, denoting that version 2 of HTTP was used by the connection as it passed through the Fly Proxy.
-
-
-
-
-
-
-


### PR DESCRIPTION
### Summary of changes
Splits the current runtime environment doc into one doc on environment variables and another doc on http request headers.  Makes several corrections and clarifications.