### PR TITLE
Add Restart Policy section to Fly.toml docs

### DIFF
--- a/machines/guides-examples/machine-restart-policy.html.markerb
+++ b/machines/guides-examples/machine-restart-policy.html.markerb
@@ -94,3 +94,14 @@ For example:
 ```
 
 Refer to the Machines API docs for more information about [updating a Machine](/docs/machines/api-machines-resource/#update-a-machine).
+
+## Set a restart policy in your Fly.toml
+You can also set a default app-level restart policy in your Fly.toml file:
+```toml
+[[restart]]
+  policy = "<never | always | on-failure>"
+  retries = 10
+  processes = ["app"]
+```
+
+ A restart policy can be targeted to a specific process group. If a group is not specified, all machines in an app will have the same default restart policy. If needed, you can still apply different policies on individual machines using the Flyctl or Machines API methods above.

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -823,6 +823,23 @@ size = "performance-1x"
 processes = ["worker"]
 ```
 
+## The `restart` section
+
+```toml
+[[restart]]
+  policy = "never"
+  retries = 10
+  processes = ["app"]
+```
+
+When a machine unexpectedly exits, our scheduling machinery follows a machine’s restart policy to restart it without your intervention. These policies are quite similar to docker’s container restart policies:
+
+- always: we’ll attempt to restart the machine no matter the exit code.
+- never: we won’t restart the machine even if it exits with a non-zero exit code.
+- on-failure: we’ll only restart the machine if it exited with a non-zero exit code (due to a failure or crash). This is the default policy if one is not explicitly set. 
+
+A restart policy can be targeted to a specific process group. If a group is not specified, all machines in an app will have the same default restart policy. You can also specify the number of times we should retry restarting the machine before giving up.
+
 ## The `checks` section
 
 If your app doesn't have public-facing services, or you want independent health checks that don't affect request routing,


### PR DESCRIPTION
### Summary of changes
The ability to specify a restart policy in the Fly.toml was added a couple months ago, but never made it into docs. This adds details to the fly.toml reference, and the restart policy doc. 

### Preview

### Related Fly.io community and GitHub links
https://community.fly.io/t/more-control-over-your-app-restarts/19180 announcement post

### Notes

