### PR TITLE
Rename speedrun

### DIFF
--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -12,9 +12,9 @@ toc: false
 
 Get up and running quickly on Fly.io.
 
-- **[Hands-on](/docs/hands-on/):** Launch a small demo app, walk through creating an account, and installing `flyctl`, the Fly.io command-line tool.
+- **[Launch on Fly.io](/docs/getting-started/launch/):** Jump right in and launch your own app fast.
 
-- **[Speedrun](/docs/speedrun/):** Jump right in and launch your own app fast.
+- **[Hands-on](/docs/hands-on/):** Launch a small demo app, walk through creating an account, and installing `flyctl`, the Fly.io command-line tool.
 
 Once that's done, check out our in-depth docs:
 

--- a/getting-started/launch.html.markerb
+++ b/getting-started/launch.html.markerb
@@ -1,5 +1,5 @@
 ---
-title: "Speedrun: Launch on Fly.io"
+title: "Launch on Fly.io"
 layout: docs
 sitemap: false
 nav: firecracker

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -7,7 +7,7 @@
       path: "/docs/getting-started/",
       open: current_page?("/docs"),
       links: [
-        { text: "Speedrun: Launch on Fly.io", path: "/docs/speedrun/" },
+        { text: "Launch on Fly.io", path: "/docs/getting-started/launch/" },
         { text: "Hands-on with Fly.io", path: "/docs/hands-on/" },
         { text: "Troubleshooting Deployments", path: "/docs/getting-started/troubleshooting/" }
       ]

--- a/retired-launcher.html.md
+++ b/retired-launcher.html.md
@@ -7,7 +7,7 @@ toc: false
 
 We've retired our web-based launchers for individual apps like Jupyter and code-server. You can launch these apps yourself, with the `fly launch` command. Apps that have their own official Docker images are especially convenient. Here are a couple of places to start:
 
-[Speedrun: Launch on Fly.io](/docs/speedrun/)
+[Speedrun: Launch on Fly.io](/docs/getting-started/launch/)
 
 [Deploy via Dockerfile](/docs/languages-and-frameworks/dockerfile/)
 

--- a/signup-welcome.html.md
+++ b/signup-welcome.html.md
@@ -13,6 +13,6 @@ Thanks for signing up for Fly.io!
 
 ## Where to start
 
-* **[Speedrun](/docs/speedrun/):** You have a project or a Dockerfile and you just want to launch. 
+* **[Launch on Fly.io](/docs/getting-started/launch/):** You have a project or a Dockerfile and you just want to launch. 
 * **[Hands-on with Fly.io](/docs/hands-on/start/):** A step-by-step approach to learning.
 * **[Languages & Framework guides](/docs/languages-and-frameworks/):** Choose your framework or language and get started.


### PR DESCRIPTION
### Summary of changes

- rename speedrun to Launch on Fly.io and move under getting-started
- update nav
- fix links

### Preview

https://aa-docs-3.fly.dev/docs/getting-started/launch/

### Related Fly.io community and GitHub links

### Notes

