### PR TITLE
add ref docs on autoscaling

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -156,6 +156,7 @@
         { text: "Sentry Error Tracking", path: "/docs/reference/sentry/" },
         { text: "Fly Launch", path: "/docs/reference/fly-launch/" },
         { text: "Load Balancing", path: "/docs/reference/load-balancing/" },
+        { text: "Autoscaling", path: "/docs/reference/autoscaling/" },
         { text: "Machines", path: "/docs/machines/overview/" },
         { text: "Monorepo Apps", path: "/docs/reference/monorepo/" },
         { text: "Multiple Processes in Apps", path: "/docs/app-guides/multiple-processes/" },

--- a/reference/autoscaling.html.md
+++ b/reference/autoscaling.html.md
@@ -18,7 +18,8 @@ For a comprehensive overview of how it works, see the [documentation](https://fl
 
 ## Metrics-based autoscaling
 
-This feature is supported through [Fly Autoscaler](https://github.com/superfly/fly-autoscaler) which you deploy as an app into your organisation.
-It polls metrics from a Prometheus instance and computes the number of machines needed based on those metrics. The autoscaler will create and
-delete machines as configured. To learn how to deploy and configure it, see the [documentation](https://github.com/superfly/fly-autoscaler). 
+Autoscales your application based on metrics such as CPU and memory. This uses [Fly Autoscaler](https://github.com/superfly/fly-autoscaler)
+which you deploy as an app into your organisation. It polls metrics from a Prometheus instance and computes the number of machines needed
+based on those metrics. The autoscaler will create and delete machines as configured. To learn how to deploy and configure it, see
+the [documentation](https://github.com/superfly/fly-autoscaler). 
 

--- a/reference/autoscaling.html.md
+++ b/reference/autoscaling.html.md
@@ -1,0 +1,24 @@
+---
+title: Autoscaling
+layout: docs
+sitemap: false
+nav: firecracker
+---
+
+Autoscaling is used to increase the number of Fly Machines based on demand. There are two forms of autoscaling supported:
+
+1. Pre-allocated Machine autoscaling
+2. Metrics-based autoscaling
+
+## Pre-allocated Machine autoscaling
+
+This relies on the Fly Proxy feature, [auto start and stop machines](https://fly.io/docs/apps/autostart-stop/). The proxy starts and stops
+existing Machines based on demand, machines are never created or deleted. The responsibility is on you to create as many machines as needed.
+For a comprehensive overview of how it works, see the [documentation](https://fly.io/docs/apps/autostart-stop/).
+
+## Metrics-based autoscaling
+
+This feature is supported through [Fly Autoscaler](https://github.com/superfly/fly-autoscaler) which you deploy as an app into your organisation.
+It polls metrics from a Prometheus instance and computes the number of machines needed based on those metrics. The autoscaler will create and
+delete machines as configured. To learn how to deploy and configure it, see the [documentation](https://github.com/superfly/fly-autoscaler). 
+


### PR DESCRIPTION
### Summary of changes

Adds reference documentation on autoscaling capabilities on our platform

### Preview

### Related Fly.io community and GitHub links

### Notes

I'm not sure how in depth the reference should be. Both link out to the respective features and documentation, just providing a short overview of the features. Also, the name "pre-allocated machine autoscaling" sucks but i'm not sure how else to describe it. Open to ideas!