### PR TITLE
chore: replace docs on creating a swapfile with using swap_size_mb

### DIFF
--- a/rails/advanced-guides/phusion-passenger.html.md
+++ b/rails/advanced-guides/phusion-passenger.html.md
@@ -35,9 +35,6 @@ RUN rm /etc/nginx/sites-enabled/default
 ADD config/fly/rails.conf /etc/nginx/sites-enabled/rails.conf
 ADD config/fly/envvars.conf /etc/nginx/main.d/envvars.conf
 
-ADD config/fly/mkswap.sh /etc/my_init.d/95-mkswap.sh
-RUN chmod +x /etc/my_init.d/95-mkswap.sh
-
 ENV RAILS_LOG_TO_STDOUT true
 
 ARG BUNDLE_WITHOUT=development:test
@@ -121,22 +118,11 @@ env RAILS_LOG_TO_STDOUT;
 
 The above are commonly used variables, feel free to adjust as you see fit.
 
-## Making a swapfile
+## Enabling swap
 
-The Dockerfile provided by Phusion will create a swapfile when your application
-is run in a container.  Fly uses your Dockerfile to build an image, but then
-deploys that image to a VM, so while the commands necessary to build a
-swapfile are there, they aren't executed on your VM.  We can execute them by
-placing the following into `config/fly/mkswap.sh`:
-
-```
-#!/bin/sh
-fallocate -l 512M /swapfile
-chmod 0600 /swapfile
-mkswap /swapfile
-swapon /swapfile
-exit 0
-```
+See
+[`swap_size_mb`](https://fly.io/docs/reference/configuration/#swap_size_mb-option) for configuring
+for deploys.
 
 ## Deployment
 

--- a/rails/cookbooks/deploy.html.markerb
+++ b/rails/cookbooks/deploy.html.markerb
@@ -48,23 +48,11 @@ install yjit by default if rustc is available.
 
 ## Enabling swap
 
-While RAM is always faster, not everything that is loaded into RAM needs 
+While RAM is always faster, not everything that is loaded into RAM needs
 equal treatment.  Enabling swap can allow less frequently used regions
-of memory to be moved out to disk (which these days is SSD).  Running
-the following commands at runtime will enable swap:
-
-```
-fallocate -l 512M /swapfile
-chmod 0600 /swapfile
-mkswap /swapfile
-echo 10 > /proc/sys/vm/swappiness
-swapon /swapfile
-echo 1 > /proc/sys/vm/overcommit_memory
-```
-
-The way to incorporate these commands into your deploy is to change
-the CMD (or ENTRYPOINT) of your Dockerfile to run either a rake task 
-or shell script which runs these commands then starts your server.
+of memory to be moved out to disk (which these days is SSD). See
+[`swap_size_mb`](https://fly.io/docs/reference/configuration/#swap_size_mb-option) for configuring
+for deploys.
 
 ## Recap
 


### PR DESCRIPTION
### Summary of changes

With the rollout of [overlayfs](https://flyio.discourse.team/t/fresh-produce-a-new-way-to-rootfs/5386), trying to create a swapfile will no longer be a workable solution.

### Preview

### Related Fly.io community and GitHub links

https://community.fly.io/t/a-new-way-to-rootfs/19196

### Notes

