### PR TITLE
Pricing and Billing: GPUs are by the second

### DIFF
--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -20,7 +20,7 @@ To download a past invoice, click View for the relevant cycle. You'll be sent to
 
 ## Plan billing
 
-You're charged for a plan as soon as you sign up for that plan. The exception is [new customers](/docs/about/pricing/#new-customers-get-a-free-trial), who have a $5 free trial credit for usage, and are only charged after that credit is used up. For existing Fly.io accounts, when you create a new organization, you are signing up for the Hobby plan. 
+You're charged for a plan as soon as you sign up for that plan. There's an exception for [new customers](/docs/about/pricing/#new-customers-get-a-free-trial), who have a $5 free trial credit for usage, and are only charged after that credit is used up. For existing Fly.io accounts, when you create a new organization, you are signing up for the Hobby plan. 
 
 Plan billing, and any included usage, is pro-rated over the month. For example, if you sign up for a Hobby plan on September 15th, then you'll be charged $2.50 (half of the $5/mo plan cost) right away and you'll have $2.50 of usage included up to September 30th. Then you'll be charged $5 at the start of October and have $5/mo of usage included for that billing cycle.
 
@@ -35,6 +35,12 @@ For example, a Machine described in your dashboard as "shared-1x-cpu@1024MB" is 
 Stopped Machines are billed based on their root file system (rootfs) usage per second (the time they spend in the `stopped` state) by $0.15 per GB per month.
 
 For example, a Machine described in your dashboard as having 1GB of rootfs stopped for 10 days in the entire month will cost $0.05. If you have 3 stopped Machines of 1GB rootfs each stopped for 30 days it will cost $0.45 ($0.15 x 3).
+
+## GPU billing
+
+GPUs are billed per second that the attached Fly Machine is running (the time they spend in the `started` state), based on the per hour cost of the GPU card. See [pricing for GPUs](/docs/about/pricing/#gpus-and-fly-machines).
+
+You're also billed for the Fly Machine separately from the GPU.
 
 ## Volume billing
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -73,7 +73,7 @@ For stopped machines we charge only for the root file system (rootfs) needed for
 
 ### GPUs and Fly Machines
 
-Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see above) plus the price of the attached GPU.
+Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see above) plus the price of the attached GPU. Like Machines, GPUs are billed by the second when the attached Machine is running.
 
 On-demand GPU pricing:
 


### PR DESCRIPTION
### Summary of changes

Add that GPU billing is by the second (while prices are by the hour).

### Related Fly.io community and GitHub links


### Notes

