### PR TITLE
GPU docs: minor edits/updates

### DIFF
--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -33,10 +33,11 @@ vm.size = "a100-40gb"
 
 The `a100-40gb` preset is the `a100-pcie-40gb` GPU with the `performance-8x` CPU config and 32GB RAM. You can exert more granular control over resources using the [`[[vm]]` table](https:///docs/reference/configuration/#the-vm-section) in `fly.toml`.
 
-Run `fly platform vm-sizes` to get the list of presets, and [check out the pricing page](https:///docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
+Run `fly platform vm-sizes` to get the list of presets, and check out the [pricing page](/docs/about/pricing/#gpus-and-fly-machines) to help you plan ahead.
 
 ### Specify the region
-But you're not done! For `fly deploy` to succeed in provisioning your Machine(s), the app's `primary_region` must match a region that hosts the kind of GPU you're asking for. At the time of writing, `a100-pcie-40gb` GPUs are only available in `ord`. Set the initial region in `fly.toml`:
+
+But you're not done! For `fly deploy` to succeed in provisioning your Machine(s), the app's `primary_region` must match a region that hosts the kind of GPU you're asking for. At the time of writing, `a100-40gb` GPUs are only available in `ord`. Set the initial region in `fly.toml`:
 
 ```
 primary_region = "ord"  # If you change this, ensure it's to a region that offers the GPU model you want
@@ -50,20 +51,21 @@ Currently GPUs are available in the following regions:
 
 
 ### Change GPU model
+
 GPU models are located in different regions, so you'll likely have to destroy any existing Machines before redeploying using a different GPU spec.
 
 
 ## Choosing a Docker base image
 
-Many open-source ML projects have ready-made Docker images; for example: [Ollama](https://ollama.ai/blog/ollama-is-now-available-as-an-official-docker-image), [Basaran](https://github.com/hyperonym/basaran), [LocalAI](https://localai.io/basics/getting_started/). Check out [GitHub `fly-apps` repos with the `gpu` topic](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu) for some examples.
+Many open-source ML projects have ready-made Docker images; for example: [Ollama](https://ollama.ai/blog/ollama-is-now-available-as-an-official-docker-image+external), [Basaran](https://github.com/hyperonym/basaran+external), [LocalAI](https://localai.io/basics/getting_started/+external). Check out [GitHub `fly-apps` repos with the `gpu` topic](https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu+external) for some examples.
 
-If you're building your own image, choose a base image that [NVIDIA supports](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements); `ubuntu:22.04` is a solid choice that's compatible with the CUDA driver GPU Machines use. You can launch a vanilla Ubuntu image and run `nvidia-smi` with no further setup.
+If you're building your own image, choose a base image that [NVIDIA supports](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements+external); `ubuntu:22.04` is a solid choice that's compatible with the CUDA driver GPU Machines use. You can launch a vanilla Ubuntu image and run `nvidia-smi` with no further setup.
 
 From there, install whatever packages your project needs. This will include some libraries from NVIDIA if you want to do something more than admire the output of `nvidia-smi`.
 
 ## Installing NVIDIA libraries
 
-You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries)—`libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler)  for compiling stuff with CUDA support.
+You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries+external)—`libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler+external) for compiling stuff with CUDA support.
 
 In general, you'll install NVIDIA libs using your Linux package manager. In a Python environment, it's possible to skip system-wide installation and use pip packages instead.
 
@@ -87,7 +89,7 @@ Unless you've got a constant workload, you'll likely want to shut down GPU Machi
 
 ## Using swap
 
-Designing your workload and provisioning appropriate resources for it are the first line of defence against losing work by running out of memory (system RAM or VRAM). 
+Designing your workload and provisioning appropriate resources for it are the first line of defense against losing work by running out of memory (system RAM or VRAM). 
 
 You can also enable swap for system RAM on a Fly Machine, simply by including a line like the following in `fly.toml`:
 
@@ -97,4 +99,4 @@ swap_size_mb = 8192    # This enables 8GB swap
 
 Keep in mind that this consumes the commensurate amount of space on the Machine's root file system, leaving less capacity for whatever else you want to store there.
 
-If you need more system RAM and fastest performance, also scale up with `fly scale memory`.
+If you need more system RAM and faster performance, also scale up with `fly scale memory`.

--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -65,7 +65,7 @@ From there, install whatever packages your project needs. This will include some
 
 ## Installing NVIDIA libraries
 
-You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries+external)—`libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler+external) for compiling stuff with CUDA support.
+You don't need to install any `cuda-drivers` packages in the Docker image, but you'll want some subset of [NVIDIA's GPU-accelerated libraries](https://developer.nvidia.com/gpu-accelerated-libraries+external). `libcublas-12-2` (linear algebra) and `libcudnn8` (deep-learning primitives) are a common combination, along with [`cuda-nvcc`](https://developer.nvidia.com/cuda-llvm-compiler+external) for compiling stuff with CUDA support.
 
 In general, you'll install NVIDIA libs using your Linux package manager. In a Python environment, it's possible to skip system-wide installation and use pip packages instead.
 

--- a/gpus/gpu-quickstart.html.markerb
+++ b/gpus/gpu-quickstart.html.markerb
@@ -17,16 +17,12 @@ nav: firecracker
 1. From flyctl, create an app using either `fly launch` or `fly apps create`.
 
     <div class="note icon">
-    **Note**: GPUs are not available in all regions.
-
-    There are three GPU types available: Nvidia L40S, A100-PCIe-40GB and A100-SXM4-80GB ([datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf)). And we offer two Machine size presets `a100-40gb` and `a100-80gb` available in the following regions:
-
-    Currently GPUs are available in the following regions:
+    **Note**: GPUs are not available in all regions. There are three GPU types available: Nvidia L40S, A100-PCIe-40GB, and A100-SXM4-80GB.
+    
+    <br>Currently GPUs are available in the following regions:
     - `l40s`: `ord`
     - `a100-40gb`: `ord`
     - `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
-
-    <br>Follow [this thread](https://community.fly.io/t/fly-gpus-are-here/16110) for updates.
     </div>
 
 1. Create or modify the `fly.toml` config file in the project source directory, replacing values with your own:
@@ -63,16 +59,18 @@ nav: firecracker
 
 That's pretty much it to get an app running with a Machine on a GPU.
 
+## Volumes and GPU Machines
+
 <div class="important icon">
-**Important**: If you create any additional volumes, they need to be created with the same constraints as your Machine. See the following example.
+**Important**: If you create any additional volumes, they need to be created with the same constraints as your Machine.
 </div>
 
-A volume needs to be created with the same constraints as your Machine. Here's an example of creating a one hundred gigabyte volume for storing ML models in the `ord` region, on a machine with a GPU:
+Here's an example of creating a one hundred gigabyte volume for storing ML models in the `ord` region, on a machine with a GPU:
 
 ```cmd
 fly volumes create models \
   --size 100 \
-  --vm-gpu-kind a100-pcie-40gb \
+  --vm-gpu-kind a100-40gb \
   --region ord
 ```
 
@@ -96,10 +94,10 @@ COPY --from=builder /usr/local/bin/deviceQuery /usr/local/bin/deviceQuery
 CMD ["sleep", "inf"]
 ```
 
-## Examples
+## Examples using Fly GPUs
 
-- Elixir Llama2-13b on Fly.io GPUs: https://gist.github.com/chrismccord/59a5e81f144a4dfb4bf0a8c3f2673131
+- Elixir Llama2-13b on Fly GPUs: https://gist.github.com/chrismccord/59a5e81f144a4dfb4bf0a8c3f2673131
 - Github fly-apps repos with the `gpu` topic: https://github.com/orgs/fly-apps/repositories?q=topic%3Agpu
 - Fly.io CUDA example: https://gist.github.com/dangra/f8123001fe0f2453a8cd638b89738465
-- Deploying CLIP on Fly: https://gist.github.com/simonw/52c7734e34cac2b26ea1378845674edc
+- Deploying CLIP on Fly.io: https://gist.github.com/simonw/52c7734e34cac2b26ea1378845674edc
 

--- a/gpus/gpu-quickstart.html.markerb
+++ b/gpus/gpu-quickstart.html.markerb
@@ -65,7 +65,7 @@ That's pretty much it to get an app running with a Machine on a GPU.
 **Important**: If you create any additional volumes, they need to be created with the same constraints as your Machine.
 </div>
 
-Here's an example of creating a one hundred gigabyte volume for storing ML models in the `ord` region, on a machine with a GPU:
+Here's an example of creating a new one hundred gigabyte volume for storing ML models in the `ord` region, on a machine with a GPU:
 
 ```cmd
 fly volumes create models \

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -11,13 +11,21 @@ Fly.io has GPUs! If you have workloads that would benefit from GPU acceleration,
 
 Three models of GPU are available: NVIDIA A100 40G PCIe, A100 80G SXM, and L40S.
 
-A100 units are all about the tensor cores, and are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory. ([A100 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf))
+A100 units are all about the tensor cores, and are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory. ([A100 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf+external))
 
-The L40S cards are all-rounders; they've got tensor cores, RT cores, and NVENC/NVDEC, and have 48GB of GPU RAM. Choose the L40S to accelerate graphics or video workloads, as well as for inference. ([L40S datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413))
+The L40S cards are all-rounders; they've got tensor cores, RT cores, and NVENC/NVDEC, and have 48GB of GPU RAM. Choose the L40S to accelerate graphics or video workloads, as well as for inference. ([L40S datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413+external))
 
 Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to rendering, encoding/decoding, inference, and a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
 
 Go to the [GPU Quickstart](https://fly.io/docs/gpus/gpu-quickstart/) to get off the ground fast, or read more practicalities in [Getting started with Fly GPUs](/docs/gpus/getting-started-gpus/).
+
+## Regions with GPUs
+
+Currently GPUs are available in the following regions:
+
+- `l40s`: `ord`
+- `a100-40gb`: `ord`
+- `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
 
 ## Examples
 

--- a/gpus/python-gpu-example.html.md
+++ b/gpus/python-gpu-example.html.md
@@ -21,7 +21,7 @@ git clone git@github.com:fly-apps/python_gpu_example.git && cd python_gpu_exampl
 
 ### Edit app configuration in `fly.toml`
 * Change `app` to match the name of the app you just created.
-* Optionally, `primary_region`&mdash;make sure to choose a region in which GPU Machines are available. Check the [docs](https://fly.io/docs/gpus/gpu-quickstart/) for GPU regions.
+* Optionally, `primary_region`&mdash;make sure to choose a [region in which GPU Machines are available](/docs/gpus/#regions-with-gpus).
 * Optionally, change the NONROOT_USER `build.arg`&mdash;if you do, also edit the `destination` of the volume mount in `mounts` to match.
 * Optionally, tweak `swap_size_mb`.
 


### PR DESCRIPTION
### Summary of changes

- created a new section "Regions with GPUs" on the landing page, so it can be linked to (regions are in three places now which is fine/good, but probably should be a partial at some point)
- gave the volume content a heading in the Quickstart so people know whether they need to follow it
- added external icons to external links
- fixed a broken link
- fixed a typo

### Related Fly.io community and GitHub links


### Notes

