### PR TITLE
Fix broken link: Update position.html.markerb

### DIFF
--- a/litefs/position.html.markerb
+++ b/litefs/position.html.markerb
@@ -23,7 +23,7 @@ The TXID is represented a 16-character hex-encoded `uint64`. The checksum is
 encoded as a 16-character hex-encoded `uint64`. These are concatenated using
 a slash and a newline is appended at the end.
 
-You can also use the [LiteFS event stream](events) to receive replication
+You can also use the [LiteFS event stream](../events) to receive replication
 position updates in real time.
 
 


### PR DESCRIPTION
Fix link to https://fly.io/docs/litefs/events/

Otherwise https://fly.io/docs/litefs/position/ has a broken link in it.
