### PR TITLE
Clear up Supabase alpha release status

### DIFF
--- a/reference/supabase.html.md
+++ b/reference/supabase.html.md
@@ -6,16 +6,18 @@ status: alpha
 nav: firecracker
 ---
 
-[Supabase](https://supabase.com) offers a preview of their managed Postgres service on Fly.io infrastructure. Provisioning Supabase on Fly.io ensures low-latency database access from applications hosted on Fly.io.
+[Supabase](https://supabase.com) offers managed Postgres databases on Fly.io infrastructure. Provisioning Supabase on Fly.io ensures low-latency database access from applications hosted on Fly.io.
 
 <aside class="callout">
-This service is in **public alpha**. Do not run production workloads of any kind!
+This service is in **public alpha**. Here's what you should know.
 
-Alpha databases:
- * should only be used for testing and getting customer feedback
- * can lose data or go offline at any time
- * come with no support guarantees
- * won't be charged for
+Supabase Databases run on single machines and are susceptible to hardware issues. Restoring an affected database may require contacting support.
+
+During the alpha, you won't be charged for usage, but your usage will show up as a preview on your Fly.io bill.
+
+Most Supabase features besides raw Postgres are not enabled yet, such as [auth](https://supabase.com/docs/guides/auth) or [storage](https://supabase.com/docs/guides/storage).
+
+Supabase's connection pooler runs on AWS infrastructure, so using it may add connection latency depending on your region's [proximity to AWS servers](https://rtt.fly.dev/).
 </aside>
 
 ## Create and manage a Supabase Postgres database


### PR DESCRIPTION
This puts less scary wording around the alpha, which Supabase is more confident about supporting now.