### PR TITLE
docs: update multiple-processes docs with correct internal DNS addresses

### DIFF
--- a/app-guides/multiple-processes.html.md
+++ b/app-guides/multiple-processes.html.md
@@ -221,7 +221,7 @@ There are good reasons to run multiple programs in a single container, but somet
 
 If you're running multiple heavy-weight things in a single container, you might explore just running them as separate Fly.io apps. The advantage to doing this, apart from the apps not fighting over the same CPUs and memory, is that you can scale separate apps independently, and put them in different sets of regions.
 
-Fly.io apps can talk to each other over a [private network](https://fly.io/docs/networking/private-networking/) that's always available. They can find each other under the `.internal` top-level domain (if your apps are `foo` and `bar`, they'll be in the DNS as `foo.internal` and `bar.internal`). Because the network connection is private and encrypted, you can generally just talk back and forth without extra authentication until you know you need it; in other words, you can keep things simple.
+Fly.io apps can talk to each other over a [private network](https://fly.io/docs/networking/private-networking/) that's always available. They can find each other under the `.internal` [top-level domain](https://fly.io/docs/networking/private-networking/#fly-io-internal-addresses) (if your apps are named `foo` and `bar`, and deployed in `cdg` region, they'll be in the DNS as `cdg.foo.internal` and `cdg.bar.internal`). Because the network connection is private and encrypted, you can generally just talk back and forth without extra authentication until you know you need it; in other words, you can keep things simple.
 
 ### Maybe you don't need multiple processes
 


### PR DESCRIPTION
### Summary of changes

This PR adds small change to the "Multiple processes" section in the docs. Since internal domains like `foo.internal` and `bar.internal` are missing the`<region>.` part, I updated the description with the correct addresses.

This would help users come up with the proper internal DNS addresses without having to read other doc pages

### Related Fly.io community and GitHub links
- Changes directly update this page: https://fly.io/docs/app-guides/multiple-processes/
- Documentation with correct addresses: https://fly.io/docs/networking/private-networking/