### PR TITLE
Blueprint: Autostart/autostop internal apps

### DIFF
--- a/blueprints/autostart-internal-apps.html.md
+++ b/blueprints/autostart-internal-apps.html.md
@@ -1,0 +1,109 @@
+---
+title: Autostart/autostop internal apps
+layout: docs
+nav: firecracker
+---
+
+You have an internal app that communicates only with other apps on your [private network](/docs/networking/private-networking/). This internal app might be a database or authentication server, or any other "backend" app that you don't want exposed to the public Internet. You want the app's Machines to stop when they're not serving requests from your other apps, and start again automatically when needed.
+
+To use the Fly Proxy autostart/autostop feature you need to configure services in `fly.toml`, like you would for a public app. But instead of using a public Anycast address, you assign a Flycast address to expose those services only on your private network.
+
+This blueprint focuses on the Fly Proxy autostart/autostop feature that controls Machines based on incoming requests. But when you use Flycast for internal apps you also get other Fly Proxy features like geographically aware load balancing.
+
+Learn more about [Flycast](/docs/networking/private-networking/#flycast-private-fly-proxy-services).
+
+## Create a new app with a Flycast address
+
+When you run `fly launch` to create a new app, it automatically assigns your app a public IPv6 address and a public shared IPv4 address. If you know your app won't need to be reachable from the Internet, then you can inform Fly Launch with the following option:
+
+```
+fly launch --no-public-ips
+```
+
+Then allocate a Flycast address to your app with:
+
+```
+fly ips allocate-v6 --private
+```
+
+Next steps: [Configure and deploy a private app](#configure-and-deploy-a-private-app).
+
+## Use Flycast for an existing app
+
+If you already have an app and you want to make it private and use Flycast, it's very important to make sure you remove the app's public IP addresses.
+
+### Add a Flycast address
+
+```
+fly ips allocate-v6 --private
+```
+
+### Remove public IP addresses
+
+List your IPs to check whether your app has public IP addresses:
+
+```
+fly ips list
+```
+
+Example output:
+
+```
+VERSION	IP                  	TYPE              	REGION	CREATED AT
+v6     	2a09:8280:1::2d:678b	public (dedicated)	global	Sep 1 2023 19:47
+v6     	fdaa:2:45b:0:1::23  	private           	global	Mar 16 2024 18:20
+v4     	66.241.124.63       	public (shared)   	      	Jan 1 0001 00:00
+```
+
+This example app has a shared public IPv4 address and a dedicated private IPv6 address. These are the addresses automatically assigned to an app on first deploy.
+
+Copy the public IP addresses and run the `release` command to remove them from your app. For example:
+
+```
+fly ips release 2a09:8280:1::2d:678b 66.241.124.63
+```
+
+Next steps: [Configure and deploy a private app](#configure-and-deploy-a-private-app) below.
+
+## Configure and deploy a private app
+
+Whether you're creating a new app or making an existing app private, there are a few things you'll need to check or configure.
+
+### Add services in your `fly.toml` config file
+
+If your app was private, then you might not have configured an `[http_services]` or `[services]` section in `fly.toml` because you didn't want it reachable through the public Internet. Now that you removed the public IPs, you can safely add services to allow access to the app on your private network and enable Fly Proxy to control Machines and load balance traffic.
+
+Here's an example `fly.toml` snippet:
+
+```toml
+[http_service]
+  internal_port = 8081 # the port on which your app receives requests over the 6PN
+  force_https = false # must be false - Flycast is http-only
+  auto_stop_machines = true # Fly Proxy stops Machines based on traffic
+  auto_start_machines = true # Fly Proxy starts Machines based on traffic 
+  min_machines_running = 0 # No. of Machines to keep running in primary region
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 200 # Fly Proxy uses this to determine Machine excess capacity
+```
+
+Make sure to set `force_https = false` since Flycast only works over HTTP.  HTTPS isn't necessary because all your private network traffic is sent through an encrypted WireGuard tunnel.
+
+Learn more about [Fly Launch configuration](https://docs/reference/configuration/) and the [autostart/autostop](https:///docs/apps/autostart-stop/) feature.
+
+### Make sure your app binds to `0.0.0.0:<port>`
+
+To be reachable by Fly Proxy, an app needs to listen on `0.0.0.0` and bind to the `internal_port` defined in the `fly.toml` configuration file.
+
+### Deploy the app 
+
+Run `fly deploy` for the configuration changes to take effect.
+
+Other apps in your organization can now reach your internal app using the private Flycast IP address or  [`<appname>.flycast`](/docs/networking/private-networking/#flycast-and-fly-io-dns).
+
+## Implementation resources
+
+We've talked about apps that use Flycast in some past blog posts:
+
+- [Deploy Your Own (Not) Midjourney Bot on Fly GPUs](https://fly.io/blog/not-midjourney-bot/) 
+- [Scaling Large Language Models to zero with Ollama](https://fly.io/blog/scaling-llm-ollama/) 

--- a/blueprints/autostart-internal-apps.html.md
+++ b/blueprints/autostart-internal-apps.html.md
@@ -1,14 +1,14 @@
 ---
-title: Autostart/autostop internal apps
+title: Autostart and autostop internal apps
 layout: docs
 nav: firecracker
 ---
 
 You have an internal app that communicates only with other apps on your [private network](/docs/networking/private-networking/). This internal app might be a database or authentication server, or any other "backend" app that you don't want exposed to the public Internet. You want the app's Machines to stop when they're not serving requests from your other apps, and start again automatically when needed.
 
-To use the Fly Proxy autostart/autostop feature you need to configure services in `fly.toml`, like you would for a public app. But instead of using a public Anycast address, you assign a Flycast address to expose those services only on your private network.
+To use the Fly Proxy autostart and autostop feature you need to configure services in `fly.toml`, like you would for a public app. But instead of using a public Anycast address, you assign a Flycast address to expose those services only on your private network.
 
-This blueprint focuses on the Fly Proxy autostart/autostop feature that controls Machines based on incoming requests. But when you use Flycast for internal apps you also get other Fly Proxy features like geographically aware load balancing.
+This blueprint focuses on autostart and autostop to control Machines based on incoming requests. But when you use Flycast for internal apps you also get other Fly Proxy features like geographically aware load balancing.
 
 Learn more about [Flycast](/docs/networking/private-networking/#flycast-private-fly-proxy-services).
 
@@ -30,7 +30,7 @@ Next steps: [Configure and deploy a private app](#configure-and-deploy-a-private
 
 ## Use Flycast for an existing app
 
-If you already have an app and you want to make it private and use Flycast, it's very important to make sure you remove the app's public IP addresses.
+If you already have an app and you want to make it private and use Flycast, it's important to make sure you remove the app's public IP addresses.
 
 ### Add a Flycast address
 
@@ -100,10 +100,10 @@ Here's an example `fly.toml` snippet:
 ```
 
 <div class="important icon">
-**Important:** Set `force_https = false` since Flycast only works over HTTP.  HTTPS isn't necessary because all your private network traffic is sent through an encrypted WireGuard tunnel.
+**Important:** Set `force_https = false` since Flycast only works over HTTP.  HTTPS isn't necessary because all your private network traffic goes through encrypted WireGuard tunnels.
 </div>
 
-Learn more about [Fly Launch configuration](https://docs/reference/configuration/) and the [autostart/autostop](https:///docs/apps/autostart-stop/) feature.
+Learn more about [Fly Launch configuration](https://docs/reference/configuration/) and the [autostart and autostop](https:///docs/apps/autostart-stop/) feature.
 
 ### Make sure your app binds to `0.0.0.0:<port>`
 

--- a/blueprints/autostart-internal-apps.html.md
+++ b/blueprints/autostart-internal-apps.html.md
@@ -14,13 +14,13 @@ Learn more about [Flycast](/docs/networking/private-networking/#flycast-private-
 
 ## Create a new app with a Flycast address
 
-When you run `fly launch` to create a new app, it automatically assigns your app a public IPv6 address and a public shared IPv4 address. If you know your app won't need to be reachable from the Internet, then you can inform Fly Launch with the following option:
+When you run `fly launch` to create a new app, it automatically assigns your app a public IPv6 address and a shared public IPv4 address. If you know your app won't need to be reachable from the Internet, then you can inform Fly Launch with the following option:
 
 ```
 fly launch --no-public-ips
 ```
 
-Then allocate a Flycast address to your app with:
+Then allocate a Flycast address to your app:
 
 ```
 fly ips allocate-v6 --private
@@ -50,17 +50,23 @@ Example output:
 
 ```
 VERSION	IP                  	TYPE              	REGION	CREATED AT
-v6     	2a09:8280:1::2d:678b	public (dedicated)	global	Sep 1 2023 19:47
-v6     	fdaa:2:45b:0:1::23  	private           	global	Mar 16 2024 18:20
-v4     	66.241.124.63       	public (shared)   	      	Jan 1 0001 00:00
+v6     	2a09:8280:1::2d:1111	public (dedicated)	global	Sep 1 2023 19:47
+v6     	fdaa:2:45b:0:1::11  	private           	global	Mar 16 2024 18:20
+v4     	66.241.124.11       	public (shared)   	      	Jan 1 0001 00:00
 ```
 
-This example app has a shared public IPv4 address and a dedicated private IPv6 address. These are the addresses automatically assigned to an app on first deploy.
+This example app has public IPv4 and IPv6 addresses. These are the addresses automatically assigned to an app on first deploy.
 
-Copy the public IP addresses and run the `release` command to remove them from your app. For example:
+Copy the public IP addresses and run the `release` command to remove them from your app:
 
 ```
-fly ips release 2a09:8280:1::2d:678b 66.241.124.63
+fly ips release <ip address> <ip address> ...
+```
+
+For example:
+
+```
+fly ips release 2a09:8280:1::2d:1111 66.241.124.11
 ```
 
 Next steps: [Configure and deploy a private app](#configure-and-deploy-a-private-app) below.
@@ -77,17 +83,25 @@ Here's an example `fly.toml` snippet:
 
 ```toml
 [http_service]
-  internal_port = 8081 # the port on which your app receives requests over the 6PN
-  force_https = false # must be false - Flycast is http-only
-  auto_stop_machines = true # Fly Proxy stops Machines based on traffic
-  auto_start_machines = true # Fly Proxy starts Machines based on traffic 
-  min_machines_running = 0 # No. of Machines to keep running in primary region
+  # the port on which your app receives requests over the 6PN
+  internal_port = 8081
+  # must be false - Flycast is http-only
+  force_https = false
+  # Fly Proxy stops Machines based on traffic
+  auto_stop_machines = true
+  # Fly Proxy starts Machines based on traffic
+  auto_start_machines = true
+  # Number of Machines to keep running in primary region
+  min_machines_running = 0
   [http_service.concurrency]
     type = "requests"
-    soft_limit = 200 # Fly Proxy uses this to determine Machine excess capacity
+    # Fly Proxy uses this limit to determine Machine excess capacity
+    soft_limit = 250
 ```
 
-Make sure to set `force_https = false` since Flycast only works over HTTP.  HTTPS isn't necessary because all your private network traffic is sent through an encrypted WireGuard tunnel.
+<div class="important icon">
+**Important:** Set `force_https = false` since Flycast only works over HTTP.  HTTPS isn't necessary because all your private network traffic is sent through an encrypted WireGuard tunnel.
+</div>
 
 Learn more about [Fly Launch configuration](https://docs/reference/configuration/) and the [autostart/autostop](https:///docs/apps/autostart-stop/) feature.
 
@@ -99,7 +113,7 @@ To be reachable by Fly Proxy, an app needs to listen on `0.0.0.0` and bind to th
 
 Run `fly deploy` for the configuration changes to take effect.
 
-Other apps in your organization can now reach your internal app using the private Flycast IP address or  [`<appname>.flycast`](/docs/networking/private-networking/#flycast-and-fly-io-dns).
+Other apps in your organization can now reach your internal app using the Flycast IP address or  [`<appname>.flycast`](/docs/networking/private-networking/#flycast-and-fly-io-dns).
 
 ## Implementation resources
 


### PR DESCRIPTION
### Summary of changes

New blueprint to explain how you can use a Flycast address for an internal app to get Fly Proxy features like autostart/autostop.

### Preview

### Related Fly.io community and GitHub links

### Notes

