### PR TITLE
Getting started changes for languages and frameworks

### DIFF
--- a/getting-started/get-started-by-framework.html.markerb
+++ b/getting-started/get-started-by-framework.html.markerb
@@ -1,0 +1,18 @@
+---
+title: "Get started with your language or framework"
+layout: docs
+nav: firecracker
+toc: false
+---
+
+Fly Launch can launch any app from a [Dockerfile](/docs/languages-and-frameworks/dockerfile/). 
+
+The Fly Launch scanners also detect and deploy the following kinds of apps automatically:
+
+<%= partial "/docs/languages-and-frameworks/partials/scanner_guides" %>
+
+See [Launch a new app](/docs/apps/launch/) to learn more about what `fly launch` does.
+
+<figure class="text-center">
+  <img src="/static/images/speedrun-guidebooks.webp" srcset="/static/images/speedrun-guidebooks@2x.webp 2x" alt="Illustration by Annie Ruygt of Frankie the Fly.io hot air balloon character with one hand on their hip and the other hand out, palm up, with images floating above the hand representing the Elixir, Ruby, Laravel, and Django programming languages">
+</figure>

--- a/getting-started/get-started-by-framework.html.markerb
+++ b/getting-started/get-started-by-framework.html.markerb
@@ -7,7 +7,7 @@ toc: false
 
 Fly Launch can deploy almost any app from a [Dockerfile](/docs/languages-and-frameworks/dockerfile/). 
 
-The Fly Launch scanners also detect and deploy the following kinds of apps automatically:
+Fly Launch scanners also detect and deploy the following kinds of apps automatically:
 
 <%= partial "/docs/languages-and-frameworks/partials/scanner_guides" %>
 

--- a/getting-started/get-started-by-framework.html.markerb
+++ b/getting-started/get-started-by-framework.html.markerb
@@ -5,7 +5,7 @@ nav: firecracker
 toc: false
 ---
 
-Fly Launch can launch any app from a [Dockerfile](/docs/languages-and-frameworks/dockerfile/). 
+Fly Launch can deploy almost any app from a [Dockerfile](/docs/languages-and-frameworks/dockerfile/). 
 
 The Fly Launch scanners also detect and deploy the following kinds of apps automatically:
 

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -22,8 +22,8 @@ Get up and running on Fly.io:
 
 ## Learn more
 
-* [Language & Framework Guides](/docs/languages-and-frameworks/): Comprehensive and starter guides for your favorite languages and frameworks.
 * [Fly Launch](/docs/apps): You've tried the `fly launch` command. Now learn how to use all the Fly Launch features that help you manage and run your apps.
+* [Fly.io Blueprints](/docs/blueprints/): A library of patterns and examples that you can apply in your own projects.
 * [Databases & Storage](/docs/database-storage-guides/): Options for persistent data storage on Fly.io.
 * [Fly Machines](/docs/machines/): Go deeper with our fast-launching VMs, and use them to run your projects and tasks.
 * [Networking](/docs/networking): How to connect to an app service, use a custom domain, and take advantage of private networking and dynamic request routing.

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -12,6 +12,8 @@ Get up and running on Fly.io:
 
 - **[Launch a demo app](/docs/hands-on/):** Walk through installing the flyctl command-line tool and creating an account, then launch a simple "hellofly" demo app.
 
+- **[Choose your language or framework](/docs/getting-started/get-started-by-framework/):** Get started on Fly.io with the tech _you_ love.
+
 - **[Fly.io essentials](/docs/getting-started/essentials):** A primer on Fly Machines and Fly Launch, plus the Fly.io glossary. It's all here.
 
 <figure>

