### PR TITLE
Extend Next.js guide with Supabase Postgres

### DIFF
--- a/js/frameworks/nextjs.html.markerb
+++ b/js/frameworks/nextjs.html.markerb
@@ -191,20 +191,18 @@ const supabaseUrl = process.env.SUPABASE_URL ?? ''
 const supabaseKey = process.env.SUPABASE_ANON_KEY ?? ''
 
 export default async function Page() {
-    const supabase = createClient(supabaseUrl, supabaseKey)
-    const { data: todos } = await supabase.from('todos').select()
+  const supabase = createClient(supabaseUrl, supabaseKey)
+  const { data: todos } = await supabase.from('todos').select()
 
-    return (
-        <main className="flex min-h-screen flex-col items-center justify-between p-24">
-                <ul>
-                    {todos?.map((todo) => (
-                        <li key={todo.id} className="flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-                            {todo.title}
-                        </li>
-                    ))}
-                </ul>
-        </main>
-    )
+  return (
+    <ul>
+      {todos?.map((todo) => (
+        <li key={todo.id}>
+          {todo.title}
+        </li>
+      ))}
+    </ul>
+  )
 }
 ```
 

--- a/js/frameworks/nextjs.html.markerb
+++ b/js/frameworks/nextjs.html.markerb
@@ -141,7 +141,94 @@ our [Vanilla with Candy Sprinkles](https://fly.io/blog/vanilla-candy-sprinkles/)
 blog entry and select the configuration that most closely matches your
 application.  If you still have questions, post on our [community forum](https://community.fly.io/).
 
+### Connecting to Supabase Postgres
 
+[Supabase](https://fly.io/docs/reference/supabase/#create-and-manage-a-supabase-postgres-database) is a managed Postgres service deployed at Fly.io infrastructure.
+
+You can create a Supabase Postgres instance at Fly.io and use the provided `DATABASE_URL`
+as described above. Alternatively, you can connect with a dedicated JavaScript client and leverage its API. In this section we'll help you to get started with such setup.
+
+Start off with provisioning a Supabase project:
+
+<aside class="callout">Running the following command in a Fly.io app context -- inside an app directory or specifying `-a yourapp` -- will automatically pick a region and set secrets on your app.</aside>
+
+```cmd
+flyctl ext supabase create
+```
+```output
+? Choose a name, use the default, or leave blank to generate one: hello-nextjs-db
+? Choose the primary region (can't be changed later) Warsaw, Poland (waw)
+
+Your Supabase database (hello-nextjs-db) in waw is ready. See details and next steps with: https://fly.io/docs/reference/supabase/
+
+Setting the following secrets on hello-nextjs:
+DATABASE_POOLER_URL
+DATABASE_URL
+
+...
+
+-------
+ ✔ [1/2] Machine 1781344b935d38 [app] update succeeded
+ ✔ [2/2] Machine e82de57a07e528 [app] update succeeded
+-------
+```
+
+Next, go to the Supabase Dashboard (`fly ext supabase dashboard`) and copy the _Project URL_ and _API Key_ into an `.env` file in the root of the project:
+
+```env
+SUPABASE_URL=<PROJECT URL>
+SUPABASE_ANON_KEY=<API KEY>
+```
+
+Finally, install the [supabase.js](https://www.npmjs.com/package/@supabase/supabase-js) `npm install @supabase/supabase-js`.
+
+With the above setup in place, let's create a simple page listing TODOs (we'll add some items to the database later) in `app/todos/page.tsx`:
+
+```javascript
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL ?? ''
+const supabaseKey = process.env.SUPABASE_ANON_KEY ?? ''
+
+export default async function Page() {
+    const supabase = createClient(supabaseUrl, supabaseKey)
+    const { data: todos } = await supabase.from('todos').select()
+
+    return (
+        <main className="flex min-h-screen flex-col items-center justify-between p-24">
+                <ul>
+                    {todos?.map((todo) => (
+                        <li key={todo.id} className="flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
+                            {todo.title}
+                        </li>
+                    ))}
+                </ul>
+        </main>
+    )
+}
+```
+
+If you try to run it locally and hit the `http://localhost:3000/todos` you'll get an empty page. That's totally expected since we need to create the table and fill it in with some data!
+To do that, return to the Supabase dashboard, navigate to the _SQL Editor_, and create the table with sample TODO tasks:
+
+```sql
+ -- Create the table
+ create table todos (
+   id serial primary key,
+   title text
+ );
+
+ -- Insert some sample data
+ insert into todos (title)
+ values
+   ('Create a Supabase project'),
+   ('Configure the Next.js project to use Supabase'),
+   ('Deploy to Fly.io');
+```
+
+And that's it! You should see your TODOs served locally from Supabase as well as when you redeploy the app at `Fly.io` with `fly deploy`.
+
+<aside class="callout">This is the basic setup that to get you started and connect your Next.js app to a Fly.io-hosted Supabase Postgres. For more comprehensive guide look at [Supabase Frameworks Quickstarts](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs).</aside>
 
 ## Static site generation with databases
 

--- a/js/frameworks/nextjs.html.markerb
+++ b/js/frameworks/nextjs.html.markerb
@@ -182,9 +182,9 @@ SUPABASE_ANON_KEY=<API KEY>
 
 Finally, install the [supabase.js](https://www.npmjs.com/package/@supabase/supabase-js) `npm install @supabase/supabase-js`.
 
-With the above setup in place, let's create a simple page listing TODOs (we'll add some items to the database later) in `app/todos/page.tsx`:
+With the above setup in place, let's create a simple to-do list on a new page `app/todos/page.tsx` (we'll add some items to the database later):
 
