### PR TITLE
Hostname validation will fail without an IPv6 address

### DIFF
--- a/networking/custom-domains-with-fly.html.md
+++ b/networking/custom-domains-with-fly.html.md
@@ -31,13 +31,13 @@ There's a question to ask and answer. Do you want to start accepting traffic imm
 
 ### Accepting traffic immediately for the custom domain
 
-In this scenario, we want the custom domain to point to the `nginxproxy` server which will allow unencrypted IPv4 and IPv6 connections. Again, there are two ways to do this. Using DNS's CNAME capability or setting the A and AAAA records.
+In this scenario, we want the custom domain to point to the `nginxproxy` server which will allow unencrypted IPv4 and IPv6 connections. Again, there are two ways to do this. Using DNS CNAME capability or setting the A and AAAA records.
 
 #### Option I: CNAME records
 
 CNAME records in DNS act like a pointer. If we add a CNAME record to our custom domain that points to our proxy name `nginxproxy.fly.dev` then requests for the custom domain's IP address would return the proxy's address and clients would then lookup the IP addresses for the proxy.
 
-It's the quickest way to get set up, but there are catches. First, it is ever so slightly slower with that second look up. Second, it limits what you can do with the domain, especially if it's an "Apex domain" - CNAMEs are, according to DNS standards, meant to be the only record in a host's DNS records and so you can't add MX and other essential records to the DNS entry. If you aren't setting up an Apex domain, the CNAME is the quickest way to get going.
+It's the quickest way to get set up, but there are catches. First, it is ever so slightly slower with that second look up. Second, it limits what you can do with the domain, especially if it's an "Apex domain" - CNAME records are, according to DNS standards, meant to be the only record in a host's DNS records and so you can't add MX and other essential records to the DNS entry. If you aren't setting up an Apex domain, the CNAME is the quickest way to get going.
 
 #### Option II: A and AAAA records
 

--- a/networking/custom-domains-with-fly.html.md
+++ b/networking/custom-domains-with-fly.html.md
@@ -55,7 +55,7 @@ fly ips list
 Create an A record pointing to your v4 address, and an AAAA record pointing to your v6 address. You're then free to make this an Apex domain as needed.
 
 <div class="important">
-Our hostname validation will fail without a v6 address and we won't attempt to issue or renew a certificate. If your app does not have one, you can allocate one with `flyctl ips allocate-v6`. If you use a CNAME `_acme-challenge` for domain verification, you don't need to worry about this. However, it is still recommended to have both IPv4 and IPv6 addresses allocated if your app is serving traffic.
+**Important:** Our hostname validation will fail without an IPv6 address and we won't attempt to issue or renew a certificate. If your app does not have one, you can allocate one with `flyctl ips allocate-v6`. If you use a CNAME `_acme-challenge` for domain verification, you don't need to worry about this. However, it is still recommended to have both IPv4 and IPv6 addresses allocated if your app is serving traffic.
 </div>
 
 #### Adding the certificate

--- a/networking/custom-domains-with-fly.html.md
+++ b/networking/custom-domains-with-fly.html.md
@@ -54,6 +54,10 @@ fly ips list
 
 Create an A record pointing to your v4 address, and an AAAA record pointing to your v6 address. You're then free to make this an Apex domain as needed.
 
+<div class="important">
+`TLS-APLN-01` validation will fail without an IPv6 address. If your app does not have one, you can allocate one with `flyctl ips allocate-v6` or we wonlt be able to issue or renew certificates.
+</div>
+
 #### Adding the certificate
 
 Once these settings are in place, you can add the custom domain to the application's certificates. If we are configuring example.com, then we would simply run:

--- a/networking/custom-domains-with-fly.html.md
+++ b/networking/custom-domains-with-fly.html.md
@@ -55,7 +55,7 @@ fly ips list
 Create an A record pointing to your v4 address, and an AAAA record pointing to your v6 address. You're then free to make this an Apex domain as needed.
 
 <div class="important">
-`TLS-APLN-01` validation will fail without an IPv6 address. If your app does not have one, you can allocate one with `flyctl ips allocate-v6` or we wonlt be able to issue or renew certificates.
+Our hostname validation will fail without a v6 address and we won't attempt to issue or renew a certificate. If your app does not have one, you can allocate one with `flyctl ips allocate-v6`. If you use a CNAME `_acme-challenge` for domain verification, you don't need to worry about this. However, it is still recommended to have both IPv4 and IPv6 addresses allocated if your app is serving traffic.
 </div>
 
 #### Adding the certificate

--- a/networking/custom-domains-with-fly.html.md
+++ b/networking/custom-domains-with-fly.html.md
@@ -52,7 +52,7 @@ fly ips list
   v6     2a09:8280:1:659f:6cb7:4925:6bfd:90a3   2020-03-02T14:59:13Z
 ```
 
-Create an A record pointing to your v4 address, and an AAAA record pointing to your v6 address. You're then free to make this an Apex domain as needed.
+Create an A record pointing to your IPv4 address, and an AAAA record pointing to your IPv6 address. You're then free to make this an Apex domain as needed.
 
 <div class="important">
 **Important:** Our hostname validation will fail without an IPv6 address and we won't attempt to issue or renew a certificate. If your app does not have one, you can allocate one with `flyctl ips allocate-v6`. If you use a CNAME `_acme-challenge` for domain verification, you don't need to worry about this. However, it is still recommended to have both IPv4 and IPv6 addresses allocated if your app is serving traffic.


### PR DESCRIPTION
### Summary of changes

In my testing I came across this issue — we perform a hostname check and unless an IPv6 is associated with an app, we won't attempt to issue (or renew) a cert.

(These docs are in need of a bigger overhaul, I think)

### Preview

<img width="865" alt="Screenshot 2024-04-03 at 16 07 48" src="https://github.com/superfly/docs/assets/3727384/d628b490-7b4b-4182-b11e-29e808426f68">

