### PR TITLE
flyctl install: new page and a lot of link changes

### DIFF
--- a/app-guides/graphql-on-fly-with-hasura.html.markerb
+++ b/app-guides/graphql-on-fly-with-hasura.html.markerb
@@ -39,7 +39,7 @@ For any Fly application, you need to reserve an app name. So let's create an app
 flyctl apps create
 ```
 
-**If you don't have `flyctl`, you'll need to install it. Check out our [Install Flyctl](/docs/hands-on/install-flyctl/) guide. If you haven't got a Fly account yet, run `flyctl auth signup` to get your own free account.**
+**If you don't have `flyctl`, you'll need to install it. Check out our [Install Flyctl](/docs/flyctl/install/) guide. If you haven't got a Fly account yet, run `flyctl auth signup` to get your own free account.**
 
 You will be asked for an app name at this point. Hit return to have one auto-generated for you. You'll see the app name when the create has been completed like this:
 

--- a/app-guides/planetscale.html.markerb
+++ b/app-guides/planetscale.html.markerb
@@ -105,7 +105,7 @@ You've successfully connected to a PlanetScale database!
 
 ## Deploy the app to Fly
 
-If you haven't already done so, [install the Fly CLI](https://fly.io/docs/hands-on/install-flyctl/) and  then [log in to Fly](https://fly.io/docs/getting-started/log-in-to-fly/).
+If you haven't already done so, [install the Fly CLI](/docs/flyctl/install/) and  then [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 We've added a few files to make this sample app ready to run on Fly: a `Dockerfile`, `.dockerignore` and `fly.toml`. The `Dockerfile` tells Fly how to _package_ the application. The `.dockerignore` file specifies the files/folders we want included (else it would include ones like `.env` that we do not want). The `fly.toml` file _configures_ the application. The Fly CLI can make that for you. But since we know which variables, ports, services and so on our app needs, we made one.
 

--- a/app-guides/run-a-global-image-service.html.markerb
+++ b/app-guides/run-a-global-image-service.html.markerb
@@ -100,7 +100,7 @@ For this you'll need flyctl, it's your CLI-powered remote control for your Fly a
 
 ### Installing `flyctl`
 
-If you've already installed `flyctl`, move on to the next step. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/).
+If you've already installed `flyctl`, move on to the next step. If not, hop over to [our installation guide](/docs/flyctl/install/).
 
 ### Sign In (or Up) for Fly
 

--- a/blueprints/review-apps-guide.html.md
+++ b/blueprints/review-apps-guide.html.md
@@ -35,7 +35,7 @@ For more details about each step, follow the guide below.
 
 ### Set your Fly API token
 
-Your GitHub Action will need a Fly API token in order to deploy and manage new review apps on Fly.io. You can get this token using the following [flyctl](https://fly.io/docs/hands-on/install-flyctl/) command:
+Your GitHub Action will need a Fly API token in order to deploy and manage new review apps on Fly.io. You can get this token using the following [flyctl](/docs/flyctl/install/) command:
 
 ```cmd
 fly auth token

--- a/django/getting-started/existing.html.md
+++ b/django/getting-started/existing.html.md
@@ -25,7 +25,7 @@ Be sure to have generated an up-to-date `requirements.txt` file for any new pack
 
 ## flyctl
 
