### PR TITLE
Regions: add edges

### DIFF
--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -28,7 +28,6 @@ You can host your apps in any of the following regions.
 | cdg       | Paris, France                 | ✓           |                                                       |
 | den       | Denver, Colorado (US)         |             |                                                       |
 | dfw       | Dallas, Texas (US)            | ✓           |                                                       |
-| dxb       | Dubai, United Arab Emirates   |             |                                                       |
 | ewr       | Secaucus, NJ (US)             |             |                                                       |
 | eze       | Ezeiza, Argentina             |             |                                                       |
 | fra       | Frankfurt, Germany            | ✓           | ✓                                                     |
@@ -37,12 +36,10 @@ You can host your apps in any of the following regions.
 | gru       | Sao Paulo, Brazil             |             |                                                       |
 | hkg       | Hong Kong, Hong Kong          | ✓           |                                                       |
 | iad       | Ashburn, Virginia (US)        | ✓           |                                                       |
-| ist       | Istanbul, Turkey              |             |                                                       |
 | jnb       | Johannesburg, South Africa    |             |                                                       |
 | lax       | Los Angeles, California (US)  | ✓           |                                                       |
 | lhr       | London, United Kingdom        | ✓           |                                                       |
 | mad       | Madrid, Spain                 |             |                                                       |
-| mel       | Melbourne, Australia          |             |                                                       |
 | mia       | Miami, Florida (US)           |             |                                                       |
 | nrt       | Tokyo, Japan                  | ✓           |                                                       |
 | ord       | Chicago, Illinois (US)        | ✓           |                                                       |

--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -4,7 +4,7 @@ layout: docs
 nav: firecracker
 ---
 
-Fly.io runs applications physically close to users: in datacenters around the world, on servers we run ourselves. You can currently deploy your apps in 35 regions, connected to a global Anycast network that makes sure your users hit our nearest server, whether they’re in Tokyo, São Paulo, or Amsterdam.
+Fly.io runs applications physically close to users: in datacenters around the world, on servers we run ourselves. You can currently deploy your apps in 38 regions, connected to a global Anycast network that makes sure your users hit our nearest server, whether they’re in Tokyo, São Paulo, or Amsterdam.
 
 <div class="callout">
 Run <code>fly platform regions</code> to get a list of regions.
@@ -14,52 +14,66 @@ Run <code>fly platform regions</code> to get a list of regions.
 
 ## Fly.io Regions
 
