### PR TITLE
fly.toml: Connections concurrency type opens a new conn per req

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -290,12 +290,14 @@ The `http_service` concurrency section configures how to measure load for an app
 
 * `type` specifies what metric is used to determine when to auto start or stop, or when a given Machine should receive more or less traffic (load balancing). The two supported values are `connections` and `requests`.
 
-**connections**: Load balance and scale based on the number of concurrent TCP connections. A new connection is established for each HTTP request. This is the default when unspecified. This is also the default when `fly.toml` is created with `fly launch`.  Consider the `requests` type for HTTP apps.
+**connections**: Load balance and scale based on the number of concurrent TCP connections. This is the default when unspecified. This is also the default when `fly.toml` is created with `fly launch`. A new connection is established for each HTTP request; consider the `requests` type for HTTP apps.
 
-**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, since it enables multiple requests to be sent over a single TCP connection.
+**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, because the Fly Proxy can pool and reuse connections for requests.
 
 * `hard_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that Machine.
 * `soft_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that Machine and only send it to that Machine if all other Machines are also at or above their `soft_limit`. This setting is also used to determine excess capacity for the [auto start and stop feature](/docs/apps/autostart-stop/).
+
+For more information about concurrency settings, see [Guidelines for concurrency settings](/docs/reference/concurrency/).
 
 ### `http_service.http_options.response.headers`
 
@@ -530,12 +532,14 @@ This section is a simple list of key/values, so the section is denoted with sing
 
 `type` specifies what metric is used to determine when a given Machine has reached a concurrency limit. The two supported values are `connections` and `requests`.
 
-**connections**: Load balance and scale based on the number of concurrent TCP connections. A new connection is established for each HTTP request. This is the default when unspecified. This is also the default when `fly.toml` is created with `fly launch`.  Consider the `requests` type for HTTP apps.
+**connections**: Load balance and scale based on the number of concurrent TCP connections. This is the default when unspecified. This is also the default when `fly.toml` is created with `fly launch`. A new connection is established for each HTTP request; consider the `requests` type for HTTP apps.
 
-**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, since it enables multiple requests to be sent over a single TCP connection.
+**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, because the Fly Proxy can pool and reuse connections for requests.
 
 * `hard_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that Machine.
 * `soft_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that Machine and only send it to that Machine if all other Machines are also at or above their `soft_limit`. This setting is also used to determine excess capacity for the [auto start and stop feature](/docs/apps/autostart-stop/).
+
+For more information about concurrency settings, see [Guidelines for concurrency settings](/docs/reference/concurrency/).
 
 ### `services.tcp_checks`
 

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -290,9 +290,9 @@ The `http_service` concurrency section configures how to measure load for an app
 
 * `type` specifies what metric is used to determine when to auto start or stop, or when a given Machine should receive more or less traffic (load balancing). The two supported values are `connections` and `requests`.
 
-**connections**: Load balance and scale based on the number of concurrent TCP connections. This is the default when unspecified. This is also the default when fly.toml is created with `fly launch`.
+**connections**: Load balance and scale based on the number of concurrent TCP connections. A new connection is established for each HTTP request. This is the default when unspecified. This is also the default when `fly.toml` is created with `fly launch`.  Consider the `requests` type for HTTP apps.
 
-**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, since multiple requests can be sent over a single TCP connection.
+**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, since it enables multiple requests to be sent over a single TCP connection.
 
 * `hard_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that Machine.
 * `soft_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that Machine and only send it to that Machine if all other Machines are also at or above their `soft_limit`. This setting is also used to determine excess capacity for the [auto start and stop feature](/docs/apps/autostart-stop/).
@@ -530,9 +530,9 @@ This section is a simple list of key/values, so the section is denoted with sing
 
 `type` specifies what metric is used to determine when a given Machine has reached a concurrency limit. The two supported values are `connections` and `requests`.
 
-**connections**: Load balance based on the number of concurrent TCP connections. This is the default when unspecified. This is also the default when fly.toml is created with `fly launch`.
+**connections**: Load balance and scale based on the number of concurrent TCP connections. A new connection is established for each HTTP request. This is the default when unspecified. This is also the default when `fly.toml` is created with `fly launch`.  Consider the `requests` type for HTTP apps.
 
-**requests**: Load balance based on the number of HTTP requests. This is recommended for web services, since multiple requests can be sent over a single TCP connection.
+**requests**: Load balance and scale based on the number of HTTP requests. This is recommended for web services, since it enables multiple requests to be sent over a single TCP connection.
 
 * `hard_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will stop sending new traffic to that Machine.
 * `soft_limit` : When a Fly Machine is at or over this number of concurrent connections or requests, the system will deprioritize sending new traffic to that Machine and only send it to that Machine if all other Machines are also at or above their `soft_limit`. This setting is also used to determine excess capacity for the [auto start and stop feature](/docs/apps/autostart-stop/).


### PR DESCRIPTION
### Summary of changes
Adds a note to the fly.toml reference doc that if you use the `connections` concurrency type, you get a new connection per http request.

### Notes
This is a minimum viable change -- the fly.toml reference is where this info will have the most impact, but isn't where the canonical info should ultimately live.