### PR TITLE
Add python link

### DIFF
--- a/languages-and-frameworks/index.html.erb
+++ b/languages-and-frameworks/index.html.erb
@@ -23,6 +23,7 @@ toc: false
   <li><%=link_to_page find_page("/docs/django") %></li>
   <li><%=link_to_page find_page("/docs/js") %></li>
   <li><%=link_to_page find_page("/docs/rust") %></li>
+  <li><%=link_to_page find_page("/docs/python") %></li>
 </ul>
 
 <h2 id="supported" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">

--- a/networking/index.html.markerb
+++ b/networking/index.html.markerb
@@ -12,7 +12,7 @@ Networking on Fly.io.
  
 - **[Private networking](/docs/networking/private-networking):** Learn about Fly.io's IPv6 private network (6PN), DNS on Fly Machines, and how to use Flycast for load balancing and other Fly Proxy features on a private network.
 
-- **[Public networking](/docs/networking/services):** Details about public network services on Fly.io, including allocating IP addresses finding a Machines outbound IP, connection handlers, and redirects.
+- **[Public networking](/docs/networking/services):** Details about public network services on Fly.io, including allocating IP addresses, finding a Machine's outbound IP, connection handlers, and redirects.
 
 - **[Dynamic request routing](/docs/networking/dynamic-request-routing/):** Use the `fly-replay` response header to route requests to other apps and regions.
 


### PR DESCRIPTION
### Summary of changes

- add a link to python docs from frameworks index page
- fix an unrelated typo elsewhere

### Preview

### Related Fly.io community and GitHub links

### Notes

