### PR TITLE
Correct fly apps restart info

### DIFF
--- a/apps/restart.html.markerb
+++ b/apps/restart.html.markerb
@@ -1,5 +1,5 @@
 ---
-title: Restart an App or a Machine
+title: Restart apps or Machines
 objective: 
 layout: docs
 nav: firecracker
@@ -10,20 +10,20 @@ order: 70
   <img src="/static/images/docs-mountains.webp" alt="">
 </figure>
 
-Running `fly deploy` on an App creates a new release of the App, and restarts the Machines that it manages.
+Running `fly deploy` on an app creates a new release of the app, and updates and restarts the Machines that belong to Fly Launch.
 
 Sometimes you don't want to update anything; you just want to reboot and start the root file system afresh. (Yes, restarting wipes the ephemeral file system, just as a `fly deploy` or `fly machine update` will.)
 
-## Restart every Machine in the App
+## Restart every Machine managed by Fly Launch
 
-`fly apps restart <app-name>` restarts all Machines in the App&mdash; Machines that belong to Fly Launch as well as any other standalone Machines you might have created within the App.
+`fly apps restart <app name>` restarts all Machines in the app that are managed by Fly Launch. In other words, all the Machines deployed with `fly deploy` and configured with `fly.toml`.
 
-## Restart an Individual Machine
+## Restart individual Machines
 
-If one particular Machine needs a kick, restart it using `fly machine restart`:
+If one particular Machine needs a kick&mdash;or you want to restart an unmanaged Machine&mdash;then run `fly machine restart`:
 
 ```cmd
-fly machine restart <machine-id>
+fly machine restart <machine id>
 ```
 
-You can provide multiple `<machine-id>`s to restart several Machines in one command.
+You can provide multiple `<machine id>`s to restart several Machines in one command.

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -47,17 +47,17 @@
       links: [
         { text: "Launch a New App", path: "/docs/apps/launch/" },
         { text: "Deploy a Fly App", path: "/docs/apps/deploy/" },
-        { text: "Get Information about an App", path: "/docs/apps/info/" },
+        { text: "Get App Info", path: "/docs/apps/info/" },
         { text: "Scale Machine CPU and RAM", path: "/docs/apps/scale-machine/" },
         { text: "Scale the Number of Machines", path: "/docs/apps/scale-count/" },
         { text: "Auto Stop and Start Machines", path: "/docs/apps/autostart-stop/" },
-        { text: "Add volume storage", path: "/docs/apps/volume-storage/" },
-        { text: "Manage volume storage", path: "/docs/apps/volume-manage/" },
-        { text: "Restart an App", path: "/docs/apps/restart/" },
+        { text: "Add Volume Storage", path: "/docs/apps/volume-storage/" },
+        { text: "Manage Volume Storage", path: "/docs/apps/volume-manage/" },
+        { text: "Restart Apps and Machines", path: "/docs/apps/restart/" },
         { text: "Run Multiple Processes in an App", path: "/docs/apps/processes/" },
         { text: "Deploy with GitHub Actions", path: "/docs/app-guides/continuous-deployment-with-github-actions/" },
         { text: "Delete an App", path: "/docs/apps/delete/" },
-        { text: "Troubleshoot apps when a host is unavailable", path: "/docs/apps/trouble-host-unavailable/" },
+        { text: "Troubleshoot When a Host is Down", path: "/docs/apps/trouble-host-unavailable/" },
         { text: "Fly Launch Config (fly.toml)", path: "/docs/reference/configuration/" }
       ]
     },


### PR DESCRIPTION
### Summary of changes

- `fly apps restart` does not restart unmanaged Machines
- minor fixes to nav while in there

### Related Fly.io community and GitHub links


### Notes

