### PR TITLE
Fill in details for new Nvidia A10 cards

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -77,6 +77,7 @@ Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (se
 
 On-demand GPU pricing:
 
+* A10: $1.50/hr per GPU
 * L40S: $2.50/hr per GPU
 * A100 40G PCIe: $2.50/hr per GPU
 * A100 80G SXM: $3.50/hr per GPU

--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -46,6 +46,7 @@ primary_region = "ord"  # If you change this, ensure it's to a region that offer
 Currently GPUs are available in the following regions:
 
 - `l40s`: `ord`
+- `a10`: `ord`
 - `a100-40gb`: `ord`
 - `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
 

--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -45,8 +45,8 @@ primary_region = "ord"  # If you change this, ensure it's to a region that offer
 
 Currently GPUs are available in the following regions:
 
-- `l40s`: `ord`
 - `a10`: `ord`
+- `l40s`: `ord`
 - `a100-40gb`: `ord`
 - `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
 

--- a/gpus/gpu-quickstart.html.markerb
+++ b/gpus/gpu-quickstart.html.markerb
@@ -17,11 +17,11 @@ nav: firecracker
 1. From flyctl, create an app using either `fly launch` or `fly apps create`.
 
     <div class="note icon">
-    **Note**: GPUs are not available in all regions. There are these GPU types available: Nvidia L40S, A10, A100-PCIe-40GB, and A100-SXM4-80GB.
+    **Note**: GPUs are not available in all regions. There are these GPU types available: Nvidia A10, L40S, A100-PCIe-40GB, and A100-SXM4-80GB.
     
     <br>Currently GPUs are available in the following regions:
-    - `l40s`: `ord`
     - `a10`: `ord`
+    - `l40s`: `ord`
     - `a100-40gb`: `ord`
     - `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
     </div>
@@ -45,7 +45,7 @@ nav: firecracker
 
     <div class="note icon">
     **Notes**:
-    - Make sure `vm.size` is set in `fly.toml`, valid values are `a100-40gb`, `a100-80gb`, `a10` and `l40s`.
+    - Make sure `vm.size` is set in `fly.toml`, valid values are `a10`, `l40s`, `a100-40gb` and `a100-80gb`.
     - Make sure to include a `[[mounts]]` section in `fly.toml`.
     - The volume gets created automatically by `fly deploy`.
     - Use the volume to store the models and large files that can't be shipped as a docker image.

--- a/gpus/gpu-quickstart.html.markerb
+++ b/gpus/gpu-quickstart.html.markerb
@@ -17,10 +17,11 @@ nav: firecracker
 1. From flyctl, create an app using either `fly launch` or `fly apps create`.
 
     <div class="note icon">
-    **Note**: GPUs are not available in all regions. There are three GPU types available: Nvidia L40S, A100-PCIe-40GB, and A100-SXM4-80GB.
+    **Note**: GPUs are not available in all regions. There are these GPU types available: Nvidia L40S, A10, A100-PCIe-40GB, and A100-SXM4-80GB.
     
     <br>Currently GPUs are available in the following regions:
     - `l40s`: `ord`
+    - `a10`: `ord`
     - `a100-40gb`: `ord`
     - `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`
     </div>
@@ -44,7 +45,7 @@ nav: firecracker
 
     <div class="note icon">
     **Notes**:
-    - Make sure `vm.size` is set in `fly.toml`, valid values are `a100-40gb`, `a100-80gb` and `l40s`.
+    - Make sure `vm.size` is set in `fly.toml`, valid values are `a100-40gb`, `a100-80gb`, `a10` and `l40s`.
     - Make sure to include a `[[mounts]]` section in `fly.toml`.
     - The volume gets created automatically by `fly deploy`.
     - Use the volume to store the models and large files that can't be shipped as a docker image.

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -15,7 +15,7 @@ A100 units are all about the tensor cores, and are positioned for inference, mod
 
 The L40S cards are all-rounders; they've got tensor cores, RT cores, and NVENC/NVDEC, and have 48GB of GPU RAM. Choose the L40S to accelerate graphics or video workloads, as well as for inference. ([L40S datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413+external))
 
-A10 cards are ... ([A10 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a10/pdf/a10-datasheet.pdf))
+A10 cards are all-arounders with less GPU RAM. They've got tensor cores, shader cores, NVENC/NVDEC, and can run Llama 3 8B at float16 without breaking the bank. Choose the A10 when you don't need more than 8 billion parameters. This works great for smaller large language models, Stable Diffusion, and other such workflows. ([A10 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a10/pdf/a10-datasheet.pdf))
 
 Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to rendering, encoding/decoding, inference, and a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
 

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -9,13 +9,14 @@ Fly.io has GPUs! If you have workloads that would benefit from GPU acceleration,
 
 ## What can I use Fly GPUs for?
 
-Four models of GPU are available: NVIDIA A100 40G PCIe, A100 80G SXM, A10 and L40S.
+Four models of GPU are available: A10, L40S, NVIDIA A100 40G PCIe and A100 80G SXM.
 
 A100 units are all about the tensor cores, and are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory. ([A100 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf+external))
 
-The L40S cards are all-rounders; they've got tensor cores, RT cores, and NVENC/NVDEC, and have 48GB of GPU RAM. Choose the L40S to accelerate graphics or video workloads, as well as for inference. ([L40S datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413+external))
+L40S cards are all-rounders; they've got tensor cores, RT cores, and NVENC/NVDEC, and have 48GB of GPU RAM. Choose the L40S to accelerate graphics or video workloads, as well as for inference. ([L40S datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413+external))
 
 A10 cards are all-arounders with less GPU RAM. They've got tensor cores, shader cores, NVENC/NVDEC, and can run Llama 3 8B at float16 without breaking the bank. Choose the A10 when you don't need more than 8 billion parameters. This works great for smaller large language models, Stable Diffusion, and other such workflows. ([A10 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a10/pdf/a10-datasheet.pdf))
+
 
 Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to rendering, encoding/decoding, inference, and a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
 
@@ -25,6 +26,7 @@ Go to the [GPU Quickstart](https://fly.io/docs/gpus/gpu-quickstart/) to get off 
 
 Currently GPUs are available in the following regions:
 
+- `a10`: `ord`
 - `l40s`: `ord`
 - `a100-40gb`: `ord`
 - `a100-80gb`: `ams`, `iad`, `mia`, `sjc`, `syd`

--- a/gpus/index.html.md
+++ b/gpus/index.html.md
@@ -9,11 +9,13 @@ Fly.io has GPUs! If you have workloads that would benefit from GPU acceleration,
 
 ## What can I use Fly GPUs for?
 
-Three models of GPU are available: NVIDIA A100 40G PCIe, A100 80G SXM, and L40S.
+Four models of GPU are available: NVIDIA A100 40G PCIe, A100 80G SXM, A10 and L40S.
 
 A100 units are all about the tensor cores, and are positioned for inference, model training, and intensive high-precision computation tasks like scientific simulations. As their names suggest, they have 40GB and 80GB of GPU memory. ([A100 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-nvidia-us-2188504-web.pdf+external))
 
 The L40S cards are all-rounders; they've got tensor cores, RT cores, and NVENC/NVDEC, and have 48GB of GPU RAM. Choose the L40S to accelerate graphics or video workloads, as well as for inference. ([L40S datasheet](https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413+external))
+
+A10 cards are ... ([A10 datasheet](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a10/pdf/a10-datasheet.pdf))
 
 Right now each Fly GPU Machine uses a single full GPU. A single GPU is well suited to rendering, encoding/decoding, inference, and a smidgen of fine tuning. Training large models from scratch requires much, much beefier resources.
 

--- a/kubernetes/using-gpus.html.markerb
+++ b/kubernetes/using-gpus.html.markerb
@@ -14,7 +14,7 @@ GPUs are available on Fly Kubernetes. Information about our GPUs can be found in
 GPUs are consumed by requesting a GPU resource, similarly to requesting `cpu` or `memory`. There is a custom resource `gpu.fly.io/<gpu type>` that is used to request
 GPUs. Note that:
 
-* The available GPU types are: `a100-40gb`, `a100-80gb`, `a10` and `l40s`. Check the [documentation](https://fly.io/docs/gpus/#regions-with-gpus) for which regions they are available in.
+* The available GPU types are: `a10`, `l40s`, `a100-pcie-40gb` and `a100-sxm4-80gb`. Check the [documentation](https://fly.io/docs/gpus/#regions-with-gpus) for which regions they are available in.
 * Pods are deployed in the same region as your cluster. You can place your Pod in a particular region by adding a `fly.io/region: <region>` annotation to your Pod's metadata.
 * GPU resource requests should only specify the `limits` section.
 * You can specify CPU and memory resources alongside GPU resources. The minimum number of cores supported is 2 and the minimum amount of memory is 4096 MiB. The VMs

--- a/kubernetes/using-gpus.html.markerb
+++ b/kubernetes/using-gpus.html.markerb
@@ -14,7 +14,7 @@ GPUs are available on Fly Kubernetes. Information about our GPUs can be found in
 GPUs are consumed by requesting a GPU resource, similarly to requesting `cpu` or `memory`. There is a custom resource `gpu.fly.io/<gpu type>` that is used to request
 GPUs. Note that:
 
-* The available GPU types are: `a100-40gb`, `a100-80gb` and `l40s`. Check the [documentation](https://fly.io/docs/gpus/#regions-with-gpus) for which regions they are available in.
+* The available GPU types are: `a100-40gb`, `a100-80gb`, `a10` and `l40s`. Check the [documentation](https://fly.io/docs/gpus/#regions-with-gpus) for which regions they are available in.
 * Pods are deployed in the same region as your cluster. You can place your Pod in a particular region by adding a `fly.io/region: <region>` annotation to your Pod's metadata.
 * GPU resource requests should only specify the `limits` section.
 * You can specify CPU and memory resources alongside GPU resources. The minimum number of cores supported is 2 and the minimum amount of memory is 4096 MiB. The VMs

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -727,7 +727,7 @@ Setting this value requires also setting `gpu_kind`.
 
 ### `gpu_kind`
 
-The kind of GPU to request. Valid values are `a100-pcie-40gb`, `a100-sxm4-80gb` and `l40s`.
+The kind of GPU to request. Valid values are `a100-pcie-40gb`, `a100-sxm4-80gb`, `a10` and `l40s`.
 
 Setting this value assumes `gpus = 1` if not present.
 

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -727,7 +727,7 @@ Setting this value requires also setting `gpu_kind`.
 
 ### `gpu_kind`
 
-The kind of GPU to request. Valid values are `a100-pcie-40gb`, `a100-sxm4-80gb`, `a10` and `l40s`.
+The kind of GPU to request. Valid values are `a10`, `l40s`, `a100-pcie-40gb` and `a100-sxm4-80gb`.
 
 Setting this value assumes `gpus = 1` if not present.
 


### PR DESCRIPTION
### Summary of changes

Extend GPU documentation to include references for new Nvidia A10 cards

### Preview

### Related Fly.io community and GitHub links

https://github.com/superfly/fly-go/pull/45

### Notes

- [x] TODO: Fill in the blanks for what A10 are good for in gpus/index.html 