### PR TITLE
Machines docs: update landing pages, intros, links, and words

### DIFF
--- a/machines/api/index.html.md
+++ b/machines/api/index.html.md
@@ -17,7 +17,3 @@ The REST Machines API provides resources to provision and manage Fly Apps, Fly M
 * **[Volumes resource](/docs/machines/api/volumes-resource):** Create and manage persistent storage volumes for your Machines.
 
 * **[Machines API Spec](https://docs.machines.dev/+external):** OpenAPI specification.
-
-<figure>
-  <img src="/static/images/docs-machines-fast.webp" alt="fast-launching hot air balloons against a green sky">
-</figure>

--- a/machines/api/index.html.md
+++ b/machines/api/index.html.md
@@ -8,17 +8,15 @@ redirect_from: /docs/machines/working-with-machines/
 The REST Machines API provides resources to provision and manage Fly Apps, Fly Machines, and Fly Volumes.
 
 
-* **[Working with the Machines API](/docs/machines/api/working-with-machines-api)**
+* **[Working with the Machines API](/docs/machines/api/working-with-machines-api):** Get set up quickly to use the Machines API.
 
-* **[Apps resource](/docs/machines/api/apps-resource)**
+* **[Machines resource](/docs/machines/api/machines-resource):** The core of the Machines API. Use the Machines resource to fully control Machines at speed.
 
-* **[Machines resource](/docs/machines/api/machines-resource)**
+* **[Apps resource](/docs/machines/api/apps-resource):** Create and manage Fly Apps to group and administer your Machines.
 
-* **[Volumes resource](/docs/machines/api/volumes-resource)**
+* **[Volumes resource](/docs/machines/api/volumes-resource):** Create and manage persistent storage volumes for your Machines.
 
-API reference and OpenAPI specification:
-
-* **[Machines API Spec](https://docs.machines.dev/+external)**
+* **[Machines API Spec](https://docs.machines.dev/+external):** OpenAPI specification.
 
 <figure>
   <img src="/static/images/docs-machines-fast.webp" alt="fast-launching hot air balloons against a green sky">

--- a/machines/api/index.html.md
+++ b/machines/api/index.html.md
@@ -16,4 +16,4 @@ The REST Machines API provides resources to provision and manage Fly Apps, Fly M
 
 * **[Volumes resource](/docs/machines/api/volumes-resource):** Create and manage persistent storage volumes for your Machines.
 
-* **[Machines API Spec](https://docs.machines.dev/+external):** OpenAPI specification.
+* **[OpenAPI spec](https://docs.machines.dev/+external):** OpenAPI 3.0 specification for the Machines API.

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -4,34 +4,10 @@ layout: docs
 nav: machines
 ---
 
-Fly Machines are fast-launching VMs; they can be started and stopped at subsecond speeds. You control Machines with their simple REST API or with the flyctl `fly machine` commands. On the other hand, if you prefer easy app-wide configuration and containerized deployment for your app, then try [Fly Launch](/docs/reference/fly-launch/).
+Fly Machines are fast-launching VMs; they can be started and stopped at subsecond speeds. We give you control over every Machine's lifecycle, resources, count, and region placement with a simple REST API or flyctl commands.
 
-## Learn
+- [**An introduction to Fly Machines**:](/docs/machines/overview/) Learn about the lifecycle of Fly Machines and what you can do with them.
+- [**Machines API:**](/docs/machines/api/) A simple and fast REST API for full control over our fast-launching Machines.
+- **[Run a New Machine](/docs/machines/flyctl/fly-machine-run/) or [Update a Machine](/docs/machines/flyctl/fly-machine-update/) with flyctl:** Configure, build, and start new Machines with a single command or update some or all of a Machine's configuration.
 
-Understand how Machines work and other things you need to know when you have low-level control of powerful VMs on Fly.io.
-
-[Fly Machines overview](/docs/machines/overview)
-
-[Machine sizing](/docs/machines/guides-examples/machine-sizing/)
-
-[The Machine runtime environment](/docs/machines/runtime-environment/)
-
-## How-Tos
-
-Using Machines.
-
-[Run a new Machine](/docs/machines/run/)
-
-[Work with the Machines API](/docs/machines/working-with-machines)
-
-[Set a Machine restart policy](/docs/machines/guides-examples/machine-restart-policy/)
-
-[Run user code on Fly Machines](/docs/machines/guides-examples/functions-with-machines/)
-
-## Reference
-
-Commands and APIs for Machines.
-
-[Machines API Spec](https://docs.machines.dev/+external)
-
-[flyctl commands - `fly machine`](/docs/flyctl/machine/)
+On the other hand, try [Fly Launch](/docs/reference/fly-launch/) if you prefer easy app-wide configuration and containerized deployment for your app.

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -4,7 +4,7 @@ layout: docs
 nav: machines
 ---
 
-Fly Machines are the engine of the Fly.io platform: fast-launching VMs that can be started and stopped at subsecond speeds. Control them with their fast REST API or the flyctl CLI. Or use [Fly Launch](/docs/reference/fly-launch/) for opinionated app-wide configuration and deployment.
+Fly Machines are fast-launching VMs; they can be started and stopped at subsecond speeds. You control Machines with their simple REST API or with the flyctl `fly machine` commands. On the other hand, if you prefer easy app-wide configuration and containerized deployment for your app, then try [Fly Launch](/docs/reference/fly-launch/).
 
 ## Learn
 

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -6,7 +6,7 @@ nav: machines
 
 Fly Machines are fast-launching VMs; they can be started and stopped at subsecond speeds. We give you control over every Machine's lifecycle, resources, count, and region placement with a simple REST API or flyctl commands.
 
-- [**An introduction to Fly Machines**:](/docs/machines/overview/) Learn whether you need low-level Machine control. Then learn about the lifecycle of Fly Machines and what you can do with them.
+- [**Introduction to Fly Machines**:](/docs/machines/overview/) Learn whether you need low-level Machine control. Then learn about the lifecycle of Fly Machines and what you can do with them.
 - [**Machines API:**](/docs/machines/api/) A simple and fast REST API for full control over our fast-launching Machines.
 - **[Run a New Machine](/docs/machines/flyctl/fly-machine-run/) or [Update a Machine](/docs/machines/flyctl/fly-machine-update/) with flyctl:** Configure, build, and start new Machines with a single command or update some or all of a Machine's configuration.
 

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -6,8 +6,12 @@ nav: machines
 
 Fly Machines are fast-launching VMs; they can be started and stopped at subsecond speeds. We give you control over every Machine's lifecycle, resources, count, and region placement with a simple REST API or flyctl commands.
 
-- [**An introduction to Fly Machines**:](/docs/machines/overview/) Learn about the lifecycle of Fly Machines and what you can do with them.
+- [**An introduction to Fly Machines**:](/docs/machines/overview/) Learn whether you need low-level Machine control. Then learn about the lifecycle of Fly Machines and what you can do with them.
 - [**Machines API:**](/docs/machines/api/) A simple and fast REST API for full control over our fast-launching Machines.
 - **[Run a New Machine](/docs/machines/flyctl/fly-machine-run/) or [Update a Machine](/docs/machines/flyctl/fly-machine-update/) with flyctl:** Configure, build, and start new Machines with a single command or update some or all of a Machine's configuration.
 
 On the other hand, try [Fly Launch](/docs/reference/fly-launch/) if you prefer easy app-wide configuration and containerized deployment for your app.
+
+<figure>
+  <img src="/static/images/docs-machines-fast.webp" alt="fast-launching hot air balloons against a green sky">
+</figure>

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -20,12 +20,13 @@ out to more regions and more Machine counts. [Fly Launch](/docs/apps) does all t
 
 ## Concepts
 
-You control Machine states, resources, count, and placement.
+You control every Machine's lifecycle, resources, count, and region placement.
 
 ### Machines
 
-A Machine is the configuration and state for a single VM running on our platform. Every Machine will belong to a Fly App; Apps 
-can have more than one Machine. You can start a Machine right now, without configuring anything: 
+A Machine is the configuration and state for a single VM running on Fly.io.
+
+Every Machine will belong to a Fly App; Apps can have more than one Machine. You can start a Machine right now, without configuring anything: 
 
 ```cmd
 fly machine run --shell

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -53,13 +53,13 @@ The big Fly Machine trick is: starting up super fast; like, "in response to an H
 To get your head around that trick, start by understanding the lifecycle of a Fly Machine:
 
 1. You create a Fly Machine with a [Create Machine request](/docs/machines/api/machines-resource/#create-a-machine), or 
-   with `fly machine run`. The Machine is in `created` state while we reserve space for your Machine, and fetch your container from our global registry, and then build a root file system; this can take some time, maybe low double digit seconds.
+   with `fly machine run`. The Machine is in `created` state while we reserve space for your Machine, fetch your container from our global registry, and then build a root file system; this can take some time, maybe low double digit seconds.
    
 2. Once the Fly Machine exists, we boot it up for you right away. The Machine is in `started` state. It's running. You can talk to it. This happens fast! Everything's already assembled; we're just booting. Usually this takes _well under a second_. The same goes for starting a stopped Machine with a [Start Machine request](/docs/machines/api/machines-resource/#start-a-machine), or with `fly machine start`.
    
 3. You're done with the Fly Machine, so you stop it with a [Stop Machine request](/docs/machines/api/machines-resource/#stop-a-machine), or `fly machine stop`. The VM shuts down. The Machine is in `stopped` state. Its components are still assembled on our worker host, ready to start back up; if you want to do that, `GOTO 2`.
    
-4. You're tired of the Fly Machine, and want it to go away. Send a [Delete Machine request](/docs/machines/api/machines-resource/#delete-a-machine-permanently), or use `fly machine destroy`. We clear the resources we were holding for the Machine off our server. You can easily create and start a new Machine from the same image, but it'll be slower than stopping and starting an existing Machine.
+4. You're tired of the Fly Machine, and want it to go away permanently. Send a [Delete Machine request](/docs/machines/api/machines-resource/#delete-a-machine-permanently), or use `fly machine destroy`. We clear the resources we were holding for the Machine off our server. You can easily create and start a new Machine from the same image, but it'll be slower than stopping and starting an existing Machine.
 
 Learn more about [running a new Machine](/docs/machines/flyctl/fly-machine-run/) or [updating a Machine](/docs/machines/flyctl/fly-machine-update/) with flyctl commands.
 

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -7,7 +7,7 @@ redirect_from: /docs/reference/machines/
 
 Fly Machines are fast-launching VMs with a simple [REST API](/docs/machines/api/). They're [the compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. If you've launched an app on Fly.io, you're already using Fly Machines.
 
-We use the Machines API to build the orchestration for [Fly Launch](/docs/apps). You can use it however you'd like.
+We use the [Machines API](/docs/machines/api/) to build the orchestration for [Fly Launch](/docs/apps). You can use it however you'd like.
 
 ## Do I need to control Machines directly?
 

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -5,15 +5,13 @@ nav: machines
 redirect_from: /docs/reference/machines/
 ---
 
-Fly Machines are fast-launching VMs. They are:
+Fly Machines are fast-launching VMs with a simple [REST API](/docs/machines/api/). They're [the compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. If you've launched an app on Fly.io, you're already using Fly Machines.
 
-* [The compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. If you've launched an app on Fly.io, then you're already using Machines.
-
-* [Driven by a simple REST API](/docs/machines/api/) that you can use for precise control over Machines to deploy and build out applications on a larger scale.
+We use the Machines API to build the orchestration for [Fly Launch](/docs/apps). You can use it however you'd like.
 
 ## Do I need to control Machines directly?
 
-We give you low-level control over Fly Machines for when you need to be picky about how, where, and when to start VMs on Fly.io. We use the Machines API to build the orchestration for [Fly Launch](/docs/apps), and you can use it however you'd like. 
+We give you low-level control over Fly Machines for when you need to be picky about how, where, and when to start VMs on Fly.io.
 
 For most applications, most of the time, you don't need to be picky! You scale things up to more cores or more memory, and
 out to more regions and more Machine counts. [Fly Launch](/docs/apps) does all that for you with simple syntax and configuration.
@@ -24,7 +22,7 @@ You control every Machine's lifecycle, resources, count, and region placement.
 
 ### Machines
 
-A Machine is the configuration and state for a single VM running on Fly.io.
+You can look at a Machine as the configuration and state for a single VM running on Fly.io.
 
 Every Machine will belong to a Fly App; Apps can have more than one Machine. You can start a Machine right now, without configuring anything: 
 

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -18,13 +18,13 @@ out to more regions and more Machine counts. [Fly Launch](/docs/apps) does all t
 
 ## Concepts
 
-You control every Machine's lifecycle, resources, count, and region placement.
+You can create and destroy Machines directly, and you have control over every Machine's lifecycle, resources, and region placement.
 
 ### Machines
 
-You can look at a Machine as the configuration and state for a single VM running on Fly.io.
+A Machine is the configuration and state for a single VM running on Fly.io.
 
-Every Machine will belong to a Fly App; Apps can have more than one Machine. You can start a Machine right now, without configuring anything: 
+Every Machine will belong to a Fly App; Apps can have more than one Machine. You can start a Machine right now, without configuring anything:
 
 ```cmd
 fly machine run --shell

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -22,9 +22,9 @@ You can create and destroy Machines directly, and you have control over every Ma
 
 ### Machines
 
-A Machine is the configuration and state for a single VM running on Fly.io.
+A Machine is the configuration and state for a single VM running on Fly.io. Every Machine will belong to a Fly App; Apps can have more than one Machine. 
 
-Every Machine will belong to a Fly App; Apps can have more than one Machine. You can start a Machine right now, without configuring anything:
+You can start a Machine right now, without configuring anything:
 
 ```cmd
 fly machine run --shell
@@ -46,7 +46,8 @@ Go ahead and try it! When you `run` a Machine with `--shell`, we'll make a small
 
 ### Machine state
 
-The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast.
+The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast. Doing things like 
+that is why you'd use Fly Machines directly, rather than [letting flyctl run your deployment](/docs/apps/deploy/). 
 
 To get your head around that trick, start by understanding the lifecycle of a Fly Machine:
 

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -1,5 +1,5 @@
 ---
-title: "Fly Machines overview"
+title: "An introduction to Fly Machines"
 layout: docs
 nav: machines
 redirect_from: /docs/reference/machines/
@@ -7,22 +7,20 @@ redirect_from: /docs/reference/machines/
 
 Fly Machines are fast-launching VMs. They are:
 
-* [The compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. Once created, Machines can be started and stopped at subsecond speeds. 
+* [The compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. If you've launched an app on Fly.io, then you're already using Machines.
 
-* [A REST API](/docs/machines/api/) you can use for precise control over groups of Machines to deploy and scale out applications. 
+* [Driven by a simple REST API](/docs/machines/api/) that you can use for precise control over Machines to deploy and build out applications on a larger scale.
 
-<section class="warning icon">
-**This is a low-level interface**.
+## Do I need to control Machines directly?
 
-Use Fly Machines directly when you need to be picky about how, where, and when to start VMs on Fly.io. For most
-applications, most of the time, you don't need to be picky! You scale things up to more cores or more memory, and
-out to more regions and more VM counts. [Fly Launch](/docs/apps) does all that for you with simple syntax. 
+We give you low-level control over Fly Machines for when you need to be picky about how, where, and when to start VMs on Fly.io. We use the Machines API to build the orchestration for [Fly Launch](/docs/apps), and you can use it however you'd like. 
 
-🌶️ **But some applications get spicy.**🌶️ This is our spicy interface! We use it to build the orchestration
-for `fly launch`, but you can use it however you'd like. 
-</section>
+For most applications, most of the time, you don't need to be picky! You scale things up to more cores or more memory, and
+out to more regions and more Machine counts. [Fly Launch](/docs/apps) does all that for you with simple syntax and configuration.
 
 ## Concepts
+
+You control Machine states, resources, count, and placement.
 
 ### Machines
 
@@ -49,28 +47,20 @@ Go ahead and try it! When you `run` a Machine with `--shell`, we'll make a small
 
 ### Machine state
 
-The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast. Doing things like 
-that is why you'd use Fly Machines directly, rather than a [Fly App](https://fly.io/docs/apps/deploy/). 
+The big Fly Machine trick is: starting up super fast; like, "in response to an HTTP request from a user" fast.
 
 To get your head around that trick, start by understanding the lifecycle of a Fly Machine:
 
-1. You create a Fly Machine with a [Create Machine request](https://docs.machines.dev/#tag/machines/post/apps/{app_name}/machines), or 
-   with `fly machine create`. The Machine is in `created` state. This step can take some time: you're asking us to reserve space
-   for your Machine, and then fetch your container from our global registry, and build a root file system; low double digit seconds, maybe. 
+1. You create a Fly Machine with a [Create Machine request](/docs/machines/api/machines-resource/#create-a-machine), or 
+   with `fly machine run`. The Machine is in `created` state while we reserve space for your Machine, and fetch your container from our global registry, and then build a root file system; this can take some time, maybe low double digit seconds.
    
-2. Now that the Fly Machine exists, you can start it with a [Start Machine request](https://docs.machines.dev/#tag/machines/post/apps/{app_name}/machines/{machine_id}/start), or 
-   with `fly machine start`. We boot a VM. The Machine is in `started` state. It's running. You can talk to it. This happens fast! Everything's
-   already assembled; we're just booting. Usually this takes _well under a second_.
+2. Once the Fly Machine exists, we boot it up for you right away. The Machine is in `started` state. It's running. You can talk to it. This happens fast! Everything's already assembled; we're just booting. Usually this takes _well under a second_. The same goes for starting a stopped Machine with a [Start Machine request](/docs/machines/api/machines-resource/#start-a-machine), or with `fly machine start`.
    
-3. You're done with the Fly Machine, so you stop it with a [Stop Machine request](https://docs.machines.dev/#tag/machines/post/apps/{app_name}/machines/{machine_id}/stop), or
-  `fly machine stop`. The VM shuts down. The Machine is in `stopped` state. Its components are still assembled on our worker host, ready to start back up; if
-   you want to do that, `GOTO 2`. 
+3. You're done with the Fly Machine, so you stop it with a [Stop Machine request](/docs/machines/api/machines-resource/#stop-a-machine), or `fly machine stop`. The VM shuts down. The Machine is in `stopped` state. Its components are still assembled on our worker host, ready to start back up; if you want to do that, `GOTO 2`.
    
-4. You're tired of the Fly Machine, and want it to go away. Send a [Delete Machine request](https://docs.machines.dev/#tag/machines/delete/apps/{app_name}/machines/{machine_id}), or 
-   use `fly machine destroy`. We clear the resources we were holding for the Machine off our server. You can easily create and start
-   a new Machine from the same image, but it'll be slower than stopping and starting an existing Machine. 
+4. You're tired of the Fly Machine, and want it to go away. Send a [Delete Machine request](/docs/machines/api/machines-resource/#delete-a-machine-permanently), or use `fly machine destroy`. We clear the resources we were holding for the Machine off our server. You can easily create and start a new Machine from the same image, but it'll be slower than stopping and starting an existing Machine.
 
-Here's [more detail on using flyctl to manage individual Machines](/docs/machines/guides-examples/machines-app-using-flyctl/).
+Learn more about [running a new Machine](/docs/machines/flyctl/fly-machine-run/) or [updating a Machine](/docs/machines/flyctl/fly-machine-update/) with flyctl commands.
 
 ### Scaling Machines
 
@@ -79,8 +69,7 @@ Remember, the ordinary way to scale an application on Fly.io is to use [Fly Laun
 commands to scale instances out or up. Here, we're going to scale Machines directly, in a fiddly way.
 
 Whether or not you use `fly launch` to boot up a Fly App, every Machine belongs to an "App" (an "App" is ultimately just a named 
-collection of resources, configuration, and routing rules). But you don't have to use the `fly apps` commands to manage Machines;
-you can do it directly.
+collection of resources, configuration, and routing rules).
 </div>
 
 Scale a workload out horizontally with `fly machine clone`:
@@ -126,7 +115,7 @@ Machine 7811373c095228 updated successfully!
 
 Updating a Machine takes it down (like with `fly machine stop`), applies configuration changes, and brings it back up. If you're
 not changing the image, so we don't have to go fetch it from the global registry, this is fast, for the same reason `stop` and `start`
-are; we've already done the heavy lifting. 
+are; we've already done the heavy lifting.
 
 ### Placement
 

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -17,15 +17,15 @@
       path: "/docs/machines/",
       open: false,
       links: [
-        { text: "Fly Machines overview", path: "/docs/machines/overview/" },
+        { text: "Introduction to Fly Machines", path: "/docs/machines/overview/" },
+        { text: "Machines API", path: "/docs/machines/api/" },
         { text: "Run a new Machine", path: "/docs/machines/flyctl/fly-machine-run/" },
         { text: "Update a Machine", path: "/docs/machines/flyctl/fly-machine-update/" },
-        { text: "Machines API", path: "/docs/machines/api/" },
-        { text: "The Machine Runtime Environment", path: "/docs/machines/runtime-environment/" },
-        { text: "Run User Code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" },
         { text: "Machine Sizing", path: "/docs/machines/guides-examples/machine-sizing/" },
         { text: "Machine restart policy", path: "/docs/machines/guides-examples/machine-restart-policy/" },
-        { text: "Machine states", path: "/docs/machines/machine-states/" }
+        { text: "Machine states", path: "/docs/machines/machine-states/" },
+        { text: "Run User Code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" },
+        { text: "The Machine Runtime Environment", path: "/docs/machines/runtime-environment/" }
       ]
     },
     {

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -7,7 +7,7 @@
       path: "/docs/machines/",
       accordion: false,
       links: [
-        { text: "Fly Machines overview", path: "/docs/machines/overview/" }
+        { text: "Introduction to Fly Machines", path: "/docs/machines/overview/" }
       ]
     },
     {

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -11,14 +11,6 @@
       ]
     },
     {
-      title: "Machines and flyctl", 
-      open: true,
-      links: [
-        { text: "Run a new Machine", path: "/docs/machines/flyctl/fly-machine-run/" },
-        { text: "Update a Machine", path: "/docs/machines/flyctl/fly-machine-update/" }
-      ]
-    },
-    {
       title: "Machines API", 
       path: "/docs/machines/api/",
       open: true,
@@ -31,12 +23,20 @@
       ]
     },
     {
+      title: "Machines and flyctl", 
+      open: true,
+      links: [
+        { text: "Run a new Machine", path: "/docs/machines/flyctl/fly-machine-run/" },
+        { text: "Update a Machine", path: "/docs/machines/flyctl/fly-machine-update/" }
+      ]
+    },
+    {
       title: "Guides and Examples",
       open: true,
       links: [
-        { text: "Run user code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" },
+        { text: "Machine restart policy", path: "/docs/machines/guides-examples/machine-restart-policy/" },
         { text: "Machine sizing", path: "/docs/machines/guides-examples/machine-sizing/" },
-        { text: "Machine restart policy", path: "/docs/machines/guides-examples/machine-restart-policy/" }
+        { text: "Run user code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" }
       ]
     },
     {

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -19,7 +19,7 @@
         { text: "Apps", path: "/docs/machines/api/apps-resource/" },
         { text: "Machines", path: "/docs/machines/api/machines-resource/" },
         { text: "Volumes", path: "/docs/machines/api/volumes-resource/" },
-        { text: "Machines API Spec", path: "https://docs.machines.dev/#description/introduction+external" }
+        { text: "OpenAPI Specification", path: "https://docs.machines.dev/#description/introduction+external" }
       ]
     },
     {

--- a/volumes/index.html.markerb
+++ b/volumes/index.html.markerb
@@ -32,4 +32,4 @@ Commands and APIs for volumes.
 
 [flyctl commands - `fly volumes`](/docs/flyctl/volumes/)
 
-[Machines API - Volumes](https://docs.machines.dev/#tag/volumes)
+[Machines API - Volumes](/docs/machines/api/volumes-resource/)


### PR DESCRIPTION
### Summary of changes

- [Machines landing page](https://fly.io/docs/machines/): re-write the intro, cull the links down to 3 main ones, (move the image from API landing page to here). Preview: https://aa-docs-3.fly.dev/docs/machines/
- [Machines overview](https://fly.io/docs/machines/overview/): update content, change the warning into a section on "Do I need to control Machines?" (title TBD?), suggest changing the doc name to "Introduction to Machines" for friendliness and accuracy. Preview: https://aa-docs-3.fly.dev/docs/machines/overview/
- [Machines API landing page](https://fly.io/docs/machines/): Add descriptions to links. Preview: https://aa-docs-3.fly.dev/docs/machines/api/
- updated order and so on for main nav and Machines nav

### Preview

https://aa-docs-3.fly.dev/docs/machines/

### Related Fly.io community and GitHub links

### Notes