-| Region ID | Region Location               | Gateway     | [Launch Plan or Higher](https://fly.io/plans)         | Edge - No Deploys |
-|-----------|-------------------------------|-------------|-------------------------------------------------------|-------------------|
-| ams       | Amsterdam, Netherlands        | ✓           |                                                       |                  |
-| arn       | Stockholm, Sweden             |             |                                                       |                  |
-| atl       | Atlanta, Georgia (US)         |             |                                                       |                  |
-| bog       | Bogotá, Colombia              |             |                                                       |                  |
-| bom       | Mumbai, India                 |             | ✓                                                     |                  |
-| bos       | Boston, Massachusetts (US)    |             |                                                       |                  |
-| cdg       | Paris, France                 | ✓           |                                                       |                  |
-| den       | Denver, Colorado (US)         |             |                                                       |                  |
-| dfw       | Dallas, Texas (US)            | ✓           |                                                       |                  |
-| dxb       | Dubai, United Arab Emirates   |             |                                                       | ✓                |
-| ewr       | Secaucus, NJ (US)             |             |                                                       |                  |
-| eze       | Ezeiza, Argentina             |             |                                                       |                  |
-| fra       | Frankfurt, Germany            | ✓           | ✓                                                     |                  |
-| gdl       | Guadalajara, Mexico           |             |                                                       |                  |
-| gig       | Rio de Janeiro, Brazil        |             |                                                       |                  |
-| gru       | Sao Paulo, Brazil             |             |                                                       |                  |
-| hkg       | Hong Kong, Hong Kong          | ✓           |                                                       |                  |
-| iad       | Ashburn, Virginia (US)        | ✓           |                                                       |                  |
-| ist       | Istanbul, Turkey              |             |                                                       | ✓                |
-| jnb       | Johannesburg, South Africa    |             |                                                       |                  |
-| lax       | Los Angeles, California (US)  | ✓           |                                                       |                  |
-| lhr       | London, United Kingdom        | ✓           |                                                       |                  |
-| mad       | Madrid, Spain                 |             |                                                       |                  |
-| mel       | Melbourne, Australia          |             |                                                       |  ✓               |
-| mia       | Miami, Florida (US)           |             |                                                       |                  |
-| nrt       | Tokyo, Japan                  | ✓           |                                                       |                  |
-| ord       | Chicago, Illinois (US)        | ✓           |                                                       |                  |
-| otp       | Bucharest, Romania            |             |                                                       |                  |
-| phx       | Phoenix, Arizona (US)         |             |                                                       |                  |
-| qro       | Querétaro, Mexico             |             |                                                       |                  |
-| scl       | Santiago, Chile               | ✓           |                                                       |                  |
-| sea       | Seattle, Washington (US)      | ✓           |                                                       |                  |
-| sin       | Singapore, Singapore          | ✓           |                                                       |                  |
-| sjc       | San Jose, California (US)     | ✓           |                                                       |                  |
-| syd       | Sydney, Australia             | ✓           |                                                       |                  |
-| waw       | Warsaw, Poland                |             |                                                       |                  |
-| yul       | Montreal, Canada              |             |                                                       |                  |
-| yyz       | Toronto, Canada               | ✓           |                                                       |                  |
+You can host your apps in any of the following regions.
 
-You can host your apps in any region other than those marked "Edge - No deploy".
+
+| Region ID | Region Location               | Gateway     | [Launch Plan or Higher](https://fly.io/plans)         |
+|-----------|-------------------------------|-------------|-------------------------------------------------------|
+| ams       | Amsterdam, Netherlands        | ✓           |                                                       |
+| arn       | Stockholm, Sweden             |             |                                                       |
+| atl       | Atlanta, Georgia (US)         |             |                                                       |
+| bog       | Bogotá, Colombia              |             |                                                       |
+| bom       | Mumbai, India                 |             | ✓                                                     |
+| bos       | Boston, Massachusetts (US)    |             |                                                       |
+| cdg       | Paris, France                 | ✓           |                                                       |
+| den       | Denver, Colorado (US)         |             |                                                       |
+| dfw       | Dallas, Texas (US)            | ✓           |                                                       |
+| dxb       | Dubai, United Arab Emirates   |             |                                                       |
+| ewr       | Secaucus, NJ (US)             |             |                                                       |
+| eze       | Ezeiza, Argentina             |             |                                                       |
+| fra       | Frankfurt, Germany            | ✓           | ✓                                                     |
+| gdl       | Guadalajara, Mexico           |             |                                                       |
+| gig       | Rio de Janeiro, Brazil        |             |                                                       |
+| gru       | Sao Paulo, Brazil             |             |                                                       |
+| hkg       | Hong Kong, Hong Kong          | ✓           |                                                       |
+| iad       | Ashburn, Virginia (US)        | ✓           |                                                       |
+| ist       | Istanbul, Turkey              |             |                                                       |
+| jnb       | Johannesburg, South Africa    |             |                                                       |
+| lax       | Los Angeles, California (US)  | ✓           |                                                       |
+| lhr       | London, United Kingdom        | ✓           |                                                       |
+| mad       | Madrid, Spain                 |             |                                                       |
+| mel       | Melbourne, Australia          |             |                                                       |
+| mia       | Miami, Florida (US)           |             |                                                       |
+| nrt       | Tokyo, Japan                  | ✓           |                                                       |
+| ord       | Chicago, Illinois (US)        | ✓           |                                                       |
+| otp       | Bucharest, Romania            |             |                                                       |
+| phx       | Phoenix, Arizona (US)         |             |                                                       |
+| qro       | Querétaro, Mexico             |             |                                                       |
+| scl       | Santiago, Chile               | ✓           |                                                       |
+| sea       | Seattle, Washington (US)      | ✓           |                                                       |
+| sin       | Singapore, Singapore          | ✓           |                                                       |
+| sjc       | San Jose, California (US)     | ✓           |                                                       |
+| syd       | Sydney, Australia             | ✓           |                                                       |
+| waw       | Warsaw, Poland                |             |                                                       |
+| yul       | Montreal, Canada              |             |                                                       |
+| yyz       | Toronto, Canada               | ✓           |                                                       |
 
 - **Gateway regions:** "Gateway" regions also have WireGuard gateways, through which you connect to your organization's private network.
-- **Launch Plan or higher region:** For some higher-demand regions, we restrict scaling up Machines to organizations with the [Launch, Scale, or Enterprise plans](https://fly.io/plans).
-- **Edge - No deploys:** Edge servers receive inbound traffic from the Internet destined for apps on the Fly.io platform. Fly Proxy routes traffic from edges to regional worker servers.
+- **Launch Plan or higher regions:** For some higher-demand regions, we restrict scaling up Machines to organizations with the [Launch, Scale, or Enterprise plans](https://fly.io/plans).
+
+## Edge-only regions
+
+Edge servers receive inbound traffic from the Internet destined for apps on the Fly.io platform and private traffic between Machines in different regions. [Fly Proxy](/docs/reference/fly-proxy/) routes traffic from edges to regional worker servers.
+
+We have a few regions that don't have workers and aren't available for app deployment:
+
+| Region ID | Region Location               |
+|-----------|-------------------------------|
+| dxb       | Dubai, United Arab Emirates   |
+| ist       | Istanbul, Turkey              |
+| mel       | Melbourne, Australia          |
+
+You might see an edge-only region code on your invoices for egress bandwidth or in the `Fly-Region` request header.
 
 ## Discovering your app's region
 

--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -14,51 +14,56 @@ Run <code>fly platform regions</code> to get a list of regions.
 
 ## Fly.io Regions
 
-|Region ID| Region Location | Gateway&#42; | [Launch Plan or Higher](https://fly.io/plans) Only&#42;&#42; |
-|---------|-----------------|---------|---------|
-ams |    Amsterdam, Netherlands         | ✓
-arn |    Stockholm, Sweden              |
-atl |    Atlanta, Georgia (US)          |
-bog |    Bogotá, Colombia               |
-bom |    Mumbai, India                  |  | ✓ |
-bos |    Boston, Massachusetts (US)     |
-cdg |    Paris, France                  | ✓
-den |    Denver, Colorado (US)          |
-dfw |    Dallas, Texas (US)             | ✓
-ewr |    Secaucus, NJ (US)              |
-eze |    Ezeiza, Argentina              |
-fra |    Frankfurt, Germany             | ✓ | ✓ |
-gdl |    Guadalajara, Mexico            |
-gig |    Rio de Janeiro, Brazil         |
-gru |    Sao Paulo, Brazil              |
-hkg |    Hong Kong, Hong Kong           | ✓
-iad |    Ashburn, Virginia (US)         | ✓
-jnb |    Johannesburg, South Africa     |
-lax |    Los Angeles, California (US)   | ✓
-lhr |    London, United Kingdom         | ✓
-mad |    Madrid, Spain                  |
-mia |    Miami, Florida (US)            |
-nrt |    Tokyo, Japan                   | ✓
-ord |    Chicago, Illinois (US)         | ✓
-otp |    Bucharest, Romania             |
-phx |    Phoenix, Arizona (US)          |
-qro |    Querétaro, Mexico              |
-scl |    Santiago, Chile                | ✓
-sea |    Seattle, Washington (US)       | ✓
-sin |    Singapore, Singapore           | ✓
-sjc |    San Jose, California (US)      | ✓
-syd |    Sydney, Australia              | ✓
-waw |    Warsaw, Poland                 |
-yul |    Montreal, Canada               |
-yyz |    Toronto, Canada                | ✓
+| Region ID | Region Location               | Gateway     | [Launch Plan or Higher](https://fly.io/plans)         | Edge - No Deploys |
+|-----------|-------------------------------|-------------|-------------------------------------------------------|-------------------|
+| ams       | Amsterdam, Netherlands        | ✓           |                                                       |                  |
+| arn       | Stockholm, Sweden             |             |                                                       |                  |
+| atl       | Atlanta, Georgia (US)         |             |                                                       |                  |
+| bog       | Bogotá, Colombia              |             |                                                       |                  |
+| bom       | Mumbai, India                 |             | ✓                                                     |                  |
+| bos       | Boston, Massachusetts (US)    |             |                                                       |                  |
+| cdg       | Paris, France                 | ✓           |                                                       |                  |
+| den       | Denver, Colorado (US)         |             |                                                       |                  |
+| dfw       | Dallas, Texas (US)            | ✓           |                                                       |                  |
+| dxb       | Dubai, United Arab Emirates   |             |                                                       | ✓                |
+| ewr       | Secaucus, NJ (US)             |             |                                                       |                  |
+| eze       | Ezeiza, Argentina             |             |                                                       |                  |
+| fra       | Frankfurt, Germany            | ✓           | ✓                                                     |                  |
+| gdl       | Guadalajara, Mexico           |             |                                                       |                  |
+| gig       | Rio de Janeiro, Brazil        |             |                                                       |                  |
+| gru       | Sao Paulo, Brazil             |             |                                                       |                  |
+| hkg       | Hong Kong, Hong Kong          | ✓           |                                                       |                  |
+| iad       | Ashburn, Virginia (US)        | ✓           |                                                       |                  |
+| ist       | Istanbul, Turkey              |             |                                                       | ✓                |
+| jnb       | Johannesburg, South Africa    |             |                                                       |                  |
+| lax       | Los Angeles, California (US)  | ✓           |                                                       |                  |
+| lhr       | London, United Kingdom        | ✓           |                                                       |                  |
+| mad       | Madrid, Spain                 |             |                                                       |                  |
+| mel       | Melbourne, Australia          |             |                                                       |  ✓               |
+| mia       | Miami, Florida (US)           |             |                                                       |                  |
+| nrt       | Tokyo, Japan                  | ✓           |                                                       |                  |
+| ord       | Chicago, Illinois (US)        | ✓           |                                                       |                  |
+| otp       | Bucharest, Romania            |             |                                                       |                  |
+| phx       | Phoenix, Arizona (US)         |             |                                                       |                  |
+| qro       | Querétaro, Mexico             |             |                                                       |                  |
+| scl       | Santiago, Chile               | ✓           |                                                       |                  |
+| sea       | Seattle, Washington (US)      | ✓           |                                                       |                  |
+| sin       | Singapore, Singapore          | ✓           |                                                       |                  |
+| sjc       | San Jose, California (US)     | ✓           |                                                       |                  |
+| syd       | Sydney, Australia             | ✓           |                                                       |                  |
+| waw       | Warsaw, Poland                |             |                                                       |                  |
+| yul       | Montreal, Canada              |             |                                                       |                  |
+| yyz       | Toronto, Canada               | ✓           |                                                       |                  |
 
-&#42; You can host your apps in any region; "Gateway" regions also have WireGuard gateways, through which you connect to your organization's private network.
+You can host your apps in any region other than those marked "Edge - No deploy".
 
-&#42;&#42; For some higher-demand regions we restrict scaling up Machines to organizations with the [Launch, Scale, or Enterprise plans](https://fly.io/plans).
+- **Gateway regions:** "Gateway" regions also have WireGuard gateways, through which you connect to your organization's private network.
+- **Launch Plan or higher region:** For some higher-demand regions, we restrict scaling up Machines to organizations with the [Launch, Scale, or Enterprise plans](https://fly.io/plans).
+- **Edge - No deploys:** Edge servers receive inbound traffic from the Internet destined for apps on the Fly.io platform. Fly Proxy routes traffic from edges to regional worker servers.
 
-## _Discovering your Application's Region_
+## Discovering your app's region
 
-You can see the list of Fly.io regions any time with [`fly platform regions`](https://fly.io/docs/flyctl/platform-regions).
+View the list of Fly.io regions with [`fly platform regions`](https://fly.io/docs/flyctl/platform-regions).
 
 You can see which regions your app is running in with [`fly status`](https://fly.io/docs/flyctl/status/).
 

--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -60,9 +60,7 @@ You can host your apps in any of the following regions.
 
 ## Edge-only regions
 
-Edge servers receive inbound traffic from the Internet destined for apps on the Fly.io platform and private traffic between Machines in different regions. [Fly Proxy](/docs/reference/fly-proxy/) routes traffic from edges to regional worker servers.
-
-We have a few regions that don't have workers and aren't available for app deployment:
+Edge servers receive inbound traffic from the Internet destined for apps on the Fly.io platform and private traffic between Machines in different regions. [Fly Proxy](/docs/reference/fly-proxy/) routes traffic from edges to regional worker servers. Edge-only regions don't have any workers and therefore aren't available for app deployment.
 
 | Region ID | Region Location               |
 |-----------|-------------------------------|


### PR DESCRIPTION
### Summary of changes

One option for adding edge-only regions to the regions table. The other option is to have them listed separately as a section below the region table.

### Preview

https://aa-docs-2.fly.dev/docs/reference/regions/

### Related Fly.io community and GitHub links

### Notes

