### PR TITLE
release ip

### DIFF
--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -66,7 +66,7 @@ Allocating a dedicated IPv4 Anycast address is opt-in only. To manually allocate
 fly ips allocate-v4
 ```
 
-If your app has a shared IPv4 address and you allocate a dedicated IPv4 address, then release the shared IPv4 address:
+After allocating a dedicated IPv4 address, release the shared IPv4 address:
 
 ```cmd
 fly ips release <ip address to release>

--- a/networking/services.html.markerb
+++ b/networking/services.html.markerb
@@ -66,7 +66,11 @@ Allocating a dedicated IPv4 Anycast address is opt-in only. To manually allocate
 fly ips allocate-v4
 ```
 
-If your app has a shared IPv4 address and you allocate a dedicated IPv4 address, then the shared IPv4 is released automatically.
+If your app has a shared IPv4 address and you allocate a dedicated IPv4 address, then release the shared IPv4 address:
+
+```cmd
+fly ips release <ip address to release>
+```
 
 ### Switch from dedicated IPv4 to shared IPv4
 


### PR DESCRIPTION
### Summary of changes

You need to release the "old" IPv4 address when you allocate a new one; either dedicated -> shared or shared -> dedicated.

### Related Fly.io community and GitHub links

https://community.fly.io/t/what-happens-when-you-allocate-a-ipv4-address/18790

### Notes

