### PR TITLE
Fix link to Hands-on: Sign Up/Sign In page

### DIFF
--- a/hands-on/install-flyctl.html.markerb
+++ b/hands-on/install-flyctl.html.markerb
@@ -63,4 +63,4 @@ pwsh -Command "iwr https://fly.io/install.ps1 -useb | iex"
 
 If you encounter an error saying the `pwsh` command is not found, `powershell` can be used instead, though we recommend [installing the latest version of PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows).
 
-[Next: Sign up / Sign in](/docs/getting-started/log-in-to-fly/)
+[Next: Sign up / Sign in](/docs/hands-on/sign-up-sign-in/)


### PR DESCRIPTION
### Summary of changes

Forgot to change the "Next" link to the new Sign Up/ Sign In page, which is sort of okay since the link still went to a page that described how to Sign up and Sign In. But bothered me enough to fix on a Saturday.

### Related Fly.io community and GitHub links


### Notes

