### PR TITLE
Add table column title because empty column headers get ignored

### DIFF
--- a/networking/app-services.html.md
+++ b/networking/app-services.html.md
@@ -16,11 +16,11 @@ There are two basic ways to talk to a process running in your Fly Machine:
 1. Via Fly Proxy, the Fly.io component that handles load balancing&mdash;this is what you'll need for any public web service
 2. Over the WireGuard [IPv6 private network ("6PN")](/docs/networking/private-networking/) that the app belongs to&mdash;this can be useful for, e.g., providing private supporting services to your Fly Apps
 
-## TL:DR
+## TL;DR
 
 Here's a cheat sheet for configuring apps to be reachable by each of these means:
 
-| App config |Fly Proxy|Internal (6PN)|
+| &nbsp; |Fly Proxy|Internal (6PN)|
 |---|---|---|
 |Bind to | `0.0.0.0:<port>` ([<u>not UDP</u>](#udp-is-special)) | `fly-local-6pn:<port>`|
 |Needs `services` or<br>`http_service` in config? | YES | NO |

--- a/networking/app-services.html.md
+++ b/networking/app-services.html.md
@@ -20,7 +20,7 @@ There are two basic ways to talk to a process running in your Fly Machine:
 
 Here's a cheat sheet for configuring apps to be reachable by each of these means:
 
-||Fly Proxy|Internal (6PN)|
+| App config |Fly Proxy|Internal (6PN)|
 |---|---|---|
 |Bind to | `0.0.0.0:<port>` ([<u>not UDP</u>](#udp-is-special)) | `fly-local-6pn:<port>`|
 |Needs `services` or<br>`http_service` in config? | YES | NO |


### PR DESCRIPTION
### Summary of changes

Added a table column title that hopefully works. Table headers with empty columns get ignored as though they aren't even there, which means the column headings are in the wrong column.

### Related Fly.io community and GitHub links


### Notes

