### PR TITLE
Update about index and healthcare app links

### DIFF
--- a/about/healthcare.html.markerb
+++ b/about/healthcare.html.markerb
@@ -120,4 +120,8 @@ Anything stored persistently in a Fly.io volume is backed up on a regular schedu
 
 ## More info
 
-You can check our [community](https://community.fly.io) or [our documentation](https://fly.io/docs/) for answers to your questions. If you can't find what you're looking for want to know more, [get in touch](mailto:sales@fly.io)!
+Our blueprint for [Going to production with healthcare apps](/docs/blueprints/going-to-production-with-healthcare-apps/) runs a developer or operations engineer through the process of evaluating Fly.io’s security for HIPAA healthcare apps, launching a pilot application, signing a BAA, and deploying to production.
+
+You can also check our [community](https://community.fly.io) for answers to your questions.
+
+If you can't find what you're looking for or want to know more, [get in touch](mailto:sales@fly.io).

--- a/about/index.html.markerb
+++ b/about/index.html.markerb
@@ -1,18 +1,19 @@
 ---
-title: "About Fly"
+title: "About Fly.io"
 layout: docs
 sitemap: true
 toc: false
 nav: firecracker
 ---
 
-This section is all about the things you also need to know about Fly as a user of the service:
+More details about using and working with the Fly.io platform.
 
-* [_Pricing_](/docs/about/pricing/) : All about how the Fly service is priced.
-* [_Healthcare_](/docs/about/healthcare/) : Controls relevant to running healthcare apps on Fly.
-* [_Support_](/docs/about/support) : Who to contact and where to go when you need Fly support.
-* [_Security_](/docs/about/security) : All about how we handle security and security issues at Fly.
+* [_Pricing_](/docs/about/pricing/) : Pricing for compute, storage, and all the FLy.io platform services.
+* [_Billing_](/docs/about/pricing/) : How billing works on Fly.io.
+* [_Healthcare_](/docs/about/healthcare/) : Controls relevant to running healthcare apps on Fly.io.
+* [_Support_](/docs/about/support) : Who to contact and where to go when you need Fly.io support.
+* [_Extensions program_](/docs/about/extensions/) and [_Extensions API_](/docs/reference/extensions_api/): Learn about becoming an extensions partner.
 * [_Open Source_](/docs/about/open-source/) : How we help those OSS projects that help us.
 * [_Using Our Brand_](/docs/about/brand/) : Assets and guidelines to help represent our brand.
-* [_Privacy Policy_](/legal/privacy-policy/) : Fly's policy on privacy, detailed here.
-* [_Terms of Service_](/legal/terms-of-service) : The legal terms of service for Fly users.
+* [_Privacy Policy_](/legal/privacy-policy/) : Our policy on privacy, detailed here.
+* [_Terms of Service_](/legal/terms-of-service) : The legal terms of service for Fly.io users.


### PR DESCRIPTION
### Summary of changes

- updated the About index page with accurate content list and company naming
- added a link from healthcare doc to healthcare blueprint

### Preview

### Related Fly.io community and GitHub links

### Notes

