### PR TITLE
Clarify pricing for data transfer and extensions

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -132,10 +132,10 @@ Otherwise, Fly.io bills per-region pricing for outbound data transfer.
 
 <%= partial("shared/network_pricing") %>
 
-Any traffic exiting a Fly.io machine is considered outbound data transfer, including:
+Any traffic exiting a Fly.io Machine is considered outbound data transfer, including:
 
 * traffic destined for the internet
-* traffic destined for other machines or apps in your network
+* traffic destined for other Machines or apps in your network
 * traffic destined for [extensions](#extensions) like Supabase or Upstash Redis
 
 One exception: traffic destined for [Tigris Object Storage](/reference/tigris) is free. Learn more about [Extensions billing](#extensions).

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -122,11 +122,24 @@ We use Lets Encrypt to issue certificates, and donate half of our SSL fees to th
 * Single hostname certificates: $0.10/mo
 * Wildcard certificates: $1/mo
 
-### Outbound data transfer
+### Data transfer pricing
 
-We bill for outbound data transfer from the region a VM is running in, inbound transfer is free.
+Inbound data transfer is free.
+
+Data transfer from apps without an assigned IP address is free. [Flycast IPs](/docs/networking/private-networking/#flycast-private-fly-proxy-services) are considered an IP assignment, so apps using Flycast will accrue data transfer costs.
+
+Otherwise, Fly.io bills per-region pricing for outbound data transfer.
 
 <%= partial("shared/network_pricing") %>
+
+Any traffic exiting a Fly.io machine is considered outbound data transfer, including:
+
+* traffic destined for the internet
+* traffic destined for other machines or apps in your network
+* traffic destined for [extensions](#extensions) like Supabase or Upstash Redis
+
+One exception: traffic destined for [Tigris Object Storage](/reference/tigris) is free. Learn more about [Extensions billing](#extensions).
+
 
 ## Fly Kubernetes
 
@@ -134,6 +147,19 @@ We bill for outbound data transfer from the region a VM is running in, inbound t
 
 - $75/mo per cluster
 - Plus the cost of [compute](#compute) and [Fly volumes](#persistent-storage-volumes) that you create
+
+## Extensions
+
+Fly.io offers managed services operated by third parties, such as [Tigris Object Storage](/reference/tigris), [Supabase Postgres](/reference/supabase) and [Upstash Redis](/reference/redis).
+
+When you provision their services, you become their customer, and you pay their list prices via your monthly Fly.io bill.
+
+You will not be billed separately for:
+
+* Machines running the services, which are hosted in the provider's account
+* Bandwidth to Tigris Object Storage
+
+You **will** be billed separately for data transfer to services other than Tigris Object Storage. See our [data transfer pricing](#data-transfer-pricing) for details.
 
 ## LiteFS Cloud
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -152,11 +152,12 @@ One exception: traffic destined for [Tigris Object Storage](/reference/tigris) i
 
 Fly.io offers managed services operated by third parties, such as [Tigris Object Storage](/reference/tigris), [Supabase Postgres](/reference/supabase) and [Upstash Redis](/reference/redis).
 
-When you provision their services, you become their customer, and you pay their list prices via your monthly Fly.io bill.
+When you provision their services, you become their customer, and you pay their list prices via your monthly Fly.io bill. Charges are updated daily in your Fly.io dashboard.
 
 You will not be billed separately for:
 
 * Machines running the services, which are hosted in the provider's account
+* IP addresses associated with the service
 * Bandwidth to Tigris Object Storage
 
 You **will** be billed separately for data transfer to services other than Tigris Object Storage. See our [data transfer pricing](#data-transfer-pricing) for details.

--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -12,6 +12,7 @@ buildpacks?\b
 bursty
 callouts?\b
 cleartext
+containerd
 cron
 datacenters?\b
 datasource


### PR DESCRIPTION
This PR clarifies pricing for data transfer by adding more detail to what 'outbound' means, and clarifying which services offer free VM->service bandwidth (currently, Tigris).

Also, we clarify that provisioning extensions will not lead to extra charges for the managed service machine.