### PR TITLE
Update custom-domains-with-fly.html.md

### DIFF
--- a/networking/custom-domains-with-fly.html.md
+++ b/networking/custom-domains-with-fly.html.md
@@ -63,13 +63,13 @@ Create an A record pointing to your IPv4 address, and an AAAA record pointing to
 Once these settings are in place, you can add the custom domain to the application's certificates. If we are configuring example.com, then we would simply run:
 
 ```cmd
-fly certs create example.com
+fly certs add example.com
 ```
 
 If you need a wildcard domain, remember to place quotes around the hostname to avoid shell expansion:
 
 ```cmd
-fly certs create "*.example.com"
+fly certs add "*.example.com"
 ```
 
 This will kick off the process of validating your domain and generating certificates. You can check on the progress if you run:
@@ -100,13 +100,13 @@ This process allows certificates to be issued before the domain is live and acce
 The process starts with adding the certificate to the application like so:
 
 ```cmd
-fly certs create example.com
+fly certs add example.com
 ```
 
 Again, if you are creating a wildcard domain, remember to place quotes around the hostname to avoid shell expansion:
 
 ```cmd
-fly certs create "*.example.com"
+fly certs add "*.example.com"
 ```
 
 Now we have created the certificate, we need to ask for the CNAME entry that has to be set up. For this, we run `fly certs show`:
@@ -207,7 +207,7 @@ This lists every host associated with the application. Each host may have up to 
 
 ### Creating a certificate for an application
 
-**With flyctl**: `fly certs create <hostname>`
+**With flyctl**: `fly certs add <hostname>`
 
 **With GraphQL**: The example is [addcert.js](https://github.com/fly-apps/hostnamesapi/blob/master/getcerts.js). This request takes the application id and hostname as parameters.
 


### PR DESCRIPTION
### Summary of changes

As `fly certs --help` shows there is no more `fly certs create` command. Based on the commands that are there, I assume it was replaces with `fly certs add`, so I suppose this particular documentation page is out of date, hence here is the fix

the output of `fly certs --help`:
```cmd
Manages the certificates associated with a deployed application. Certificates are created by associating a
hostname/domain with the application. When Fly is then able to validate that hostname/domain, the platform gets
certificates issued for the hostname/domain by Let's Encrypt.

Usage:
  fly certs [command]

Available Commands:
  add         Add a certificate for an app.
  check       Checks DNS configuration
  list        List certificates for an app.
  remove      Removes a certificate from an app
  show        Shows certificate information

Flags:
  -h, --help   help for certs

Global Flags:
  -t, --access-token string   Fly API Access Token
      --debug                 Print additional logs and traces
      --verbose               Verbose output

Use "fly certs [command] --help" for more information about a command.

```

### Preview

### Related Fly.io community and GitHub links

### Notes

