### PR TITLE
Replace Redis example output with Supabase output in Supabase docs

### DIFF
--- a/reference/supabase.html.md
+++ b/reference/supabase.html.md
@@ -82,13 +82,13 @@ late-surf-5384        	fly-ephemeral mad
 Note the database name, then fetch its status.
 
 ```cmd
-fly ext supabase status late-waterfall-1133
+fly ext supabase status late-surf-5384
 ```
 ```output
-Redis
-  ID             = aaV829vaMVDGbi5
-  Name           = late-waterfall-1133
-  App            = myapp
+Status
+   Name           = late-surf-5384
+   Primary Region = mia
+   Status         = created
 ```
 
 ### Delete a Supabase database


### PR DESCRIPTION
Update `fly ext supabase status` to use Supabase and not Redis output. The demo `late-waterfall-1133` name appears to have been lifted from `redis.html.md`.
