### PR TITLE
kubernetes/fks-quickstart: document logs being per namespace and kubectl run not working

### DIFF
--- a/kubernetes/fks-quickstart.html.markerb
+++ b/kubernetes/fks-quickstart.html.markerb
@@ -126,6 +126,7 @@ Configuring firecracker
 - Gateway API
 - Daemon sets
 - EmptyDir volumes
+- Interactive pods (`kubectl run --interactive --tty`)
 
 On container specs, we don't support the following fields:
 
@@ -146,6 +147,10 @@ On container specs, we don't support the following fields:
 - `terminationMessagePolicy`
 - `imagePullPolicy`
 - `securityContext`
+
+## Other caveats
+
+- Right now we don't getting logs from a single pod. If you try to get logs from a single pod, you'll get the logs from every pod in the namespace.
 
 ## Related topics
 


### PR DESCRIPTION
### Summary of changes

Document some caveats that I discovered while smoke-testing FKS for a content prototype.

### Related Fly.io community and GitHub links

https://github.com/superfly/flyio-virtual-kubelet/issues/104