-Fly.io has its own command-line utility for managing apps, [flyctl](https://fly.io/docs/hands-on/install-flyctl/). If not already installed, follow the instructions on the [installation guide](https://fly.io/docs/hands-on/install-flyctl/) and [log in to Fly](https://fly.io/docs/getting-started/log-in-to-fly/).
+Fly.io has its own command-line utility for managing apps, [flyctl](/docs/flyctl/). If not already installed, follow the instructions on the [installation guide](/docs/flyctl/install/) and [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 
 ## Provision Django and Postgres Servers

--- a/django/getting-started/index.html.md
+++ b/django/getting-started/index.html.md
@@ -167,7 +167,7 @@ That's it! We're ready to deploy on Fly.io.
 
 ## flyctl
 
-Fly.io has its own command-line utility for managing apps, [flyctl](https://fly.io/docs/hands-on/install-flyctl/). If not already installed, follow the instructions on the [installation guide](https://fly.io/docs/hands-on/install-flyctl/) and [log in to Fly.io](https://fly.io/docs/getting-started/log-in-to-fly/).
+Fly.io has its own command-line utility for managing apps, [flyctl](/docs/flyctl/). If not already installed, follow the instructions on the [installation guide](/docs/flyctl/install/) and [log in to Fly.io](/docs/getting-started/sign-up-sign-in/).
 
 
 ## Configure and Deploy your Fly App

--- a/elixir/getting-started/index.html.markerb
+++ b/elixir/getting-started/index.html.markerb
@@ -39,7 +39,7 @@ mix archive.install hex phx_new
 
 If you just want to see how Fly.io deployment works, this is the section to focus on. Here we'll bootstrap the app and deploy it with a Postgres database.
 
-First, [install flyctl](/docs/hands-on/install-flyctl/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
+First, [install flyctl](/docs/flyctl/install/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/sign-up-sign-in/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
 
 Now let's generate a shiny, new Phoenix app:
 

--- a/flyctl/index.html.md
+++ b/flyctl/index.html.md
@@ -6,9 +6,13 @@ edit: false
 nav: flyctl
 ---
 
-The `fly` command is one of the primary ways to interact with Fly.io. If you're doing anything with Fly.io, you'll need it.
+flyctl, the Fly.io CLI, is one of the primary ways to interact with the Fly.io platform. You'll use the `fly` command to create and deploy apps, manage Machines and volumes, configure networking, and more.
 
-We have [flyctl installation instructions](/docs/hands-on/install-flyctl/) to guide you through installing it on your system. There's also [flyctl and continuous integration](/docs/flyctl/integrating/) which covers environment variables, JSON and other automation related information about flyctl.
+First, [install flyctl](/docs/flyctl/install/).
+
+Also check out [flyctl and continuous integration](/docs/flyctl/integrating/) which covers environment variables, JSON and other automation related information about flyctl.
+
+The following list includes some important commands to get started.
 
 ## Using your Fly.io Account
 

--- a/flyctl/install.html.markerb
+++ b/flyctl/install.html.markerb
@@ -1,0 +1,13 @@
+---
+title: Install flyctl
+layout: docs
+sitemap: false
+nav: flyctl
+---
+
+<%= partial "/docs/partials/docs/flyctl_install" %>
+
+## Next steps
+
+- [Launch an app](/docs/getting-started/launch/)
+- [Browse what's possible on Fly.io](/docs/blueprints/)

--- a/getting-started/launch.html.markerb
+++ b/getting-started/launch.html.markerb
@@ -15,7 +15,7 @@ You have an application you want to deploy on Fly.io? You're in the right place.
 Welcome to Fly Launch. For most languages and frameworks, you can deploy your app from zero, with the following steps:
 
 <div class="important">
-1. [Install flyctl](/docs/hands-on/install-flyctl/) &ndash; you'll need it.
+1. [Install flyctl](/docs/flyctl/install/) &ndash; you'll need it.
 
 2. Create an account with `fly auth signup` or login with `fly auth login`.
 

--- a/getting-started/sign-up-sign-in.html.markerb
+++ b/getting-started/sign-up-sign-in.html.markerb
@@ -4,6 +4,7 @@ layout: docs
 sitemap: false
 nav: firecracker
 toc: false
+redirect_from: /docs/getting-started/log-in-to-fly/
 ---
 
 ## No account? Sign up for Fly.io

--- a/hands-on/install-flyctl.html.markerb
+++ b/hands-on/install-flyctl.html.markerb
@@ -10,57 +10,7 @@ redirect_from:
   - /docs/flyctl/installing/
 ---
 
-flyctl is a command-line utility that lets you work with Fly.io, from creating your account to deploying your applications. It runs on your local device so you'll want to install the version that's appropriate for your operating system.
+<%= partial "/docs/partials/docs/flyctl_install" %>
 
-<h2 id="macos" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
-  <a href="#macos" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>
-  <svg fill="currentColor" class="relative top-[-2px] mr-3" width="24" height="24" viewBox="0 0 24 24">
-    <path d="M22 17.607c-.786 2.28-3.139 6.317-5.563 6.361-1.608.031-2.125-.953-3.963-.953-1.837 0-2.412.923-3.932.983-2.572.099-6.542-5.827-6.542-10.995 0-4.747 3.308-7.1 6.198-7.143 1.55-.028 3.014 1.045 3.959 1.045.949 0 2.727-1.29 4.596-1.101.782.033 2.979.315 4.389 2.377-3.741 2.442-3.158 7.549.858 9.426zm-5.222-17.607c-2.826.114-5.132 3.079-4.81 5.531 2.612.203 5.118-2.725 4.81-5.531z" />
-  </svg>
-  macOS
-</h2>
-
-If you have the [Homebrew](https://brew.sh) package manager installed, flyctl can be installed by running:
-
-```cmd
-brew install flyctl
-```
-
-If not, you can run the install script:
-
-```cmd
-curl -L https://fly.io/install.sh | sh
-```
-If you used curl to install flyctl, then you need to add the flyctl directory to your shell rc file. Check the output of the install script for the entries to copy and paste into the file. Now you can use the `flyctl` command from any directory. Or for maximum efficiency, you can use the `fly` command! 
-
-<h2 id="linux" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
-  <a href="#linux" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>
-  <svg fill="currentColor" class="relative top-[-2px] mr-3" width="24" height="24" viewBox="0 0 24 24">
-    <path d="M20.581 19.049c-.55-.446-.336-1.431-.907-1.917.553-3.365-.997-6.331-2.845-8.232-1.551-1.595-1.051-3.147-1.051-4.49 0-2.146-.881-4.41-3.55-4.41-2.853 0-3.635 2.38-3.663 3.738-.068 3.262.659 4.11-1.25 6.484-2.246 2.793-2.577 5.579-2.07 7.057-.237.276-.557.582-1.155.835-1.652.72-.441 1.925-.898 2.78-.13.243-.192.497-.192.74 0 .75.596 1.399 1.679 1.302 1.461-.13 2.809.905 3.681.905.77 0 1.402-.438 1.696-1.041 1.377-.339 3.077-.296 4.453.059.247.691.917 1.141 1.662 1.141 1.631 0 1.945-1.849 3.816-2.475.674-.225 1.013-.879 1.013-1.488 0-.39-.139-.761-.419-.988zm-9.147-10.465c-.319 0-.583-.258-1-.568-.528-.392-1.065-.618-1.059-1.03 0-.283.379-.37.869-.681.526-.333.731-.671 1.249-.671.53 0 .69.268 1.41.579.708.307 1.201.427 1.201.773 0 .355-.741.609-1.158.868-.613.378-.928.73-1.512.73zm1.665-5.215c.882.141.981 1.691.559 2.454l-.355-.145c.184-.543.181-1.437-.435-1.494-.391-.036-.643.48-.697.922-.153-.064-.32-.11-.523-.127.062-.923.658-1.737 1.451-1.61zm-3.403.331c.676-.168 1.075.618 1.078 1.435l-.31.19c-.042-.343-.195-.897-.579-.779-.411.128-.344 1.083-.115 1.279l-.306.17c-.42-.707-.419-2.133.232-2.295zm-2.115 19.243c-1.963-.893-2.63-.69-3.005-.69-.777 0-1.031-.579-.739-1.127.248-.465.171-.952.11-1.343-.094-.599-.111-.794.478-1.052.815-.346 1.177-.791 1.447-1.124.758-.937 1.523.537 2.15 1.85.407.851 1.208 1.282 1.455 2.225.227.871-.71 1.801-1.896 1.261zm6.987-1.874c-1.384.673-3.147.982-4.466.299-.195-.563-.507-.927-.843-1.293.539-.142.939-.814.46-1.489-.511-.721-1.555-1.224-2.61-2.04-.987-.763-1.299-2.644.045-4.746-.655 1.862-.272 3.578.057 4.069.068-.988.146-2.638 1.496-4.615.681-.998.691-2.316.706-3.14l.62.424c.456.337.838.708 1.386.708.81 0 1.258-.466 1.882-.853.244-.15.613-.302.923-.513.52 2.476 2.674 5.454 2.795 7.15.501-1.032-.142-3.514-.142-3.514.842 1.285.909 2.356.946 3.67.589.241 1.221.869 1.279 1.696l-.245-.028c-.126-.919-2.607-2.269-2.83-.539-1.19.181-.757 2.066-.997 3.288-.11.559-.314 1.001-.462 1.466zm4.846-.041c-.985.38-1.65 1.187-2.107 1.688-.88.966-2.044.503-2.168-.401-.131-.966.36-1.493.572-2.574.193-.987-.023-2.506.431-2.668.295 1.753 2.066 1.016 2.47.538.657 0 .712.222.859.837.092.385.219.709.578 1.09.418.447.29 1.133-.635 1.49zm-8-13.006c-.651 0-1.138-.433-1.534-.769-.203-.171.05-.487.253-.315.387.328.777.675 1.281.675.607 0 1.142-.519 1.867-.805.247-.097.388.285.143.382-.704.277-1.269.832-2.01.832z" />
-  </svg>
-  Linux
-</h2>
-
-Run the install script:
-
-```cmd
-curl -L https://fly.io/install.sh | sh
-```
-
-<h2 id="windows" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
-  <a href="#windows" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>
-  <svg fill="currentColor" class="relative top-[-2px] mr-3" width="20" height="20" viewBox="0 0 24 24">
-    <path d="M0 12v-8.646l10-1.355v10.001h-10zm11 0h13v-12l-13 1.807v10.193zm-1 1h-10v7.646l10 1.355v-9.001zm1 0v9.194l13 1.806v-11h-13z"/>
-  </svg>
-  Windows
-</h2>
-
-Run the PowerShell install script:
-
-```cmd
-pwsh -Command "iwr https://fly.io/install.ps1 -useb | iex"
-```
-
-If you encounter an error saying the `pwsh` command is not found, `powershell` can be used instead, though we recommend [installing the latest version of PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows).
 
 [Next: Sign up / Sign in](/docs/hands-on/sign-up-sign-in/)

--- a/js/frameworks/deno.html.markerb
+++ b/js/frameworks/deno.html.markerb
@@ -63,7 +63,7 @@ And connect to localhost:8080 to confirm that you have a working Deno applicatio
 
 ## Install Flyctl and Login
 
-We are ready to start working with Fly.io, and that means we need `flyctl`, our CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/log-in-to-fly/).
+We are ready to start working with Fly.io, and that means we need `flyctl`, our CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/sign-up-sign-in/).
 
 ## Configuring the App for Fly.io
 

--- a/js/frameworks/partials/_flyctl.html.erb
+++ b/js/frameworks/partials/_flyctl.html.erb
@@ -1,1 +1,1 @@
-First, [install flyctl](/docs/hands-on/install-flyctl/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
+First, [install flyctl](/docs/flyctl/install/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/sign-up-sign-in/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.

--- a/js/frameworks/svelte.html.markerb
+++ b/js/frameworks/svelte.html.markerb
@@ -97,7 +97,7 @@ Once the build process is complete, you can preview your production build locall
 
 ## _Install Flyctl and Login_
 
-We are ready to start working with Fly.io, and that means we need `flyctl`, our CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/log-in-to-fly/).
+We are ready to start working with Fly.io, and that means we need `flyctl`, our CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/sign-up-sign-in/).
 
 ## _Deploy the app on Fly.io_
 

--- a/js/the-basics.html.md
+++ b/js/the-basics.html.md
@@ -15,7 +15,7 @@ These guides will help you get through the basics of setting up your JavaScript 
 
 ## Installing flyctl and logging in
 
-In order to start working with Fly.io, you will need `flyctl`, our CLI app for managing apps. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/log-in-to-fly/).
+In order to start working with Fly.io, you will need `flyctl`, our CLI app for managing apps. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 Once you have logged on, below are a number of topics.  Review the ones you want, and in review them in any order.  Once you are ready, run:
 

--- a/languages-and-frameworks/dotnet.html.markerb
+++ b/languages-and-frameworks/dotnet.html.markerb
@@ -46,7 +46,7 @@ Now, let's proceed to deploy this application to Fly.
 
 ## _Install Flyctl and Login_
 
-We are ready to start working with Fly.io, and that means we need `flyctl`, our CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/log-in-to-fly/).
+We are ready to start working with Fly.io, and that means we need `flyctl`, our CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/sign-up-sign-in/).
 
 ## _Launch the app on Fly_
 

--- a/languages-and-frameworks/golang.html.markerb
+++ b/languages-and-frameworks/golang.html.markerb
@@ -72,7 +72,7 @@ As with most Go applications, a simple `go build` will create a `hellofly` binar
 
 ## _Install Flyctl and Login_
 
-We are ready to start working with Fly and that means we need `flyctl`, our CLI app for managing apps on Fly. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/log-in-to-fly/).
+We are ready to start working with Fly and that means we need `flyctl`, our CLI app for managing apps on Fly. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 ## _Launch the app on Fly_
 

--- a/languages-and-frameworks/partials/_flyctl.html.erb
+++ b/languages-and-frameworks/partials/_flyctl.html.erb
@@ -1,1 +1,1 @@
-First, [install flyctl](/docs/hands-on/install-flyctl/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.
+First, [install flyctl](/docs/flyctl/install/), the Fly.io CLI, and [sign up to Fly.io](/docs/getting-started/sign-up-sign-in/#first-time-or-no-fly-account-sign-up-for-fly) if you haven't already.

--- a/languages-and-frameworks/partials/_install_flyctl_login.html.erb
+++ b/languages-and-frameworks/partials/_install_flyctl_login.html.erb
@@ -1,3 +1,3 @@
 ## _Install Flyctl and Login_
 
-It's time to install `flyctl`, the CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/log-in-to-fly/).
+It's time to install `flyctl`, the CLI app for managing apps on Fly.io. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly.io](/docs/getting-started/sign-up-sign-in/).

--- a/languages-and-frameworks/python.html.markerb
+++ b/languages-and-frameworks/python.html.markerb
@@ -186,9 +186,9 @@ Now, let's move on to deploying this app to Fly.io.
 
 ### Launch your Fly App
 
-Fly.io has its own command-line utility for managing apps, [flyctl](/docs/hands-on/install-flyctl/). 
+Fly.io has its own command-line utility for managing apps, [flyctl](/docs/flyctl/). 
 
-If not already installed, follow the instructions on the [installation guide](/docs/hands-on/install-flyctl/) and [log in to Fly.io](/docs/getting-started/log-in-to-fly/).
+If not already installed, follow the instructions on the [installation guide](/docs/flyctl/install/) and [log in to Fly.io](/docs/getting-started/sign-up-sign-in/).
 
 <section class="callout">
 Both `flyctl` and `fly` commands will work the same way.

--- a/languages-and-frameworks/ruby.html.markerb
+++ b/languages-and-frameworks/ruby.html.markerb
@@ -73,7 +73,7 @@ And connect to localhost:9292 to confirm that you have a working Ruby applicatio
 
 ## _Install Flyctl and Login_
 
-We are ready to start working with Fly and that means we need `flyctl`, our CLI app for managing apps on Fly. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/log-in-to-fly/).
+We are ready to start working with Fly and that means we need `flyctl`, our CLI app for managing apps on Fly. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 
 ## _Launch the app on Fly_

--- a/languages-and-frameworks/static.html.markerb
+++ b/languages-and-frameworks/static.html.markerb
@@ -23,7 +23,7 @@ Alternatively, you can create all the files manually as you work through this gu
 
 ## _Install flyctl and login_
 
-To configure our application and deploy it on Fly.io, we need `flyctl`, our CLI app for managing apps on Fly. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/log-in-to-fly/).
+To configure our application and deploy it on Fly.io, we need `flyctl`, our CLI app for managing apps on Fly. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 ## _Putting the app together_
 

--- a/partials/_flyctl_nav.html.erb
+++ b/partials/_flyctl_nav.html.erb
@@ -7,7 +7,7 @@
       path: "/docs/flyctl/",
       accordion: false,
       links: [
-        { text: "Install flyctl", path: "/docs/hands-on/install-flyctl/" },
+        { text: "Install flyctl", path: "/docs/flyctl/install/" },
         { text: "Integrate flyctl", path: "/docs/flyctl/integrating/" }
       ]
     },

