### PR TITLE
Public Networking doc: update handlers with examples + update IP address allocation info

### DIFF
--- a/machines/api/apps-resource.html.markerb
+++ b/machines/api/apps-resource.html.markerb
@@ -90,7 +90,7 @@ To segment the app into its own network, you can pass a `network` argument in th
 ## Allocate an IP address for global request routing
 
 If you intend for Machines to be accessible to the internet, you'll need to allocate an IP address to the app. Currently
-this is done using `flyctl` or the [Fly.io GraphQL API](https://api.fly.io/graphql). This offers your app automatic, global routing via [Anycast](https://fly.io/docs/reference/services/#anycast). Read more about this in [the Networking section](https://fly.io/docs/reference/services/#notes-on-networking).
+this is done using `flyctl` or the [Fly.io GraphQL API](https://api.fly.io/graphql). This offers your app automatic, global routing via [Anycast](https://fly.io/docs/reference/services/#about-anycast). Read more about this in [the Networking section](https://fly.io/docs/reference/services/#notes-on-networking).
 
 Example:
 

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -58,7 +58,7 @@ Shared IPv4 addresses are recommended unless you have an explicit need for your 
 - You want your app to accept raw TCP and handle TLS termination.
 - You have a Fly Postgres app with the default hostname that you want exposed to the internet for external connections.
 
-Allocating a dedicated IPv4 anycast address is opt-in only. To manually allocate a dedicated IPv4 address for your app, run:
+Allocating a dedicated IPv4 Anycast address is opt-in only. To manually allocate a dedicated IPv4 address for your app, run:
 
 ```cmd
 fly ips allocate-v4

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -9,7 +9,7 @@ redirect_from:
 
 Fly.io has public and private network services available. The public network services connect apps to the wider public internet, while the [private network services](/docs/reference/private-networking) allow apps to communicate with other apps within the Fly.io private network.
 
-## IP addresses
+## Anycast IP addresses
 
 IPv6 addresses and shared IPv4 Anycast addresses are free. Dedicated IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
 
@@ -50,13 +50,13 @@ If you create apps with public services in their Machine config using [`fly mach
 
 Dedicated IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
 
-Shared IPv4 addresses are recommended unless you have an explicit need for your own IP. Some of the reasons to use a dedicated IPv4 address:
+Shared IPv4 addresses are recommended unless you have an explicit need for your own IP. Some of the reasons to use a dedicated IPv4 address include:
 
 - Your app uses a non-HTTP protocol that doesn't use TLS.
 - You want to use a wildcard certificate.
 - Your app needs to do something over UDP (we don't support UDP over shared IPv4 or dedicated IPv6).
 - You want your app to accept raw TCP and handle TLS termination.
-- You have a Fly Postgres app with the default hostname that you want exposed to the internet for external connections.
+- You have a Fly Postgres exposed to the internet over TLS for external connections.
 
 Allocating a dedicated IPv4 Anycast address is opt-in only. To manually allocate a dedicated IPv4 address for your app, run:
 
@@ -181,7 +181,7 @@ Example configuration from default Fly Postgres app `fly.toml`:
 
 ### PROXY protocol handler
 
-The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most apps need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt+external) directly. 
+The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most apps need additional logic to accept the PROXY protocol, either using a prebuilt library or implementing the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt+external) directly. 
 
 Fly.io supports version 1 (human-readable header format) of the PROXY protocol by default with the `proxy_proto` handler. You can configure the `proxy_proto` handler to use version 2 (binary header format) in the [`services.ports.proxy_proto_options`](/docs/reference/configuration/#services-ports-proxy_proto_options) section of your `fly.toml` file.
 
@@ -200,7 +200,7 @@ The `force_https` configuration option automatically redirects HTTP to HTTPS. Wh
 
 ## Outbound IP addresses
 
-Fly Machines have IPv6 addresses from which they make requests to the wider internet without going through the Fly proxy.
+Fly Machines have IPv6 addresses from which they make requests to the wider internet without going through the Fly Proxy.
 
 We don’t offer static IPs or regional IP ranges, and we discourage the use of our outbound IPs to bypass firewalls. A Machine's outbound IP is liable to change without notice. This shouldn't be a daily occurrence, but it will happen if a Machine is moved for whatever reason, such as a load-balancing of Fly Machines between servers in one region.
 

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -7,57 +7,70 @@ redirect_from:
   - /docs/reference/services/
 ---
 
-Fly.io has public and private network services available. The public network services connect applications to the wider public internet, while the [private network services](/docs/reference/private-networking) allow application instances to communicate with other application instances within the Fly.io private network.
+Fly.io has public and private network services available. The public network services connect apps to the wider public internet, while the [private network services](/docs/reference/private-networking) allow apps to communicate with other apps within the Fly.io private network.
 
 ## IP addresses
 
-### Anycast
+IPv6 addresses and shared IPv4 Anycast addresses are free. Dedicated IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
 
-We announce global IP blocks from all of our datacenters over BGP, otherwise known as anycast. Anycast is a core internet routing mechanism that connects clients to the "nearest" server advertising a block of IPs. [You can read all about it on Wikipedia](https://en.wikipedia.org/wiki/Anycast).
+### About Anycast
+
+We announce global IP blocks from all of our datacenters over BGP, otherwise known as Anycast. Anycast is a core internet routing mechanism that connects clients to the "nearest" server advertising a block of IPs. You can read [all about it on Wikipedia](https://en.wikipedia.org/wiki/Anycast+external).
 
 ### IPv6
 
-A new Fly App running a [public service](/docs/reference/configuration/#the-services-sections) automatically gets a dedicated anycast IPv6 address when it's first deployed.
+A new Fly App running a public service configured in [`fly.toml`](/docs/reference/configuration/) automatically gets a dedicated Anycast IPv6 address when it's first deployed. 
+
+<div class="note icon">
+If you create apps with public services in their Machine config by using [`fly machine` commands](/docs/machines/flyctl/fly-machine-run/#define-a-fly-proxy-network-service) or the [Machines API](https://fly.io/docs/machines/api/), then you need to run `fly ips allocate-v6` to get a dedicated IPv6 address.
+</div>
 
 ### Shared IPv4
 
-Along with the dedicated IPv6, apps [configured](/docs/reference/configuration/#the-services-sections) to handle either
+Along with the dedicated IPv6 address, apps are automatically given a shared Anycast IPv4 address on the first deployment when they're configured to handle one or both of the following protocols and ports in [`fly.toml`](/docs/reference/configuration/):
 
 * HTTP on port 80, or
 * TLS & HTTP on port 443
 
-(or both) are automatically given a shared anycast IPv4 address on the first deployment.
+This includes apps configured with the simplified [`[http_service]`](/docs/reference/configuration/#the-http_service-section) section, which handles only these protocols and ports by default.
 
-Shared IPs are recommended unless you have an explicit need for your own IP.
-These IPs are shared across many apps and organizations.
-Routing is based on your app's domain.
-One reason to use a dedicated IP is if your app needs to do something over UDP.
+You can use a shared IPv4 address for TCP ports other than 80 and 443 by using the [TLS handler](#tls-handler) with the port. Shared IPv4 addresses are recommended unless you have an [explicit need for your own IP](#dedicated-ipv4). Shared IPv4 addresses are shared across many apps and organizations. Routing is based on your app's domain.
 
-If you want to allocate a shared IPv4 to an app without a public IPv4 address, this is possible (with flyctl v0.0.439 and newer) using
+To allocate a shared IPv4 to an app without a public IPv4 address, run:
 
 ```cmd
 fly ips allocate-v4 --shared
 ```
 
+<div class= "note icon">
+If you create apps with public services in their Machine config using [`fly machine` commands](/docs/machines/flyctl/fly-machine-run/#define-a-fly-proxy-network-service) or the [Machines API](https://fly.io/docs/machines/api/), then you need to run `fly ips allocate-v4 --shared` to get a shared IPv4 address.
+</div>
+
 ### Dedicated IPv4
 
-Allocating a dedicated IPv4 anycast address is now opt-in only, but can still be done manually with
+Dedicated IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
+
+Shared IPv4 addresses are recommended unless you have an explicit need for your own IP. Some of the reasons to use a dedicated IPv4 address:
+
+- Your app uses a non-HTTP protocol that doesn't use TLS.
+- You want to use a wildcard certificate.
+- Your app needs to do something over UDP (we don't support UDP over shared IPv4 or dedicated IPv6).
+- You want your app to accept raw TCP and handle TLS termination.
+- You have a Fly Postgres app with the default hostname that you want exposed to the internet for external connections.
+
+Allocating a dedicated IPv4 anycast address is opt-in only. To manually allocate a dedicated IPv4 address for your app, run:
 
 ```cmd
 fly ips allocate-v4
 ```
 
-when needed; for example, if you want your app to handle TCP directly.
-
-If your app has a shared IPv4 address and you allocate a dedicated one, the shared IPv4 is released automatically.
-
-IPv6 addresses and shared IPv4 anycast addresses are free. Dedicated IPv4 addresses are [billed](/docs/about/pricing/#anycast-ip-addresses) monthly.
+If your app has a shared IPv4 address and you allocate a dedicated IPv4 address, then the shared IPv4 is released automatically.
 
 ### Switch from dedicated IPv4 to shared IPv4
 
 The following steps should allow you to switch an app with a custom domain from a dedicated IPv4 address to a free shared IPv4 without downtime. 
 
-1. Add a shared IPv4 address via `flyctl ips allocate-v4 --shared`
+1. Add a shared IPv4 address with `flyctl ips allocate-v4 --shared`.
 2. If you don't use a CNAME to `.fly.dev`, [add the shared IPv4 as an A record](/docs/networking/custom-domain/#set-the-a-record).
 3. Confirm your app works via shared IP: `curl -Iv http://<your-hostname> --resolve <your-hostname>:80:<new-shared-ipv4>`. You should receive a 301 redirect response.
 4. If you are using a custom domain and don't already have an SSL certificate for this app, [create one](/docs/networking/custom-domain/#get-certified). The cert is required for routing to your app via the custom domain, even for HTTP connections.
@@ -69,23 +82,29 @@ If you do not have a custom domain (your app is accessed by its `.fly.dev` addre
 
 ## Connection handlers
 
-Set the `handlers` config setting in the `services.ports` section of [`fly.toml`](/docs/reference/configuration/) to specify which middleware applies to incoming TCP connections for each port you accept external connections on. Use these to convert TCP connections into something your application can handle.
-
-Valid handler strings:
-* [`"http"`:](#http) Convert TCP connection to HTTP
-* [`"tls"`](#tls): Convert TLS connection to unencrypted TCP
-* [`"pg_tls"`](#postgres-connections): Handle TLS for PostgreSQL connections
-* [`"proxy_proto"`](#proxy-protocol): Wrap TCP connection in PROXY protocol
+Handlers convert TCP connections into something your app can handle. Use handlers to specify which middleware applies to incoming TCP connections for each port you accept external connections on.
 
 ### TCP pass through
 
-If you don't specify handlers, we just forward TCP to your application as-is. This is useful if you want to handle TLS termination yourself, for example.
+If you don't specify handlers, we just forward TCP to your app as-is. This is useful if you want to handle TLS termination yourself, for example.
 
-### HTTP
+### Configure connection handlers
 
-Many applications have limited HTTP support, the `HTTP` middleware normalizes HTTP connections and sends HTTP 1.1 requests to the application process. This is roughly how `nginx` and other reverse proxies work, and allows your application to globally accept modern HTTP protocols (like HTTP/2) without extra complexity.
+Set the `handlers` config setting in the [`services.ports` section](/docs/reference/configuration/#services-ports) of your `fly.toml` file.
 
-If your application stack has good HTTP/2 support (like Go), you will get better performance accepting TCP connections directly, and using the TLS handler to terminate SSL. Your application _does_ need to understand `h2c` for this to work, however.
+Valid handler strings:
+* [`"http"`:](#http-handler) Convert TCP connection to HTTP
+* [`"tls"`](#tls-handler): Convert TLS connection to unencrypted TCP
+* [`"pg_tls"`](#postgres-tls-handler): Handle TLS for PostgreSQL connections
+* [`"proxy_proto"`](#proxy-protocol): Wrap TCP connection in PROXY protocol
+
+You can also configure [TLS options](/docs/reference/configuration/#http_service-tls_options) for the `[http_service]` section, which has a TLS (and HTTP) handler by default on port 443.
+
+### HTTP handler
+
+Many apps have limited HTTP support, the `http` handler normalizes HTTP connections and sends HTTP 1.1 requests to the application process. This is roughly how `nginx` and other reverse proxies work, and allows your app to globally accept modern HTTP protocols (like HTTP/2) without extra complexity.
+
+If your application stack has good HTTP/2 support (like Go), you will get better performance accepting TCP connections directly, and using the TLS handler to terminate SSL. Your app _does_ need to understand `h2c` for this to work, however.
 
 The HTTP handler adds a number of standard HTTP headers to requests, and a few Fly.io-specific headers for convenience:
 
@@ -105,23 +124,75 @@ You can set a preference on HTTP requests for which region you would like to con
 Fly-Prefer-Region: region-code
 ```
 
-### TLS
+Configuration example in `fly.toml`:
 
-The `TLS` middleware terminates TLS using Fly.io-managed application certificates, then forwards a plaintext connection to the application process. This is useful for running TCP services and offloading `TLS` to the Fly Proxy.
+```toml
+[[services]]
+...
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+    force_https = true  # optional
+```
 
-For performance purposes, the Fly Proxy will terminate TLS on the host a client connects to, and then forward the connection to the nearest available application instance.
+### TLS handler
 
-_Note:_ the `TLS` handler includes ALPN negotiation for HTTP/2. When possible, applications will connect to these kinds of Fly.io services using HTTP/2, and we will forward an unencrypted HTTP/2 connection (`h2c`) to the application process.
+The `tls` handler terminates TLS using Fly.io-managed application certificates, then forwards a plaintext connection to the application process. This is useful for running TCP services and offloading `TLS` to the Fly Proxy.
 
-### Postgres connections
+For performance purposes, the Fly Proxy will terminate TLS on the host a client connects to, and then forward the connection to the nearest available Machine.
+
+<div class="note icon">
+**Note:** The TLS handler includes ALPN negotiation for HTTP/2. When possible, apps will connect to these kinds of Fly.io services using HTTP/2, and we will forward an unencrypted HTTP/2 connection (`h2c`) to the application process.
+</div>
+
+Configuration examples in `fly.toml`:
+
+```toml
+[[services]]
+...
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+    tls_options = { "alpn" = ["h2", "http/1.1"], "versions" = ["TLSv1.2", "TLSv1.3"] }
+```
+
+```toml
+[http_service]
+...
+[http_service.tls_options]
+  alpn = ["h2", "http/1.1"]
+  versions = ["TLSv1.2", "TLSv1.3"]
+  default_self_signed = false
+```
+
+### Postgres TLS handler
 
 The `pg_tls` handler manages Postgres connections, so that you can expose your Postgres databases over the proxy securely. Some interesting notes by @glebarez on why standard TLS termination won't work for Postgres: https://github.com/glebarez/pgssl#readme
 
-### PROXY protocol
+Example configuration from default Fly Postgres app `fly.toml`:
 
-The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most applications need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) directly. 
+```toml
+[[services]]
+...
+  [[services.ports]]
+    port = 5433
+    handlers = ["pg_tls"]
+```
+
+### PROXY protocol handler
+
+The `proxy_proto` handler adds information about the original connection, including client IP + port and server IP + port (from the client's perspective). Most apps need additional logic to accept the proxy protocol, either using a prebuilt library or implementing the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt+external) directly. 
 
 Fly.io supports version 1 (human-readable header format) of the PROXY protocol by default with the `proxy_proto` handler. You can configure the `proxy_proto` handler to use version 2 (binary header format) in the [`services.ports.proxy_proto_options`](/docs/reference/configuration/#services-ports-proxy_proto_options) section of your `fly.toml` file.
+
+Configuration examples in `fly.toml`:
+
+```toml
+[[services.ports]]
+  handlers = ["proxy_proto"]
+  port = 5000
+  proxy_proto_options = { version = "v2" }
+```
 
 ## HTTP to HTTPS redirects
 
@@ -129,7 +200,7 @@ The `force_https` configuration option automatically redirects HTTP to HTTPS. Wh
 
 ## Outbound IP addresses
 
-Fly Machiness have IPv6 addresses from which they make requests to the wider Internet without going through the Fly Proxy.
+Fly Machines have IPv6 addresses from which they make requests to the wider internet without going through the Fly proxy.
 
 We don’t offer static IPs or regional IP ranges, and we discourage the use of our outbound IPs to bypass firewalls. A Machine's outbound IP is liable to change without notice. This shouldn't be a daily occurrence, but it will happen if a Machine is moved for whatever reason, such as a load-balancing of Fly Machines between servers in one region.
 
@@ -139,22 +210,28 @@ If you depend on knowing this address for some reason, it's up to you to monitor
 
 The Machine's outbound IPv6 address is available in the `FLY_PUBLIC_IP` [environment variable](/docs/machines/runtime-environment/). Use `fly ssh console -s` to get an interactive shell on the Machine of your choice.
 
+```cmd
+echo $FLY_PUBLIC_IP
 ```
-/ # echo $FLY_PUBLIC_IP
+```out
 2605:4c40:92:520a:0:8c93:3d8a:1
 ```
 
 You can also call out to an external service that'll tell you your IP. For example:
 
+```cmd
+curl text.ipv6.wtfismyip.com
 ```
-/ # curl text.ipv6.wtfismyip.com
+```out
 2605:4c40:92:520a:0:8c93:3d8a:1
 ```
 
 or
 
+```cmd
+dig +short txt o-o.myaddr.l.google.com @ns1.google.com
 ```
-/ # dig +short txt o-o.myaddr.l.google.com @ns1.google.com
+```out
 "2605:4c40:92:520a:0:8c93:3d8a:1"
 ```
 

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -34,7 +34,9 @@ Along with the dedicated IPv6 address, apps are automatically given a shared Any
 
 This includes apps configured with the simplified [`[http_service]`](/docs/reference/configuration/#the-http_service-section) section, which handles only these protocols and ports by default.
 
-You can use a shared IPv4 address for TCP ports other than 80 and 443 by using the [TLS handler](#tls-handler) with the port. Shared IPv4 addresses are recommended unless you have an [explicit need for your own IP](#dedicated-ipv4). Shared IPv4 addresses are shared across many apps and organizations. Routing is based on your app's domain.
+You can use a shared IPv4 address for TCP ports other than 80 and 443 by using the [TLS handler](#tls-handler) when you specify the port. 
+
+Shared IPv4 addresses are recommended unless you have an [explicit need for your own IP](#dedicated-ipv4). Shared IPv4 addresses are shared across many apps and organizations. Routing is based on your app's domain.
 
 To allocate a shared IPv4 to an app without a public IPv4 address, run:
 


### PR DESCRIPTION
### Summary of changes

- add notes that if you created your app through flyctl or API, you don't get IP addresses automatically allocated
- add `fly.toml` snippets to handler sections
- rename handler sections to include the word "handler"
- add a section to handlers specifically about configuration
- add a list of some of the reasons to use a dedicated IPv4 address
- formatting

### Preview

https://aa-docs-3.fly.dev/docs/networking/services/

### Related Fly.io community and GitHub links
https://community.fly.io/t/confusing-docs-regarding-alpn/18684


### Notes

