### PR TITLE
Update Fly.io terms in partials

### DIFF
--- a/elixir/getting-started/index.html.markerb
+++ b/elixir/getting-started/index.html.markerb
@@ -39,7 +39,7 @@ mix archive.install hex phx_new
 
 If you just want to see how Fly.io deployment works, this is the section to focus on. Here we'll bootstrap the app and deploy it with a Postgres database.
 
-First, [install flyctl](/docs/hands-on/install-flyctl/), your Fly app command center, and [sign up to Fly](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
+First, [install flyctl](/docs/hands-on/install-flyctl/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
 
 Now let's generate a shiny, new Phoenix app:
 

--- a/js/frameworks/partials/_flyctl.html.erb
+++ b/js/frameworks/partials/_flyctl.html.erb
@@ -1,1 +1,1 @@
-First, [install flyctl](/docs/hands-on/install-flyctl/), your Fly.io app command center, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
+First, [install flyctl](/docs/hands-on/install-flyctl/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.

--- a/js/frameworks/partials/_intro.html.erb
+++ b/js/frameworks/partials/_intro.html.erb
@@ -1,5 +1,5 @@
 Getting an application running on Fly.io is essentially working out how to package it as a deployable image<%- if defined?(database) %> and attach it to a database<%- end %>.
-Once packaged it can be deployed to the Fly.io global application platform.
+Once packaged it can be deployed to the Fly.io platform.
 
 In this guide we'll learn how to deploy <%= "#{runtime.downcase.match(/^[aeiou]/) ? "an" : "a"} #{defined?(link) ? "[#{runtime}](#{link})" : "#{runtime}"}" %>
 <%= locals.key?(:type) ? type : "application" %>

--- a/languages-and-frameworks/partials/_flyctl.html.erb
+++ b/languages-and-frameworks/partials/_flyctl.html.erb
@@ -1,1 +1,1 @@
-First, [install flyctl](/docs/hands-on/install-flyctl/), your Fly.io app command center, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
+First, [install flyctl](/docs/hands-on/install-flyctl/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.

--- a/languages-and-frameworks/partials/_intro.html.erb
+++ b/languages-and-frameworks/partials/_intro.html.erb
@@ -1,5 +1,5 @@
 Getting an application running on Fly.io is essentially working out how to package it as a deployable image<%- if defined?(database) %> and attach it to a database<%- end %>.
-Once packaged, it can be deployed to the Fly.io global application platform.
+Once packaged, it can be deployed to the Fly.io platform.
 
 In this guide we'll learn how to deploy <%= "#{runtime.downcase.match(/^[aeiou]/) ? "an" : "a"} #{defined?(link) ? "[#{runtime}](#{link})" : "#{runtime}"}" %>
 <%= locals.key?(:type) ? type : "application" %>


### PR DESCRIPTION
### Summary of changes

- change "your Fly app command center" to "the Fly.io CLI"
- change "Fly.io global application platform" to "Fly.io platform"

### Preview

### Related Fly.io community and GitHub links

### Notes

