### PR TITLE
Add machines runtime env doc to machines nav and landing

### DIFF
--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -14,6 +14,8 @@ Understand how Machines work and other things you need to know when you have low
 
 [Machine sizing](/docs/machines/guides-examples/machine-sizing/)
 
+[The Machine Runtime Environment](/docs/machines/runtime-environment/)
+
 ## How-Tos
 
 Using Machines.

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -14,7 +14,7 @@ Understand how Machines work and other things you need to know when you have low
 
 [Machine sizing](/docs/machines/guides-examples/machine-sizing/)
 
-[The Machine Runtime Environment](/docs/machines/runtime-environment/)
+[The Machine runtime environment](/docs/machines/runtime-environment/)
 
 ## How-Tos
 

--- a/machines/runtime-environment.html.md
+++ b/machines/runtime-environment.html.md
@@ -1,7 +1,7 @@
 ---
 title: The Machine Runtime Environment
 layout: docs
-nav: firecracker
+nav: machines
 redirect_from: /docs/machines/runtime-environment/
 ---
 

--- a/machines/runtime-environment.html.md
+++ b/machines/runtime-environment.html.md
@@ -11,7 +11,7 @@ Environment variables make several kinds of information available within a Machi
 * [Environment variable settings](/docs/reference/configuration/#the-env-variables-section) from the Machine config
 * Fly.io infrastructure, as detailed below
 
-## Environment Variables
+## Environment variables
 
 ### `FLY_APP_NAME`
 **App name**: Each app running on Fly.io has a unique app name. This identifies the app for the user, and can also identify its Machines on their IPv6 private network, using internal DNS. For example, `syd.$FLY_APP_NAME.internal` can refer to the app's Machines running in the `syd` region. Read more about [6PN Naming](/docs/networking/private-networking/#fly-io-internal-addresses) in the [Private Networking](/docs/networking/private-networking/) docs.

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -84,6 +84,9 @@
       <li>
         <%= nav_link "Machine states", "/docs/machines/machine-states/" %>
       </li>
+       <li>
+        <%= nav_link "The Machine Runtime Environment", "/docs/machines/runtime-environment/" %>
+      </li>
       <li>
         <%= nav_link "flyctl Machine commands", "/docs/flyctl/machine/" %>
       </li>

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -63,10 +63,10 @@
     </span>
     <ul>
       <li>
-        <%= nav_link "Run User Code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
+        <%= nav_link "Run user code on Fly Machines", "/docs/machines/guides-examples/functions-with-machines/" %>
       </li>
       <li>
-        <%= nav_link "Machine Sizing", "/docs/machines/guides-examples/machine-sizing/" %>
+        <%= nav_link "Machine sizing", "/docs/machines/guides-examples/machine-sizing/" %>
       </li>
       <li>
         <%= nav_link "Machine restart policy", "/docs/machines/guides-examples/machine-restart-policy/" %>
@@ -85,7 +85,7 @@
         <%= nav_link "Machine states", "/docs/machines/machine-states/" %>
       </li>
        <li>
-        <%= nav_link "The Machine Runtime Environment", "/docs/machines/runtime-environment/" %>
+        <%= nav_link "The Machine runtime environment", "/docs/machines/runtime-environment/" %>
       </li>
       <li>
         <%= nav_link "flyctl Machine commands", "/docs/flyctl/machine/" %>


### PR DESCRIPTION
### Summary of changes

Add the new Machines runtime environment doc to the Machines nav and landing page.

@catflydotio I think this belongs in reference in the nav. And the way the landing page is now, I thought it best under Learn along with the machines state reference. Feel free to suggest changes!

### Related Fly.io community and GitHub links
#1385 

### Notes

