### PR TITLE
Blueprint: Staging and production isolation

### DIFF
--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -11,9 +11,8 @@ All Fly.io accounts start with a "personal" organization. You can create as many
 Before you create a new organization, here's what you need to know:
 
 - All organizations have their own [private network](/docs/networking/private-networking/) by default. An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
-- As mentioned, we bill organizations separately. You'll need to enter a payment method and you'll be invoiced per organization at the end of each billing cycle.
-- Since they're billed separately, each organization will be on its own [plan](https://fly.io/plans).
-- You'll invite or remove members in each organization separately.
+- We bill organizations separately and each org has its own [plan](https://fly.io/plans). When you create a new org, you need to enter a payment method and choose a plan. You'll be invoiced per organization at the end of each billing cycle.
+- You invite or remove members in each organization separately.
 
 Adjust the pattern to fit your needs. Here's an example:
 
@@ -23,7 +22,10 @@ Adjust the pattern to fit your needs. Here's an example:
 
 ## Create organizations
 
-You can create new organizations and invite members from the [dashboard]((https://fly.io/dashboard/)) or using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
+Create a new org from the [dashboard]((https://fly.io/dashboard/)): Select **Create new organization** from the **Organization** dropdown. Then switch to that org and view members or send invitation from the **Team** section.
+
+You can also create new organizations and invite or remove members using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
+
 
 ## Other kinds of isolation and access control
 

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -2,17 +2,18 @@
 title: Staging and production isolation
 layout: docs
 nav: firecracker
+redirect_from: /docs/going-to-production/the-basics/production-staging-isolation/
 ---
 
-You have your own good reasons for wanting to isolate your production environment from your test or staging environments. When you want to limit access to production to the smallest possible group, you can get dependable isolation by using multiple organizations. Organizations are isolated from one another at a low level by our private networking architecture.
+You have your own good reasons for wanting to isolate your production environment from your test or staging environments. When you want to limit access to production to the smallest possible group, you can get dependable isolation by using multiple organizations. Organization access is invitation-only and orgs are isolated from one another at a low level by our private networking architecture: every organization has its own [private network](/docs/networking/private-networking/) by default.
 
 All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but also for different projects or clients.
 
 Before you create a new organization, here's what you need to know:
 
-- All organizations have their own [private network](/docs/networking/private-networking/) by default. An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
-- We bill organizations separately and each org has its own [plan](https://fly.io/plans). When you create a new org, you need to enter a payment method and choose a plan. You'll be invoiced per organization at the end of each billing cycle.
+- We bill organizations separately and each org has its own [plan](https://fly.io/plans). When you create the new org, you need to enter a payment method and choose a plan. You'll be invoiced per organization at the end of each billing cycle.
 - You invite or remove members in each organization separately.
+- An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
 
 Adjust the pattern to fit your needs. Here's an example:
 
@@ -20,12 +21,21 @@ Adjust the pattern to fit your needs. Here's an example:
 - staging org: `<project>-staging`, for development and testing
 - production org: `<project>-production`, for your production app
 
-## Create organizations
+## Work with multiple organizations
 
-Create a new org from the [dashboard]((https://fly.io/dashboard/)): Select **Create new organization** from the **Organization** dropdown. Then switch to that org and view members or send invitation from the **Team** section.
+It's best if you use one Fly.io account to manage all your organizations, so you can access them without logging in and out. App names are unique across the Fly.io platform, so your staging and production apps will have different names and their own `fly.toml` files for configuration.
 
-You can also create new organizations and invite or remove members using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
+### Manage organizations in your dashboard
 
+To create a new org from the [dashboard]((https://fly.io/dashboard/)), select **Create new organization** from the **Organization** dropdown.
+
+To view or send invites to members, use the **Organization** dropdown to choose an org, then go to **Team**.
+
+### Manage organizations with flyctl
+
+You can create new organizations and invite or remove members using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
+
+When you have more than one org, flyctl prompts you to choose an organization when needed. You can run commands on a specific app in any org using the `--app` option if you aren't in the app's project source directory in your terminal.
 
 ## Other kinds of isolation and access control
 

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -8,6 +8,8 @@ You have your own good reasons for wanting to isolate your production environmen
 
 All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but also for different projects or clients.
 
+
+
 Before you create a new organization, here's what you need to know:
 
 - All organizations have their own [private network](/docs/networking/private-networking/) by default. An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
@@ -18,10 +20,16 @@ Before you create a new organization, here's what you need to know:
 Adjust the pattern to fit your needs. Here's an example:
 
 - personal org: the org you started with, and the one you keep for personal projects
-- staging org: <project>-staging, for development and testing
-- production org: <project>-production, for your production app
+- staging org: `<project>-staging`, for development and testing
+- production org: `<project>-production`, for your production app
 
 ## Create organizations
 
 You can create new organizations and invite members from the [dashboard]((https://fly.io/dashboard/)) or using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
 
+## Other kinds of isolation
+
+When you only need app isolation or user or 3rd-party access control:
+
+- Custom networks for isolating apps from one another in the same organization.
+- Deploy and organization tokens to limit access to apps or orgs.

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -15,11 +15,11 @@ Before you create a new organization, here's what you need to know:
 - You invite or remove members in each organization separately.
 - An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
 
-Adjust the pattern to fit your needs. Here's an example:
+Adjust the pattern to fit your needs. For example:
 
-- personal org: the org you started with, and the one you keep for personal projects
-- staging org: `<project>-staging`, for development and testing
-- production org: `<project>-production`, for your production app
+- personal organization: the org you started with, and the one you keep for personal projects
+- staging organization: `<project>-staging` used for development and testing
+- production organization: `<project>-production` used for your production app
 
 ## Work with multiple organizations
 
@@ -33,9 +33,9 @@ To view or send invites to members, use the **Organization** dropdown to choose 
 
 ### Manage organizations with flyctl
 
-You can create new organizations and invite or remove members using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
+To create new organizations and invite or remove members, use [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
 
-When you have more than one org, flyctl prompts you to choose an organization when needed. You can run commands on a specific app in any org using the `--app` option if you aren't in the app's project source directory in your terminal.
+When you have more than one org, flyctl prompts you to choose an organization when required. You can run commands on a specific app in any org using the `--app` option if you aren't in the app's project source directory in your terminal.
 
 ## Other kinds of isolation and access control
 

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -5,7 +5,7 @@ nav: firecracker
 redirect_from: /docs/going-to-production/the-basics/production-staging-isolation/
 ---
 
-You have your own good reasons for wanting to isolate your production environment from your test or staging environments. When you want to limit access to production to the smallest possible group, you can get dependable isolation by using multiple organizations. Organization access is invitation-only and orgs are isolated from one another at a low level by our private networking architecture: every organization has its own [private network](/docs/networking/private-networking/) by default.
+You want to isolate your production environment from your test or staging environments by limiting production access to the smallest possible group. You can get dependable isolation by using multiple organizations. Organization access is invitation-only and orgs are isolated from one another at a low level by our private networking architecture: every organization has its own [private network](/docs/networking/private-networking/) by default.
 
 All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but also for different projects or clients.
 

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -1,0 +1,28 @@
+---
+title: Staging and production isolation
+layout: docs
+nav: firecracker
+---
+
+You have your own good reasons for wanting to isolate your production environment from your test or staging environments. You want to limit access to production to the smallest possible group and make sure that untested or unstable features don't make their way into your production app. You can get dependable isolation by using multiple organizations.
+
+Organizations are isolated from one another at a low level by our private networking architecture. Organizations are administrative entities that enable you to manage billing separately, and add members to share app development environments with. 
+
+All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but for different projects or clients too.
+
+Before you create a new organization, here's what you need to know:
+
+- All organizations have their own [private network](/docs/networking/private-networking/) by default. An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
+- As mentioned, we bill organizations separately. You'll need to enter a payment method and you'll be invoiced per organization at the end of each billing cycle.
+- Since they're billed separately, each organization will be on its own plan.
+- You'll invite and manage members to each organization separately.
+
+Adjust the pattern to fit your needs. Here's an example:
+
+- personal org: the one you started with and keep for personal projects
+- staging org: <project>-staging, for development and testing
+- production org: <project>-production, for your production app
+
+## Create organizations
+
+You can create new organizations and invite members in the [dashboard]((https://fly.io/dashboard/)) or using `fly orgs` flyctl commands.

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -4,25 +4,24 @@ layout: docs
 nav: firecracker
 ---
 
-You have your own good reasons for wanting to isolate your production environment from your test or staging environments. You want to limit access to production to the smallest possible group and make sure that untested or unstable features don't make their way into your production app. You can get dependable isolation by using multiple organizations.
+You have your own good reasons for wanting to isolate your production environment from your test or staging environments. When you want to limit access to production to the smallest possible group, you can get dependable isolation by using multiple organizations. Organizations are isolated from one another at a low level by our private networking architecture.
 
-Organizations are isolated from one another at a low level by our private networking architecture. Organizations are administrative entities that enable you to manage billing separately, and add members to share app development environments with. 
-
-All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but for different projects or clients too.
+All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but also for different projects or clients.
 
 Before you create a new organization, here's what you need to know:
 
 - All organizations have their own [private network](/docs/networking/private-networking/) by default. An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.
 - As mentioned, we bill organizations separately. You'll need to enter a payment method and you'll be invoiced per organization at the end of each billing cycle.
-- Since they're billed separately, each organization will be on its own plan.
-- You'll invite and manage members to each organization separately.
+- Since they're billed separately, each organization will be on its own [plan](https://fly.io/plans).
+- You'll invite or remove members in each organization separately.
 
 Adjust the pattern to fit your needs. Here's an example:
 
-- personal org: the one you started with and keep for personal projects
+- personal org: the org you started with, and the one you keep for personal projects
 - staging org: <project>-staging, for development and testing
 - production org: <project>-production, for your production app
 
 ## Create organizations
 
-You can create new organizations and invite members in the [dashboard]((https://fly.io/dashboard/)) or using `fly orgs` flyctl commands.
+You can create new organizations and invite members from the [dashboard]((https://fly.io/dashboard/)) or using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
+

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -8,8 +8,6 @@ You have your own good reasons for wanting to isolate your production environmen
 
 All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but also for different projects or clients.
 
-
-
 Before you create a new organization, here's what you need to know:
 
 - All organizations have their own [private network](/docs/networking/private-networking/) by default. An organization can have multiple apps and those apps can communicate with each other securely over the org's private network.

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -27,9 +27,7 @@ Adjust the pattern to fit your needs. Here's an example:
 
 You can create new organizations and invite members from the [dashboard]((https://fly.io/dashboard/)) or using [`fly orgs` flyctl commands](/docs/flyctl/orgs/).
 
-## Other kinds of isolation
+## Other kinds of isolation and access control
 
-When you only need app isolation or user or 3rd-party access control:
-
-- Custom networks for isolating apps from one another in the same organization.
-- Deploy and organization tokens to limit access to apps or orgs.
+- When you only need app isolation within an org, you can use [custom private networks](https://community.fly.io/t/fly-ssh-with-custom-network/19296) to isolate apps from one another by creating an app with `fly apps create` and the `--network` option. More on this feature coming soon.
+- When you want user or 3rd-party access control, you can use [deploy](https://community.fly.io/t/deploy-tokens/11895) and [org-scoped tokens](https://community.fly.io/t/org-scoped-tokens/13194) to limit access to apps or orgs.


### PR DESCRIPTION
### Summary of changes

Add a doc that explains when you'd want to use organizations to isolate staging and production environments.

### Preview

https://aa-docs.fly.dev/docs/blueprints/staging-prod-isolation/

### Related Fly.io community and GitHub links

### Notes

