### PR TITLE
Update Dockerfile launch doc

### DIFF
--- a/languages-and-frameworks/dockerfile.html.markerb
+++ b/languages-and-frameworks/dockerfile.html.markerb
@@ -1,15 +1,19 @@
 ---
-title: Deploy via Dockerfile
+title: Deploy with a Dockerfile
 layout: language-and-framework-docs
 redirect_from: /docs/getting-started/dockerfile/
 ---
 
-You already have a project wrapped up in a [docker container](https://docs.docker.com/engine/reference/builder/)? Great! Just deploy that!
+Fly Launch can deploy your app from a [Dockerfile](https://docs.docker.com/reference/dockerfile/+external).
 
-The `fly launch` command detects your Dockerfile, builds it, and then deploys your app.  Need some extra config? No sweat, we've got you covered.
+The `fly launch` command detects your Dockerfile, builds it, and then deploys your app. Need some extra config? No sweat, we've got you covered.
+
+## Create and configure your app
+
+Run `fly launch` from your project's source directory.
 
 <div class="important icon">
-If you want to configure more than the basic settings, things like secrets or environment variables for example, then run `fly launch --no-deploy` so that you can [edit the `fly.toml` file](#more-config) before the first deployment.
+If you want to configure more than the basic settings, things like secrets or environment variables for example, run `fly launch --no-deploy` so that you can [edit the `fly.toml` file](#more-config) before the first deployment.
 </div>
 
 ```cmd
@@ -43,9 +47,9 @@ Type `n` if you're happy with the defaults listed, otherwise type `y` to open th
 
 After you click **Confirm Settings**, Fly Launch creates your app, generates a `fly.toml` file for your project with the settings, and then deploys the app.
 
-## _More config!_
+### Add environment variables and secrets
 
-Most Dockerfiles expect some configuration settings through `ENV`. The generated `fly.toml` file has a place for you to add your custom `ENV` settings. It's the `[env]` block.
+Most Dockerfiles expect some configuration settings through `ENV`. Add your custom `ENV` settings to the `[env]` section of the generated `fly.toml` file. For example:
 
 ```toml
 [env]
@@ -55,7 +59,7 @@ Most Dockerfiles expect some configuration settings through `ENV`. The generated
 
 Add the values your Dockerfile requires.
 
-Sometimes you have secrets that shouldn't be checked in to `git` or shared publicly. For those settings, you can set them using [`fly secrets`](https://fly.io/docs/reference/secrets/#setting-secrets).
+Sometimes you have secrets that shouldn't be checked in to `git` or shared publicly. You can set secrets using the [`fly secrets`](/docs/reference/secrets/#set-secrets) command. For example:
 
 ```cmd
 flyctl secrets set MY_SECRET=romance
@@ -64,7 +68,7 @@ flyctl secrets set MY_SECRET=romance
 Secrets are staged for the first deployment
 ```
 
-You can list the secrets you've already set using `fly secrets list`
+You can list the secrets you've already set using `fly secrets list`. For example:
 
 ```cmd
 fly secrets list
@@ -76,7 +80,7 @@ MY_SECRET b9e37b7b239ee4aefc75352fe3fa6dc6 1m20s ago
 
 The values aren't displayed, since they're secret!
 
-## _Deploy your app_
+### Deploy your app
 
 If you didn't deploy the new app, or you've made changes and want to redeploy, then you can do that now.
 
@@ -114,15 +118,24 @@ Visit your newly deployed app at https://my-app-name.fly.dev/
 
 By default, `fly deploy` builds the image using a remote builder. If you have Docker running locally and want to build locally, then run `fly deploy --local-only`. After the image is built, the app gets deployed.
 
-## _Open your app_
+### Open your app
 
 Run `fly apps open`, or just go to the URL specified in the output, to open your deployed app in a browser.
 
-You're off and running!
+## Stateful apps
 
-## _Taking it further_
+Lots of apps have some state that they want to keep. Learn more about the options for [databases and storage](docs/database-storage-guides/) on Fly.io.
 
-Lots of apps have some state that they want to keep. Here are a couple resources to check out for ways to do that.
+## Grow and scale
 
-- **[Persistent Volumes:](https://fly.io/docs/volumes/)** You can create [persistent volumes](https://fly.io/docs/volumes/) for reading and writing data that changes but isn't blown away when you deploy again.
-- **[Postgres Database:](https://fly.io/docs/reference/postgres/#about-postgres-on-fly)** Deploy a [Fly Postgres Database](https://fly.io/docs/reference/postgres/#about-postgres-on-fly). It automatically creates a `DATABASE_URL` ENV when you attach it to your app.
+Check out some of the ways you can increase availability, capacity, and performance with Fly.io:
+
+* Follow the blueprint for [extra Machines for more resilient apps](/docs/blueprints/resilient-apps-multiple-machines/)
+* Read up on [App availability and resiliency](/docs/reference/app-availability/)
+* [Autoscale Machines based on load or custom metrics](/docs/reference/autoscaling/)
+* [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
+* [Scale Machine count](/docs/apps/scale-count/)
+* Try out [Fly GPUs](/docs/gpus/)
+
+
+If you have questions, need help, or want to talk about what you're building, visit our [community forum](https://community.fly.io).


### PR DESCRIPTION
### Summary of changes

- updated this doc to be a bit easier to read and parse (simpler language, heading changes)
- added links at the bottom for grow and scale similar to what's at the bottom of the quickstart and launch a demo
- changed the links to volumes and postgres to link directly to the databases and storage landing page instead

### Preview

### Related Fly.io community and GitHub links

### Notes

