### PR TITLE
Missing slash was causing weird 404

### DIFF
--- a/partials/_hands_on_nav.html.erb
+++ b/partials/_hands_on_nav.html.erb
@@ -4,7 +4,7 @@
   @nav = [
     {
       title: "Hands-on with Fly.io",
-      path: "docs/hands-on/",
+      path: "/docs/hands-on/",
       accordion: false,
       links: [
         { text: "1. Install flyctl", path: "/docs/hands-on/install-flyctl/" },


### PR DESCRIPTION
### Summary of changes

Missing forward slash at start of hands-on relative link in the hands-on nav partial was 404ing with a compound url

### Related Fly.io community and GitHub links


### Notes

