### PR TITLE
Free allowances no longer given to free trial orgs, only orgs on a paid plan.

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -35,8 +35,6 @@ All plans require a [credit card](/docs/about/billing/#payment-options) on file.
 
 When you sign up for a Fly.io account, you get a one-time $5 free trial credit to let you test-drive Fly.io at no cost. You won't be charged for the $5/month Hobby plan subscription until the credit has been used up. The free trial credit doesn't expire.
 
-Usage beyond our [free resource allowances](#free-allowances) consumes your free trial credit.
-
 The free trial credit applies to your default (“personal”) organization that we create for you on sign-up. When the free trial credit is used up, that organization is automatically placed on the $5/month [Hobby plan](https://fly.io/plans) (we’ll send you an email when it happens).
 
 ### Legacy Hobby plan
@@ -54,6 +52,8 @@ Resources included for free on all plans:
 * 160GB outbound data transfer
 
 Additional resources are billed at the usage-based pricing detailed below.
+
+There are no free allowances during the free trial.
 
 ## Compute
 


### PR DESCRIPTION
### Summary of changes

We've stopped giving free allowances to trial orgs to avoid potential for abuse.

### Preview

<img width="768" alt="image" src="https://github.com/superfly/docs/assets/8368500/c462337e-8f90-49ac-aec2-86164d05d12c">

<img width="649" alt="image" src="https://github.com/superfly/docs/assets/8368500/402e160a-e23a-4a6b-a45c-69625d6b6817">

### Related Fly.io community and GitHub links

### Notes