-```javascript
+```jsx
 import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.SUPABASE_URL ?? ''
@@ -208,8 +208,8 @@ export default async function Page() {
 }
 ```
 
-If you try to run it locally and hit the `http://localhost:3000/todos` you'll get an empty page. That's totally expected since we need to create the table and fill it in with some data!
-To do that, return to the Supabase dashboard, navigate to the _SQL Editor_, and create the table with sample TODO tasks:
+If you try to run your app locally (`npm run dev`) and visit `http://localhost:3000/todos`, you'll get an empty page. That's totally expected since we need to create the table and fill it in with some data!
+To do that, return to the Supabase dashboard (`fly ext supabase dashboard`), navigate to _SQL Editor_, and create a table named `todo` and insert some sample tasks:
 
 ```sql
  -- Create the table
@@ -226,7 +226,7 @@ To do that, return to the Supabase dashboard, navigate to the _SQL Editor_, and 
    ('Deploy to Fly.io');
 ```
 
-And that's it! You should see your TODOs served locally from Supabase as well as when you redeploy the app at `Fly.io` with `fly deploy`.
+And that's it! You should see your to-do items served locally at `http://localhost:3000/todos` from Supabase as well as when you redeploy the app to Fly.io with `fly deploy`.
 
 <aside class="callout">This is the basic setup that to get you started and connect your Next.js app to a Fly.io-hosted Supabase Postgres. For more comprehensive guide look at [Supabase Frameworks Quickstarts](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs).</aside>
 


### PR DESCRIPTION
### Summary of changes

This adds _Connecting to Supabase Postgres_ section to the Next.js guide.

It hand-holds the user through a process of connecting their Next.js project launched at Fly.io to Supabase with [`supabase-js`](https://www.npmjs.com/package/@supabase/supabase-js).

### Preview

<img width="1482" alt="Screenshot 2024-05-20 at 09 55 31" src="https://github.com/superfly/docs/assets/748608/dd6dd85f-fbf0-4c83-976e-8b1d365482f1">
<img width="1489" alt="Screenshot 2024-05-20 at 09 56 11" src="https://github.com/superfly/docs/assets/748608/d5083b25-a19c-46ef-bdae-48e1da5a283f">
<img width="1481" alt="Screenshot 2024-05-20 at 09 56 22" src="https://github.com/superfly/docs/assets/748608/7caa78af-a6d3-4982-9923-86462bec8513">


### Related Fly.io community and GitHub links

### Notes

* The changes ignore the fact that Supabase is a web development platform and thus doesn't mention how it fits into the Client/Server Components, Middleware etc. (see https://supabase.com/docs/guides/getting-started/quickstarts/nextjs)
   * adding that would bloat this section significantly
* Shall we add something similar but with [`Prisma`](https://www.prisma.io/nextjs)? @anniebabannie 
* Do we want to attract devs only interested in using Supabase to build their apps? Even if they host them somewhere else?
   * @raethlo you may know the answer ;)

