### PR TITLE
Remove experimental feature note

### DIFF
--- a/reference/deploy-tokens.html.md
+++ b/reference/deploy-tokens.html.md
@@ -5,10 +5,6 @@ sitemap: false
 nav: firecracker
 ---
 
-<div class="border border-violet-600 bg-violet-50 rounded-l p-4 my-4 text-base text-navy">
-Deploy tokens are an experimental feature. They may be less reliable than traditional API tokens. Use them with caution and visit our <a href="https://community.fly.io">community forum</a> for help.
-</div>
-
 Whether you're [deploying your app with GitHub Actions](/docs/app-guides/continuous-deployment-with-github-actions/) or running your own CD service, it's best to avoid configuring deployment infrastructure with all-powerful tokens. Deploy tokens can be used with `flyctl` to manage a single application and its resources.
 
 To get started, generate a deploy token on the Tokens tab of your app dashboard. Alternatively, run `flyctl tokens create deploy` to generate an app deploy token from the command line. Instruct `flyctl` to use your new token by setting it in the `FLY_API_TOKEN` environment variable.


### PR DESCRIPTION
### Summary of changes

remove the note about deploy tokens being experimental; we're clearly beyond those early days

### Preview

### Related Fly.io community and GitHub links

### Notes

