### PR TITLE
Fix links in autostart-internal-apps blueprint

### DIFF
--- a/blueprints/autostart-internal-apps.html.md
+++ b/blueprints/autostart-internal-apps.html.md
@@ -103,7 +103,7 @@ Here's an example `fly.toml` snippet:
 **Important:** Set `force_https = false` since Flycast only works over HTTP.  HTTPS isn't necessary because all your private network traffic goes through encrypted WireGuard tunnels.
 </div>
 
-Learn more about [Fly Launch configuration](https://docs/reference/configuration/) and the [autostart and autostop](https:///docs/apps/autostart-stop/) feature.
+Learn more about [Fly Launch configuration](/docs/reference/configuration/) and the [autostart and autostop](/docs/apps/autostart-stop/) feature.
 
 ### Make sure your app binds to `0.0.0.0:<port>`
 


### PR DESCRIPTION
### Summary of changes

A small fix for two links.

### Preview

### Related Fly.io community and GitHub links

### Notes