### PR TITLE
Move Deploy tokens under security

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -159,7 +159,8 @@
       open: false,
       links: [
         { text: "SSO for organizations", path: "/docs/security/sso/" },
-        { text: "TLS termination", path: "/docs/security/tls-termination/" },        
+        { text: "TLS termination", path: "/docs/security/tls-termination/" },
+        { text: "Deploy Tokens", path: "/docs/reference/deploy-tokens/" },      
         { text: "Security practices and compliance", path: "/docs/security/security-at-fly-io/" },
         { text: "App Security by Arcjet", path: "/docs/reference/arcjet/" }
       ]
@@ -178,7 +179,6 @@
         { text: "Fine-tune and Benchmark", path: "/docs/reference/fine-tune-apps/" },
         { text: "Builders", path: "/docs/reference/builders/" },
         { text: "Concurrency Settings", path: "/docs/reference/concurrency/" },
-        { text: "Deploy Tokens", path: "/docs/reference/deploy-tokens/" },
         { text: "Sentry Error Tracking", path: "/docs/reference/sentry/" },
         { text: "Fly Launch", path: "/docs/reference/fly-launch/" },
         { text: "Load Balancing", path: "/docs/reference/load-balancing/" },

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -160,7 +160,7 @@
       links: [
         { text: "SSO for organizations", path: "/docs/security/sso/" },
         { text: "TLS termination", path: "/docs/security/tls-termination/" },
-        { text: "Deploy Tokens", path: "/docs/reference/deploy-tokens/" },      
+        { text: "Deploy Tokens", path: "/docs/security/deploy-tokens/" },      
         { text: "Security practices and compliance", path: "/docs/security/security-at-fly-io/" },
         { text: "App Security by Arcjet", path: "/docs/reference/arcjet/" }
       ]

--- a/security/deploy-tokens.html.md
+++ b/security/deploy-tokens.html.md
@@ -1,8 +1,8 @@
 ---
 title: Deploy Tokens
 layout: docs
-sitemap: false
 nav: firecracker
+redirect_from: /docs/reference/deploy-tokens/
 ---
 
 Whether you're [deploying your app with GitHub Actions](/docs/app-guides/continuous-deployment-with-github-actions/) or running your own CD service, it's best to avoid configuring deployment infrastructure with all-powerful tokens. Deploy tokens can be used with [flyctl](/docs/flyctl/) to manage a single application and its resources.

--- a/security/index.html.markerb
+++ b/security/index.html.markerb
@@ -1,5 +1,5 @@
 ---
-title: "Security"
+title: Security
 layout: docs
 nav: firecracker
 toc: false
@@ -9,8 +9,9 @@ Securing a public cloud platform like Fly.io is a hard problem, and we take it s
 
 ## Fly.io platform security
 
-- **[Single sign-on (SSO) for organizations](/docs/security/sso/):** Set up org-wide SSO with Google or GitHub.
+- **[SSO for organizations](/docs/security/sso/):** Set up org-wide Single Sign-on with Google or GitHub.
 - **[Built-in TLS termination](/docs/security/tls-termination/):** You get TLS termination by default for your web apps.
+- **[Deploy tokens](/docs/security/deploy-tokens/):** Create tokens to manage and deploy individual apps.
 - **[Fly.io security practices and compliance](/docs/security/security-at-fly-io/):** Learn about our security practices for the Fly.io platform.
 
 ## Security extensions


### PR DESCRIPTION
### Summary of changes

move the existing deploy tokens file from reference to security

### Preview

### Related Fly.io community and GitHub links

### Notes