--- a/getting-started/launch-demo.html.markerb
+++ b/getting-started/launch-demo.html.markerb
@@ -46,7 +46,7 @@ Sign up for an account or [sign in](#sign-in-to-your-flyio-account) to your exis
 
 Fly Launch helps you quickly deploy almost any kind of app using a Docker image. For this example, you'll use our pre-built Docker image, `flyio/hellofly:latest`, to create and deploy the demo app.
 
-Every Fly Launch app uses a [`fly.toml` config file](/docs/reference/configuration/) to tell the platform how to deploy it. Running `fly launch` to create a new app generates the `fly.toml` file, which provides some useful defaults that you can tweak through a web interface before deploying the app. When you run a command post-deploy, flyctl looks for a `fly.toml` file to get the name of the app to operate on and the config to apply during deployment.
+Every Fly Launch app uses a [`fly.toml` config file](/docs/reference/configuration/) to tell the platform how to deploy it. Running `fly launch` to create a new app generates the `fly.toml` file with some useful defaults that you can tweak through a web interface before deploying the app. When you run a command post-deploy, flyctl looks for a `fly.toml` file to get the app name and configuration.
 
 To create the demo app, run:
 
@@ -73,7 +73,7 @@ Redis:        <none>                 (not requested)
 
 Type `y` at the prompt to open the Fly Launch page, where you can make changes to your app config.
 
-For this example, you'll probably want to change the app name and maybe the [region](/docs/reference/regions/) to deploy in. App names need to be globally unique and can include only numbers, lowercase letters, and dashes.
+For this example, you'll probably want to change the app name and maybe the [region](/docs/reference/regions/) to deploy in. App names need to be globally unique.
 
 Click **Confirm Settings** to confirm and deploy the demo app.
 
@@ -133,11 +133,11 @@ app    	148e453b7d7289	1      	ord   	started	      	        2023-05-17T17:39:37
 app    	5683d311c3228e	1      	ord   	stopped	      	        2023-05-17T17:38:44Z
 ```
 
-In this example, the app has a DNS hostname of `hellofly.fly.dev`. Your app's name will, of course, be different. The app has two Machines running in the ord (Chicago) region. We recommend running at least two machines to improve availability in case of a single-host failure.
+In this example, the app has a DNS hostname of `hellofly.fly.dev`. The app has two Machines running in the ord (Chicago) region. We recommend running at least two machines to improve availability.
 
 ## 5. Visit your app
 
-You can connect to your deployed app with the `fly apps open` command, which opens a browser on the http version of the site. That http connection will automatically be upgraded to an https secured connection (when using the `fly.dev` domain) to connect to it securely.
+You can connect to your deployed app with the `fly apps open` command, which opens a browser to `https://<my-app-name>.fly.dev/` for a secure connection.
 
 You've successfully launched your first app on Fly.io!
 
@@ -147,7 +147,7 @@ For fun, add `/<your-name>` to `fly apps open` and your name will be appended to
 fly apps open /fred
 ```
 ```out
-Opening http://hellofly.fly.dev/fred
+opening https:http://hellofly.fly.dev/fred ...
 ```
 
 ## Deploy changes

--- a/getting-started/launch-demo.html.markerb
+++ b/getting-started/launch-demo.html.markerb
@@ -168,5 +168,5 @@ Check out some of the ways you can increase availability, capacity, and performa
 * Read up on [App availability and resiliency](/docs/reference/app-availability/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine count](/docs/apps/scale-count/)
-* [Automatically start and stop Machines](/docs/apps/autostart-stop/) in response to app traffic
+* [Autoscale Machines based on load or metrics](/docs/reference/autoscaling/)
 * Try out [Fly GPUs](/docs/gpus/)

--- a/getting-started/launch-demo.html.markerb
+++ b/getting-started/launch-demo.html.markerb
@@ -166,7 +166,7 @@ Check out some of the ways you can increase availability, capacity, and performa
 
 * Follow the blueprint for [extra Machines for more resilient apps](/docs/blueprints/resilient-apps-multiple-machines/)
 * Read up on [App availability and resiliency](/docs/reference/app-availability/)
+* [Autoscale Machines based on load or custom metrics](/docs/reference/autoscaling/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine count](/docs/apps/scale-count/)
-* [Autoscale Machines based on load or metrics](/docs/reference/autoscaling/)
 * Try out [Fly GPUs](/docs/gpus/)

--- a/getting-started/launch.html.markerb
+++ b/getting-started/launch.html.markerb
@@ -35,9 +35,9 @@ Check out some of the ways you can increase availability, capacity, and performa
 
 * Follow the blueprint for [extra Machines for more resilient apps](/docs/blueprints/resilient-apps-multiple-machines/)
 * Read up on [App availability and resiliency](/docs/reference/app-availability/)
+* [Autoscale Machines based on load or custom metrics](/docs/reference/autoscaling/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine count](/docs/apps/scale-count/)
-* [Autoscale Machines based on load or metrics](/docs/reference/autoscaling/)
 * Try out [Fly GPUs](/docs/gpus/)
 
 

--- a/getting-started/launch.html.markerb
+++ b/getting-started/launch.html.markerb
@@ -1,12 +1,13 @@
 ---
 title: "Quickstart: Launch your app"
 layout: docs
-sitemap: false
 nav: firecracker
 toc: false
 ---
 
-Welcome to Fly Launch. To deploy your app on Fly.io for the first time:
+Welcome to Fly Launch. Fly Launch works with a Dockerfile or scans and configures apps for most common languages and frameworks. 
+
+To deploy your app on Fly.io for the first time:
 
 <div class="important">
 1. [Install flyctl](/docs/flyctl/install/) &ndash; the [open-source](https://github.com/superfly/flyctl+external) Fly.io CLI.
@@ -18,17 +19,11 @@ Welcome to Fly Launch. To deploy your app on Fly.io for the first time:
 4. If prompted, run `fly deploy` to deploy your new app (or to redeploy after changes!).
 </div>
 
-Fly Launch knows what to do with a [Dockerfile](/docs/languages-and-frameworks/dockerfile/)&mdash;so you can use the tech _you_ love&mdash;and also configures and deploys the following kinds of apps automatically:
-
-<%= partial "/docs/languages-and-frameworks/partials/scanner_guides" %>
-
-See [Launch a new app](/docs/apps/launch/) to learn more about what `fly launch` does.
-
 ## Next steps
 
 1. Run `fly status` to show the status of your app and Machines.
 2. Run `fly apps open` to open your app in your browser.
-3. Learn [the essentials](/docs/getting-started/essentials/) about Fly Launch and Machines.
+3. Learn [the essentials](/docs/getting-started/essentials/) about Fly Launch and Fly Machines.
 
 <figure class="w:full mt:6">
   <img src="/static/images/speedrun-next-steps.webp" srcset="/static/images/speedrun-next-steps@2x.webp 2x" alt="Illustration by Annie Ruygt of Frankie the Fly.io hot air balloon character pointing at a set of stairs">

--- a/getting-started/launch.html.markerb
+++ b/getting-started/launch.html.markerb
@@ -37,7 +37,7 @@ Check out some of the ways you can increase availability, capacity, and performa
 * Read up on [App availability and resiliency](/docs/reference/app-availability/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine count](/docs/apps/scale-count/)
-* [Automatically start and stop Machines](/docs/apps/autostart-stop/) in response to app traffic
+* [Autoscale Machines based on load or metrics](/docs/reference/autoscaling/)
 * Try out [Fly GPUs](/docs/gpus/)
 
 

--- a/languages-and-frameworks/partials/_scanner_guides.html.erb
+++ b/languages-and-frameworks/partials/_scanner_guides.html.erb
@@ -30,7 +30,7 @@
     <a href="/docs/js/frameworks/nuxtjs/">Nuxt</a>
   </li>
   <li>
-    <a href="/docs/languages-and-frameworks/python/">Python</a>
+    <a href="/docs/python/">Python</a>
   </li>
   <li>
     <a href="/docs/rails/getting-started/">Rails</a>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -9,6 +9,7 @@
       links: [
         { text: "Quickstart: Launch your app", path: "/docs/getting-started/launch/" },
         { text: "Launch a Demo App", path: "/docs/getting-started/launch-demo" },
+        { text: "Choose a language or framework", path: "/docs/getting-started/get-started-by-framework/" },
         { text: "Fly.io Essentials", path: "/docs/getting-started/essentials/" },
         { text: "Troubleshooting Deployments", path: "/docs/getting-started/troubleshooting/" }
       ]
@@ -26,12 +27,14 @@
       path: "/docs/languages-and-frameworks/",
       open: false,
       links: [
-        { text: "Run an Elixir App", path: "/docs/elixir/getting-started" },
-        { text: "Run a Rails App", path: "/docs/rails/getting-started/" },
-        { text: "Run a Laravel App", path: "/docs/laravel/" },
-        { text: "Run a Django App", path: "/docs/django/getting-started/" },
-        { text: "Run a JavaScript App", path: "/docs/js/" },
-        { text: "Run a Rust App", path: "/docs/rust/" }
+        { text: "Elixir", path: "/docs/elixir/" },
+        { text: "Rails", path: "/docs/rails/getting-started/" },
+        { text: "Laravel", path: "/docs/laravel/" },
+        { text: "Django", path: "/docs/django/getting-started/" },
+        { text: "JavaScript", path: "/docs/js/" },
+        { text: "Rust", path: "/docs/rust/" },
+        { text: "Python", path: "/docs/python/" },
+        { text: "More...", path: "/docs/languages-and-frameworks/" }
       ]
     },
     {

--- a/reference/autoscaling.html.md
+++ b/reference/autoscaling.html.md
@@ -12,8 +12,12 @@ Autoscaling adjusts the number of running or created Fly Machines dynamically. W
 
 ## Autostart/autostop Machines
 
-The Fly Proxy autostart/autostop feature starts and stops Machines based on load; Machines are never created or deleted. You create a "pool" of Machines in one or more regions and the Fly Proxy starts and stops them as needed. For a comprehensive overview of how it works, see [Automatically stop and start Machines](https://fly.io/docs/apps/autostart-stop/).
+The Fly Proxy autostart/autostop feature starts and stops Machines based on load; Machines are never created or deleted. You create a "pool" of Machines in one or more regions and the Fly Proxy starts and stops them as needed. 
+
+For a comprehensive overview of how it works, see [Automatically stop and start Machines](https://fly.io/docs/apps/autostart-stop/).
 
 ## Metrics-based autoscaling
 
-The metrics-based autoscaler scales your application based on any metric. You deploy the autoscaler as an app in your organization. It polls collected metrics and computes the number of machines needed based on the metric you define. The autoscaler can create and delete machines or stop and start existing Machines. To learn how to deploy and configure the autoscaler, see [Autoscale based on metrics](/docs/apps/autoscale-by-metric/).
+The metrics-based autoscaler scales your application based on any metric. You deploy the autoscaler as an app in your organization. It polls collected metrics and computes the number of machines needed based on the metric you define. The autoscaler can create and delete machines or stop and start existing Machines. 
+
+To learn how to deploy and configure the autoscaler, see [Autoscale based on metrics](/docs/apps/autoscale-by-metric/).


### PR DESCRIPTION
### Summary of changes

- move the full list of languages and frameworks from the Quickstart to a new page "Get started with your language or framework"
- add a "Choose a language or framework" entry in the Getting started nav that links to the new page
- keep the Languages and Frameworks top-level entry in the nav, but change the sub-levels from "Run a Foo app" to just "Foo" and have them link to the main framework section page rather than getting started. Add an entry for "More...".

### Preview

### Related Fly.io community and GitHub links

### Notes
- having the list of languages and frameworks in the quickstart didn't make sense anymore, since users would have already run `fly launch` before reading the list
