### PR TITLE
Initial page for setting Vite Secrets for Laravel apps 

### DIFF
--- a/laravel/advanced-guides/vite-secrets.html.md
+++ b/laravel/advanced-guides/vite-secrets.html.md
@@ -1,0 +1,69 @@
+---
+title: "Setting Vite Environment Variables"
+layout: framework_docs
+objective: How to set up your Dockerfile to build assets that require vite environment variable values.
+order: 6
+---
+
+Vite makes use of the [dotenv module](https://vitejs.dev/guide/env-and-mode#env-files) to load environment variables during asset bundling. Do you know what this means?
+
+It means it reads environment variables from .env files. Coincidentally, we don't upload .env values in your Fly Machines.
+
+Sorry, not sorry! Of course, given you have a Laravel application using vite, using important-secret-env variables, how do you set that up at Fly.io?
+
+The best way to explain things is to set things up with an example. Let's say, we have this Laravel Echo setup for our application:
+
+```javascript
+/* resources/js/echo.js */
+import Echo from 'laravel-echo';
+ 
+import Pusher from 'pusher-js';
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_PUSHER_APP_KEY,
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER,
+    forceTLS: true
+});
+```
+Notice it makes use of two environment variables, `VITE_PUSHER_APP_KEY` and `VITE_PUSHER_APP_CLUSTER` imported from `meta.env`.
+
+Again, Vite, reads its environment variables from the proper .env file, which for Laravel apps, we don't include when deploying at Fly.io. Because of this, those environment variables would be returned as `undefined` in your Laravel app deployed at Fly.io.
+
+A common error you'll probably see from your console because of this is: 
+```error
+You must pass your app key when you instantiate Pusher.
+```
+
+## Solution: Build Secrets + Dockerfile Setup
+Now, don't fear. This page tackles exactly how to fix this issue.
+
+All we actually need to do is ask our Dockerfile to create a `.env.production` file on the go using build secrets we pass during `flyctl deploy`.
+
+So, in the Dockerfile of your Laravel application, preferably under the stage for building your assets add the env variables you need by extracting them from the build-secrets you set:
+
+```Dockerfile
+# Mount secrets, and create a temporary .env.production which is needed when building the assets for vite
+# Please RUN this before building your assets for vite!
+RUN --mount=type=secret,id=VITE_APP_NAME \
+    --mount=type=secret,id=VITE_PUSHER_APP_SECRET \
+    --mount=type=secret,id=VITE_PUSHER_APP_KEY \
+    --mount=type=secret,id=VITE_PUSHER_APP_CLUSTER \
+    echo "VITE_APP_NAME=$(cat /run/secrets/VITE_APP_NAME)" >> .env.production && \ 
+    echo "VITE_PUSHER_APP_KEY=$(cat /run/secrets/VITE_PUSHER_APP_KEY)" >> .env.production && \
+    echo "VITE_PUSHER_APP_SECRET=$(cat /run/secrets/VITE_PUSHER_APP_SECRET)" >> .env.production && \
+    echo "VITE_PUSHER_APP_CLUSTER=$(cat /run/secrets/VITE_PUSHER_APP_CLUSTER)" >> .env.production 
+```
+
+Finally make sure that you include these build secrets when deploying your app with `fly deploy`:
+
+```
+fly deploy \
+    --build-secret VITE_APP_NAME="Laravel" \
+    --build-secret VITE_PUSHER_APP_KEY="my-key" \
+    --build-secret VITE_PUSHER_APP_SECRET="my-secret" \
+    --build-secret VITE_PUSHER_APP_CLUSTER="my-cluster" 
+```
+
+And that's it! You're assets should now be bundled with your environment variable values!


### PR DESCRIPTION
### Summary of changes
Create a page in the Laravel section of Fly.io docs to include a page that explains the steps needed in setting Vite environment variable!

### Preview
-none please

### Related Fly.io community and GitHub links
https://community.fly.io/t/how-to-setup-websocket-with-pusher-and-laravel-echo-on-deployment/19767

### Notes
.env files are not included during deployment of Laravel apps in Fly.io. But since Vite reads environment variables from .env files, we need to create a temporary .env.production file in the Dockerfile's asset bundling stage using build secrets during running of `fly deploy`.  This way, an appropriate .env file is present before building the assets and allow reading of the env variables.


This answers the issue raised by a [community member here!](https://community.fly.io/t/how-to-setup-websocket-with-pusher-and-laravel-echo-on-deployment/19767)