### PR TITLE
Pricing: updates about free trial and add headings for compute

### DIFF
--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -20,7 +20,7 @@ To download a past invoice, click View for the relevant cycle. You'll be sent to
 
 ## Plan billing
 
-You're charged for a plan as soon as you sign up for that plan. The exception is [new customers](/docs/about/pricing/#new-customers), who have a $5 sign-up credit for usage, and are only charged after that credit is used up. For existing Fly.io accounts, when you create a new organization, you are signing up for the Hobby plan. 
+You're charged for a plan as soon as you sign up for that plan. The exception is [new customers](/docs/about/pricing/#new-customers-get-a-free-trial), who have a $5 free trial credit for usage, and are only charged after that credit is used up. For existing Fly.io accounts, when you create a new organization, you are signing up for the Hobby plan. 
 
 Plan billing, and any included usage, is pro-rated over the month. For example, if you sign up for a Hobby plan on September 15th, then you'll be charged $2.50 (half of the $5/mo plan cost) right away and you'll have $2.50 of usage included up to September 30th. Then you'll be charged $5 at the start of October and have $5/mo of usage included for that billing cycle.
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -23,7 +23,7 @@ Check out our [plans and plan pricing](https://fly.io/plans).
 
 Every organization belongs to a plan. When you create a new organization, it starts on the [Hobby plan](https://fly.io/plans). If you need more support or compliance options, then you can upgrade to a Launch, Scale, or Enterprise plan.
 
-Some usage is included with all plans (except the [Legacy Hobby plan](#legacy-hobby-plan)). You can upgrade your plan at any time, or just pay for extra usage at the usage-based prices listed below.
+Some usage is included with our plans (except the [Legacy Hobby plan](#legacy-hobby-plan)). You can upgrade your plan at any time, or just pay for extra usage at the usage-based prices listed below.
 
 <div class="note icon">
 Regardless of which plan you're on, your organization may be subject to automated scaling limits to prevent abuse or to help with capacity planning. Email the address in the error message if you run into such a limit and it's getting in your way.
@@ -57,7 +57,7 @@ Additional resources are billed at the usage-based pricing detailed below.
 
 ## Compute
 
-We charge for running and stopped machines differently. Attached GPUs are charged separately.
+We charge for running and stopped machines differently. Attached GPUs are charged separately. For more details about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
 
 ### Running Fly Machines
 
@@ -69,9 +69,7 @@ Here's the pricing for named presets and the allowed additional RAM configuratio
 
 ### Stopped Fly Machines
 
-For stopped machines we charge only for the root file system (rootfs) needed for each machine. Each 1GB of rootfs for a machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/) tweaks on the underlying file system.
-
-For more details about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
+For stopped machines we charge only for the root file system (rootfs) needed for each machine. Each 1GB of rootfs for a machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/+external) tweaks on the underlying file system.
 
 ### GPUs and Fly Machines
 
@@ -93,6 +91,7 @@ Reserved and dedicated options:
 * Discounted rates for reserved GPU Machines and dedicated hosts.
 
 ## Persistent Storage Volumes
+
 [Fly Volumes](/docs/volumes/) are local persistent storage for Machines.
 
 * Free: 3GB of total provisioned capacity per organization

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -9,15 +9,21 @@ nav: firecracker
 
 ## How it works
 
-Our pricing is designed to let you test us out for free, and scale costs affordably as your needs grow.
+Our pricing lets you try Fly.io with a [free trial credit](#new-customers-get-a-free-trial) for new customers, and then scale costs affordably as your needs grow.
 
-Fly.io services are billed per organization. Organizations are administrative entities on Fly.io that enable you to add members, share app development environments, and manage billing separately. Billing is based on the resources provisioned for your apps, pro-rated for the time they are provisioned. Learn more about [billing](/docs/about/billing/).
+Fly.io services are billed per organization. Every organization is on a [plan](https://fly.io/plans), and each plan includes some usage. If you want to scale beyond your plan, then you can upgrade, or just pay for what you need at the usage-based pricing listed below.
+
+<div class="callout">
+Organizations are administrative entities on Fly.io that let you add members, share app development environments, and manage billing separately. [Billing](/docs/about/billing/) is based on the resources provisioned for your apps, pro-rated for the time they are provisioned.
+</div>
 
 ## Plans
 
-Every organization belongs to a [plan](https://fly.io/plans). New organizations start on the [Hobby plan](https://fly.io/plans). If you need more support or compliance options, you can upgrade to a Launch, Scale, or Enterprise plan.
+Check out our [plans and plan pricing](https://fly.io/plans).
 
-All plans (except the [Legacy Hobby plan](#legacy-hobby-plan)) come with some usage included; if you want to scale beyond this, you pay for just what you need at the usage-based pricing listed below. 
+Every organization belongs to a plan. When you create a new organization, it starts on the [Hobby plan](https://fly.io/plans). If you need more support or compliance options, then you can upgrade to a Launch, Scale, or Enterprise plan.
+
+Some usage is included with all plans (except the [Legacy Hobby plan](#legacy-hobby-plan)). You can upgrade your plan at any time, or just pay for extra usage at the usage-based prices listed below.
 
 <div class="note icon">
 Regardless of which plan you're on, your organization may be subject to automated scaling limits to prevent abuse or to help with capacity planning. Email the address in the error message if you run into such a limit and it's getting in your way.
@@ -25,11 +31,13 @@ Regardless of which plan you're on, your organization may be subject to automate
 
 All plans require a [credit card](/docs/about/billing/#payment-options) on file. For details, or to select a different plan, see [Plan Pricing](https://fly.io/plans).
 
-### New customers
+### New customers get a free trial
 
-When you sign up for a Fly.io account, we create a default (“personal”) organization for you, which receives a one-time $5 sign-up credit to let you test-drive Fly.io at no cost. This organization's $5/month Hobby plan subscription does not start until the credit has been used up. Usage that falls outside of our free resource allowances consumes your sign-up credit.
+When you sign up for a Fly.io account, you get a one-time $5 free trial credit to let you test-drive Fly.io at no cost. You won't be charged for the $5/month Hobby plan subscription until the credit has been used up. The free trial credit doesn't expire.
 
-Once this credit is exhausted, the organization is automatically migrated to the $5/month [Hobby plan](https://fly.io/plans) (we’ll send you an email when it happens). There’s no time limit to use up the sign-up credit and move to the paid subscription.
+Usage beyond our [free resource allowances](#free-allowances) consumes your free trial credit.
+
+The free trial credit applies to your default (“personal”) organization that we create for you on sign-up. When the free trial credit is used up, that organization is automatically placed on the $5/month [Hobby plan](https://fly.io/plans) (we’ll send you an email when it happens).
 
 ### Legacy Hobby plan
 
@@ -49,9 +57,9 @@ Additional resources are billed at the usage-based pricing detailed below.
 
 ## Compute
 
-### Fly Machines
+We charge for running and stopped machines differently. Attached GPUs are charged separately.
 
-We charge for running and stopped machines differently.
+### Running Fly Machines
 
 The price of a running [Fly Machine](/docs/machines/) VM is the price of a named CPU/RAM preset, plus about $5 per 30 days per GB of additional RAM.
 
@@ -59,13 +67,15 @@ Here's the pricing for named presets and the allowed additional RAM configuratio
 
 <%= partial("shared/cpu_mem_machines_pricing") %>
 
-For stopped machines we only charge for the root file system (rootfs) needed for each machine. Each 1GB of rootfs for a machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/) tweaks on the underlying file system.
+### Stopped Fly Machines
+
+For stopped machines we charge only for the root file system (rootfs) needed for each machine. Each 1GB of rootfs for a machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/) tweaks on the underlying file system.
 
 For more details about how costs are calculated, see [Machine billing](/docs/about/billing/#machine-billing).
 
 ### GPUs and Fly Machines
 
-Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see [Fly Machines pricing](#fly-machines)) plus the price of the attached GPU.
+Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see above) plus the price of the attached GPU.
 
 On-demand GPU pricing:
 
@@ -120,7 +130,7 @@ We bill for outbound data transfer from the region a VM is running in, inbound t
 [Fly Kubernetes](/docs/kubernetes/) (FKS) is an implementation of Kubernetes that runs on Fly.io.
 
 - $75/mo per cluster
-- Plus the cost of any [Fly Machines](#fly-machines) and [Fly volumes](#persistent-storage-volumes) that you create
+- Plus the cost of [compute](#compute) and [Fly volumes](#persistent-storage-volumes) that you create
 
 ## LiteFS Cloud
 

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -1199,7 +1199,7 @@ Properties of the `config` object for Machine configuration. See [Machine proper
 
 ---
 
-**`size`:** A [named size](/docs/about/pricing/#fly-machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
+**`size`:** A [named size](/docs/about/pricing/#running-fly-machines) for the VM, e.g. `performance-2x` or `shared-cpu-2x`. Note: `guest` and `size` are mutually exclusive.
 
 ---
 

--- a/machines/guides-examples/machine-sizing.html.markerb
+++ b/machines/guides-examples/machine-sizing.html.markerb
@@ -14,7 +14,7 @@ Here are a few ways to set the size (CPU and memory) of your Machine VMs. This g
 
 ## General Rules
 
-We have some [preset sizes](/docs/about/pricing/#fly-machines) for you to choose from. Each CPU selection defaults to a specific amount of memory.
+We have some [preset sizes](/docs/about/pricing/#running-fly-machines) for you to choose from. Each CPU selection defaults to a specific amount of memory.
 
 You can, however, scale your machine's CPU and memory separately. Memory limits are `2gb * shared CPU size` or `8gb * performance CPU size`. Minimum memory is `256m * shared CPU size` or `2048m * performance CPU size`.
 


### PR DESCRIPTION
### Summary of changes

- Reword "sign-up credit" to "free trial credit". 
- Put important info about plans and usage into the How it works section at the top of the page. 
- Link to plans more prominently.
- Rename "New customers" to "New customers get a free trial".
- Re-word, re-org the New customers and Plans sections/
- Add headings to Compute section since the rootfs was kind of buried: "Running Fly Machines" and "Stopped Fly Machines"

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-08 at 12 44 08 PM](https://github.com/superfly/docs/assets/13827355/18ffb9f6-3be0-4265-90ea-a76a0666a02d) | ![Screenshot 2024-03-08 at 12 43 37 PM](https://github.com/superfly/docs/assets/13827355/99d2c812-95ed-45dd-a7db-7b498139f60d) |

### Preview

https://aa-docs.fly.dev/docs/about/pricing/

### Related Fly.io community and GitHub links


### Notes

