### PR TITLE
Correct `auto_stop`, `auto_start` field names in Machines docs

### DIFF
--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -1193,9 +1193,9 @@ Properties of the `config` object for Machine configuration. See [Machine proper
         - `versions`: [string, string] ([]) : TLS versions to allow (for instance, [“TLSv1.2”, “TLSv1.3”]).
       + `proxy_proto_options`: Configure the version of the PROXY protocol that your app accepts. Version 1 is the default.
         - `version`: A string to indicate that the TCP connection uses PROXY protocol version 2. The default when not set is version 1.
-  - `auto_start`: bool (false) - If true, Fly Proxy starts Machines when requests for this service arrive.
-  - `auto_stop`: bool (false) - If true, Fly Proxy stops Machines when this service goes idle.
-  - `min_machines_running`: int (nil) - When `auto_start` is true, the minimum number of Machines to keep running at all times in the primary region.
+  - `autostart`: bool (false) - If true, Fly Proxy starts Machines when requests for this service arrive.
+  - `autostop`: bool (false) - If true, Fly Proxy stops Machines when this service goes idle.
+  - `min_machines_running`: int (nil) - When `autostart` is true, the minimum number of Machines to keep running at all times in the primary region.
 
 ---
 

--- a/machines/flyctl/fly-machine-run.html.md
+++ b/machines/flyctl/fly-machine-run.html.md
@@ -226,11 +226,11 @@ fly machine run . --port 80/tcp:http \
 
 The `--autostart` and `--autostop` flags only work on Machines with Fly Proxy services configured. [Read more about Fly Proxy auto start and auto stop](/docs/apps/autostart-stop/#how-it-works).
 
-In a Machine service's configuration, `auto_stop` and `auto_start` settings are optional. 
+In a Machine service's configuration, `autostop` and `autostart` settings are optional.
 
-If the `--autostop` flag is absent in a `fly machine run` command, the Machine's [`config.services.auto_stop`](/docs/machines/api-machines-resource/#machine-config-object-properties) value doesn't get set, and the Fly Proxy does not shut the Machine down, even when there is no traffic to it.
+If the `--autostop` flag is absent in a `fly machine run` command, the Machine's [`config.services.autostop`](/docs/machines/api-machines-resource/#machine-config-object-properties) value doesn't get set, and the Fly Proxy does not shut the Machine down, even when there is no traffic to it.
 
-If the `--autostart` flag is absent in a `fly machine run` command, the Machine's [`config.services.auto_start`](/docs/machines/api-machines-resource/#machine-config-object-properties) value doesn't get set, and the Fly Proxy does not start it in response to requests.
+If the `--autostart` flag is absent in a `fly machine run` command, the Machine's [`config.services.autostart`](/docs/machines/api-machines-resource/#machine-config-object-properties) value doesn't get set, and the Fly Proxy does not start it in response to requests.
 
 The `--autostart` and `--autostop` flags set the value of `autostart` or `autostop` to `true` by default; you can explicitly set the value to `false`. For example, the following runs a new Machine that may be stopped by the Fly Proxy, but will never be restarted by it:
 


### PR DESCRIPTION
### Summary of changes
`auto_stop` -> `autostop`
`auto_start` -> `autostart`

### Notes
The Machines API docs might be incorrect. When creating and updating Machines using the field names `auto_stop`, `auto_start`, these settings don't seem to take. However, using `autostop` and `autostart` works!
