### PR TITLE
Add city and country names to region selection dropdown.

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -107,7 +107,7 @@ We charge for started and stopped Machines differently. Attached GPUs are charge
   <label for="region-select">Region: </label>
   <select id="region-select" class="rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
     <% data.pricing.regions.each do |r| %>
-      <option value="<%= r.code %>"><%= r.code %></option>
+      <option value="<%= r.code %>"><%= r.city %>, <%= r.country %> (<%= r.code %>)</option>
     <% end %>
   </select>
 </p>


### PR DESCRIPTION
### Summary of changes

The region select currently just has region codes, e.g. `iad`, `eze`, etc.

This adds the city/country to the option, e.g. `Ashburn, Virginia (US) (iad)`.

### Preview

<img width="834" alt="image" src="https://github.com/superfly/docs/assets/8368500/e34899c0-70c0-4278-ba2e-9f9ec5462eec">


### Related Fly.io community and GitHub links

### Notes