--- a/partials/docs/_flyctl_install.html.erb
+++ b/partials/docs/_flyctl_install.html.erb
@@ -1,0 +1,52 @@
+flyctl is a command-line utility that lets you work with Fly.io, from creating your account to deploying your applications. It runs on your local device so you'll want to install the version that's appropriate for your operating system.
+
+<h2 id="macos" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
+  <a href="#macos" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>
+  <svg fill="currentColor" class="relative top-[-2px] mr-3" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M22 17.607c-.786 2.28-3.139 6.317-5.563 6.361-1.608.031-2.125-.953-3.963-.953-1.837 0-2.412.923-3.932.983-2.572.099-6.542-5.827-6.542-10.995 0-4.747 3.308-7.1 6.198-7.143 1.55-.028 3.014 1.045 3.959 1.045.949 0 2.727-1.29 4.596-1.101.782.033 2.979.315 4.389 2.377-3.741 2.442-3.158 7.549.858 9.426zm-5.222-17.607c-2.826.114-5.132 3.079-4.81 5.531 2.612.203 5.118-2.725 4.81-5.531z" />
+  </svg>
+  macOS
+</h2>
+
+If you have the [Homebrew](https://brew.sh) package manager installed, flyctl can be installed by running:
+
+```cmd
+brew install flyctl
+```
+
+If not, you can run the install script:
+
+```cmd
+curl -L https://fly.io/install.sh | sh
+```
+If you used curl to install flyctl, then you need to add the flyctl directory to your shell rc file. Check the output of the install script for the entries to copy and paste into the file. Now you can use the `flyctl` command from any directory. Or for maximum efficiency, you can use the `fly` command! 
+
+<h2 id="linux" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
+  <a href="#linux" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>
+  <svg fill="currentColor" class="relative top-[-2px] mr-3" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M20.581 19.049c-.55-.446-.336-1.431-.907-1.917.553-3.365-.997-6.331-2.845-8.232-1.551-1.595-1.051-3.147-1.051-4.49 0-2.146-.881-4.41-3.55-4.41-2.853 0-3.635 2.38-3.663 3.738-.068 3.262.659 4.11-1.25 6.484-2.246 2.793-2.577 5.579-2.07 7.057-.237.276-.557.582-1.155.835-1.652.72-.441 1.925-.898 2.78-.13.243-.192.497-.192.74 0 .75.596 1.399 1.679 1.302 1.461-.13 2.809.905 3.681.905.77 0 1.402-.438 1.696-1.041 1.377-.339 3.077-.296 4.453.059.247.691.917 1.141 1.662 1.141 1.631 0 1.945-1.849 3.816-2.475.674-.225 1.013-.879 1.013-1.488 0-.39-.139-.761-.419-.988zm-9.147-10.465c-.319 0-.583-.258-1-.568-.528-.392-1.065-.618-1.059-1.03 0-.283.379-.37.869-.681.526-.333.731-.671 1.249-.671.53 0 .69.268 1.41.579.708.307 1.201.427 1.201.773 0 .355-.741.609-1.158.868-.613.378-.928.73-1.512.73zm1.665-5.215c.882.141.981 1.691.559 2.454l-.355-.145c.184-.543.181-1.437-.435-1.494-.391-.036-.643.48-.697.922-.153-.064-.32-.11-.523-.127.062-.923.658-1.737 1.451-1.61zm-3.403.331c.676-.168 1.075.618 1.078 1.435l-.31.19c-.042-.343-.195-.897-.579-.779-.411.128-.344 1.083-.115 1.279l-.306.17c-.42-.707-.419-2.133.232-2.295zm-2.115 19.243c-1.963-.893-2.63-.69-3.005-.69-.777 0-1.031-.579-.739-1.127.248-.465.171-.952.11-1.343-.094-.599-.111-.794.478-1.052.815-.346 1.177-.791 1.447-1.124.758-.937 1.523.537 2.15 1.85.407.851 1.208 1.282 1.455 2.225.227.871-.71 1.801-1.896 1.261zm6.987-1.874c-1.384.673-3.147.982-4.466.299-.195-.563-.507-.927-.843-1.293.539-.142.939-.814.46-1.489-.511-.721-1.555-1.224-2.61-2.04-.987-.763-1.299-2.644.045-4.746-.655 1.862-.272 3.578.057 4.069.068-.988.146-2.638 1.496-4.615.681-.998.691-2.316.706-3.14l.62.424c.456.337.838.708 1.386.708.81 0 1.258-.466 1.882-.853.244-.15.613-.302.923-.513.52 2.476 2.674 5.454 2.795 7.15.501-1.032-.142-3.514-.142-3.514.842 1.285.909 2.356.946 3.67.589.241 1.221.869 1.279 1.696l-.245-.028c-.126-.919-2.607-2.269-2.83-.539-1.19.181-.757 2.066-.997 3.288-.11.559-.314 1.001-.462 1.466zm4.846-.041c-.985.38-1.65 1.187-2.107 1.688-.88.966-2.044.503-2.168-.401-.131-.966.36-1.493.572-2.574.193-.987-.023-2.506.431-2.668.295 1.753 2.066 1.016 2.47.538.657 0 .712.222.859.837.092.385.219.709.578 1.09.418.447.29 1.133-.635 1.49zm-8-13.006c-.651 0-1.138-.433-1.534-.769-.203-.171.05-.487.253-.315.387.328.777.675 1.281.675.607 0 1.142-.519 1.867-.805.247-.097.388.285.143.382-.704.277-1.269.832-2.01.832z" />
+  </svg>
+  Linux
+</h2>
+
+Run the install script:
+
+```cmd
+curl -L https://fly.io/install.sh | sh
+```
+
+<h2 id="windows" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
+  <a href="#windows" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>
+  <svg fill="currentColor" class="relative top-[-2px] mr-3" width="20" height="20" viewBox="0 0 24 24">
+    <path d="M0 12v-8.646l10-1.355v10.001h-10zm11 0h13v-12l-13 1.807v10.193zm-1 1h-10v7.646l10 1.355v-9.001zm1 0v9.194l13 1.806v-11h-13z"/>
+  </svg>
+  Windows
+</h2>
+
+Run the PowerShell install script:
+
+```cmd
+pwsh -Command "iwr https://fly.io/install.ps1 -useb | iex"
+```
+
+If you encounter an error saying the `pwsh` command is not found, `powershell` can be used instead, though we recommend [installing the latest version of PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows).

--- a/rails/cookbooks/index.html.md
+++ b/rails/cookbooks/index.html.md
@@ -34,7 +34,7 @@ application, and then proceed from there, running `fly deploy` after you make
 changes.  The recipes the follow contain fragments that can be added
 to multiple cookbooks.
 
-For best results, you are encouraged to try out each step.  To do so, you will need to [Log in to Fly](https://fly.io/docs/getting-started/log-in-to-fly/).  Nothing you do in this tutorial will exceed the [Free Allowances](https://fly.io/docs/about/pricing/#free-allowances) provided.
+For best results, you are encouraged to try out each step.  To do so, you will need to [Log in to Fly](/docs/getting-started/sign-up-sign-in/).  Nothing you do in this tutorial will exceed the [Free Allowances](https://fly.io/docs/about/pricing/#free-allowances) provided.
 These cookbooks can be more than mere educational materials.  Using throwaway applications is
 often better than experimenting in production when you want to make configuration changes.
 Starting a minimal application, using `flyctl ssh console` to shell into that machine and

--- a/rails/getting-started/fly-rails.html.md
+++ b/rails/getting-started/fly-rails.html.md
@@ -11,7 +11,7 @@ Please note that the `fly-rails` gem is designed to work well with common Rails 
 
 ## Install the `flyctl` command line interface
 
-First you'll need to [install the Fly CLI, and signup for a Fly.io account](/docs/hands-on/install-flyctl/). The gem used in the next step will use this CLI to deploy your application to Fly.io and it's something that's worth learning more about as you become more comfortable with Fly.io.
+First you'll need to [install the Fly CLI, and signup for a Fly.io account](/docs/flyctl/install/). The gem used in the next step will use this CLI to deploy your application to Fly.io and it's something that's worth learning more about as you become more comfortable with Fly.io.
 
 ## Install the gem
 

--- a/rails/getting-started/index.html.md
+++ b/rails/getting-started/index.html.md
@@ -22,7 +22,7 @@ demonstrates a trivial view, then scaffolds a database table, and finally makes
 use of [Turbo Streams](https://turbo.hotwired.dev/handbook/streams) to dynamically
 update pages.
 
-In order to start working with Fly.io, you will need `flyctl`, our CLI app for managing apps. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/log-in-to-fly/).
+In order to start working with Fly.io, you will need `flyctl`, our CLI app for managing apps. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 Once you have logged on, here are the three steps and a recap.
 

--- a/reference/kafka.html.md
+++ b/reference/kafka.html.md
@@ -13,7 +13,7 @@ This service is in public beta in the `iad` and `fra` regions. We don't recommen
 
 ## Create and manage a Kafka cluster
 
-Creating and managing clusters happens exclusively via the [Fly CLI](/docs/hands-on/install-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
+Creating and managing clusters happens exclusively via the [Fly CLI](/docs/flyctl/install/). Install it, then [signup for a Fly account](/docs/getting-started/sign-up-sign-in/).
 
 ### Create and get status of a Kafka cluster
 

--- a/reference/redis.html.md
+++ b/reference/redis.html.md
@@ -15,7 +15,7 @@ See the [What you Should Know](#what-you-should-know) section for more details a
 
 ## Create and manage a Redis database
 
-Creating and managing databases happens exclusively via the [Fly CLI](/docs/hands-on/install-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
+Creating and managing databases happens exclusively via the [Fly CLI](/docs/flyctl/install/). Install it, then [signup for a Fly account](/docs/getting-started/sign-up-sign-in/).
 
 ### Create and get status of a Redis database
 

--- a/reference/supabase.html.md
+++ b/reference/supabase.html.md
@@ -20,7 +20,7 @@ Alpha databases:
 
 ## Create and manage a Supabase Postgres database
 
-Creating and managing databases happens exclusively via the [Fly CLI](/docs/hands-on/install-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
+Creating and managing databases happens exclusively via the [Fly CLI](/docs/flyctl/install/). Install it, then [signup for a Fly account](/docs/getting-started/sign-up-sign-in/).
 
 <aside class="callout">Running the following command in a Fly.io app context -- inside an app directory or specifying `-a yourapp` -- will automatically pick a region and set secrets on your app.</aside>
 

--- a/reference/tigris.html.md
+++ b/reference/tigris.html.md
@@ -14,7 +14,7 @@ Learn more from their [service overview](https://www.tigrisdata.com/docs/overvie
 
 ## Create and manage a Tigris storage bucket
 
-Creating and managing storage buckets happens exclusively via the [Fly CLI](/docs/hands-on/install-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
+Creating and managing storage buckets happens exclusively via the [Fly CLI](/docs/flyctl/install/). Install it, then [signup for a Fly account](/docs/getting-started/sign-up-sign-in/).
 
 <aside class="callout">Running the following command in a Fly.io app context -- inside an app directory or specifying `-a yourapp` -- will automatically set secrets on your app.</aside>
 

--- a/reference/vector.html.md
+++ b/reference/vector.html.md
@@ -15,7 +15,7 @@ When using Upstash vector through Fly.io, your index is hosted on Fly.io infrast
 
 ## Create and manage a Vector index
 
-Creating and managing indexes happens exclusively via the [Fly CLI](/docs/hands-on/install-flyctl/). Install it, then [signup for a Fly account](https://fly.io/docs/getting-started/log-in-to-fly/).
+Creating and managing indexes happens exclusively via the [Fly CLI](/docs/flyctl/install/). Install it, then [signup for a Fly account](/docs/getting-started/sign-up-sign-in/).
 
 You need to select a [similarity function](https://upstash.com/docs/vector/features/similarityfunctions) and [embedding model](https://upstash.com/docs/vector/features/embeddingmodels) to create an index. If you're bringing your own vectorization, you need to choose the index dimension count.
 

--- a/rust/the-basics.html.md
+++ b/rust/the-basics.html.md
@@ -12,7 +12,7 @@ To develop Rust applications, you will need to setup the rust toolchain. We reco
 
 ## Install flyctl and log in
 
-In order to start working with Fly.io, you will need `flyctl`, our CLI app for managing apps. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/hands-on/install-flyctl/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/log-in-to-fly/).
+In order to start working with Fly.io, you will need `flyctl`, our CLI app for managing apps. If you've already installed it, carry on. If not, hop over to [our installation guide](/docs/flyctl/install/). Once that's installed you'll want to [log in to Fly](/docs/getting-started/sign-up-sign-in/).
 
 For most popular frameworks you can deploy your app with just one command: 
 


### PR DESCRIPTION
### Summary of changes

- uses the previously created flyctl install partial to create a new install page that is under flyctl and not part of hands-on (which can be a disorienting place to get sent to from other docs to install flyctl)
- replaces a lot of links
- also renames an existing hidden page that used a lot for sign up/sign in, with a redirect and link fixes for that

### Preview

### Related Fly.io community and GitHub links

### Notes

