### PR TITLE
Fix typos in documentation

### DIFF
--- a/elixir/the-basics/clustering.html.md
+++ b/elixir/the-basics/clustering.html.md
@@ -55,7 +55,7 @@ The Phoenix library [dns_cluster](https://github.com/phoenixframework/dns_cluste
 
 The `dns_cluster` library lets you easily setup Erlang Clustering using DNS, and Fly.io has built in DNS support!
 
-After installing `dns_cluser`, add it to the application like this:
+After installing `dns_cluster`, add it to the application like this:
 
 ```elixir
 defmodule HelloElixir.Application do

--- a/postgres/connecting/app-connection-examples.html.markerb
+++ b/postgres/connecting/app-connection-examples.html.markerb
@@ -346,7 +346,7 @@ let sequelize = new Sequelize(process.env.DATABASE_URL);
 [Fly docs: How to add Read Replica database with flyctl](https://fly.io/docs/postgres/advanced-guides/high-availability-and-global-replication/)
 
 
-Set the Sequelize consturctor in `model/index.js` to conditionally connect to the primary/read-replica database depending on the `primary region` value set in `fly.toml`.
+Set the Sequelize constructor in `model/index.js` to conditionally connect to the primary/read-replica database depending on the `primary region` value set in `fly.toml`.
 ```javascript
 let sequelize;
 if (config.use_env_variable) {

--- a/postgres/managing/upgrades.html.markerb
+++ b/postgres/managing/upgrades.html.markerb
@@ -20,7 +20,7 @@ And upgrade with:
 fly image update -a <postgres-app-name>
 ```
 
-The update only works if the major Postgres version in your existing Postgres app matches that in the newest Postgress app release, for example `postgres-flex:15.2` to `postgres-flex:15.3`.
+The update only works if the major Postgres version in your existing Postgres app matches that in the newest Postgres app release, for example `postgres-flex:15.2` to `postgres-flex:15.3`.
 
 Upgrading Postgres across major versions is more complicated, and right now the way to do this is to provision a new cluster and restore a backup of your database data into it.
 

--- a/rails/getting-started/existing.html.md
+++ b/rails/getting-started/existing.html.md
@@ -105,7 +105,7 @@ fly console
 ```
 
 If you are running with sqlite3 or a volume, you will need to ssh into an existing machine.  You may need to first make sure that you have enough
-[memory](../dockerfiles/#out-of-memory) to accomodate the additional session.
+[memory](../dockerfiles/#out-of-memory) to accommodate the additional session.
 
 ```cmd
 fly ssh console --pty -C "/rails/bin/rails console"

--- a/reference/error-codes.html.md
+++ b/reference/error-codes.html.md
@@ -207,7 +207,7 @@ This category of errors refers to internal Fly.io errors happening only on edge 
 
 #### PE01: Replay source app not found
 
-An internal error occured while using `fly-replay` related to the source app name.
+An internal error occurred while using `fly-replay` related to the source app name.
 
 #### PE02: Replay source organization not found
 

--- a/reference/sentry.html.md
+++ b/reference/sentry.html.md
@@ -5,7 +5,7 @@ sitemap: false
 nav: firecracker
 ---
 
-[Sentry](https://sentry.io) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our parternships with Sentry, each of your Fly organizations can claim a year's worth of [Team Plan](https://sentry.io/pricing) credits.
+[Sentry](https://sentry.io) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our partnerships with Sentry, each of your Fly organizations can claim a year's worth of [Team Plan](https://sentry.io/pricing) credits.
 
 To configure your application to use Sentry, run this command from your Fly.io application directory.
 


### PR DESCRIPTION
### Summary of changes
Fix typos in documentation

### Preview

### Related Fly.io community and GitHub links

### Notes
- change `dns_cluser` to `dns_cluster` 
- change `consturctor` to `constructor`
- change `Postgress` to `Postgres`
- change `accomodate` to `accommodate`
- change `occured` to `occurred`
- change `parternships` to `partnerships`

