### PR TITLE
Add 'Volume placement' section to volume reference

### DIFF
--- a/reference/volumes.html.markerb
+++ b/reference/volumes.html.markerb
@@ -14,13 +14,17 @@ A Fly Volume is a slice of an NVMe drive on the physical server your Fly App run
 ## Volume considerations
 
 * **A volume belongs to one app**: Every Fly Volume belongs to a [Fly App](/docs/reference/apps/) and you can't share a volume between apps.
-* **A volume exists in one region**: A volume exists in only one region. Only a Machine running in the same region can access it.
+* **A volume exists on one server**: Each volume exists on one server in a single region. It is not network storage.
 * **A volume can attach to one Machine**: You need to run as many volumes as there are Machines. There's a one-to-one mapping between Machines and volumes. A Machine can only mount one volume at a time and a volume can be attached to only one Machine.
 * **Develop your app to handle replication**: Volumes are independent of one another; Fly.io does not automatically replicate data among the volumes on an app, so if you need the volumes to sync up, then your app has to make that happen.
 * **Create redundancy in your primary region**: If your app needs a volume to function, and the NVMe drive hosting your volume fails, then that instance of your app goes down. There's no way around that. You can run multiple Machines with volumes in your app's primary region to mitigate hardware failures.
 * **Create and store backups**: If you only have a single copy of your data on a single volume, and that drive fails, then the data is lost. Fly.io takes daily snapshots and retains them for 5 days, but the snapshots shouldn't be your primary backup method.
 
 Explore other options for data storage in [Databases & Storage](/docs/database-storage-guides/).
+
+## Volume attachment
+
+Fly Volumes and Fly Machines are meant to be paired together, but they are not necessarily always found in pairs. A Fly Volume can be created without a Fly Machine, or a Machine can be destroyed without destroying its volume. In these cases, the volume that’s left is called an "unattached" volume. A Fly Machine that does not require a volume will never attach itself to one. Fly Machines that do require volumes will *always* be attached to one, and any method of creating a new Fly Machine will always create a matching Fly Volume if there is not an unattached one available.
 
 ## Volume redundancy
 
@@ -30,11 +34,15 @@ Explore other options for data storage in [Databases & Storage](/docs/database-s
 
 In a few cases, you can run a single Machine with an attached volume. For example, if you're running an app with a standard SQLite database, or your app is in development and you're not yet worried about downtime.
 
-Many developers use volumes for databases, so if possible, each volume you create for your app is placed in a separate hardware zone by default. Note that having each volume in a separate hardware zone limits the number of volumes your app can have in a region. You can configure this setting with the `--require-unique-zone` option when you run [`fly volumes create`](/docs/flyctl/volumes-create/).
+## Volume placement
 
-## Volumes and regions
+You can create volumes at the same time you create Machines, or ahead of time. If you try to create new Machines through `flyctl scale count`, then `flyctl` will first check if you have any unattached volumes in the region you are creating new Machines in. If it finds unattached volumes, it will try to create the new Machines on the same servers. If it does not find any unattached volumes, then it will create new ones together with the Machines. You can also create unattached volumes through [`fly volumes create`](/docs/flyctl/volumes-create/).
 
-Volumes exist in a single [region](/docs/reference/regions/). For redundancy within a region, you can run multiple Machines with attached volumes by creating multiple volumes with the same name. For example, creating three volumes named `myapp_data` would let up to three instances of the app start up and run. Every volume has a unique ID to allow for multiple volumes with the same name. Remember that volumes don't automatically replicate data between them.
+Volumes exist on a single server in a single [region](/docs/reference/regions/). For redundancy within a region, you can run multiple Machines with attached volumes by creating multiple volumes with the same name. For example, if you had an app that required a volume named `myapp_data` and wanted to run three Machines in `bos`, then you would have to create at least three volumes named `myapp_data` in `bos`. Every volume has a unique ID to allow for multiple volumes with the same name. Remember that volumes don't automatically replicate data between them.
+
+To prevent a single server hardware failure from taking down multiple Fly Machines, by default each volume you create for your app is placed in a separate hardware zone (i.e. on a different server). Note that having each volume in a separate hardware zone limits the number of volumes your app can have in a region. If you would like more volumes in a region than there are distinct hardware zones, you can set `--require-unique-zone` to `false` when you run [`fly volumes create`](/docs/flyctl/volumes-create/).
+
+When using [`fly volumes create`](/docs/flyctl/volumes-create/), you can hint what type of compute load you expect to use the volume for by using the `--vm-XXX` flags. For example, if you were creating a volume you want to use with a L40S GPU Machine, you could set `--vm-gpu-kind=l40s`. This will ensure that your new volume is placed on GPU hardware.
 
 ## Volume encryption
 


### PR DESCRIPTION
This started out as an effort to detail the meaning of the `--vm-xxx` flags, and grew into two new sections of the Volumes reference, as well as a rewrite of a few more lines, to clarify expectations and methods of volume placement.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

