### PR TITLE
Fix GitHub SSO typo

### DIFF
--- a/security/sso.html.markerb
+++ b/security/sso.html.markerb
@@ -18,7 +18,7 @@ From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization f
 
 Install the [Fly.io Github app](https://github.com/apps/fly-io/installations/select_target+external) on the GitHub organization you want to use for SSO.
 
-From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization from the dropdown. Go to **Settings > Single Sign On > Google SSO Requirement**. Enter the GitHub organization ID for SSO, check **Enable**, and click Save.
+From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization from the dropdown. Go to **Settings > Single Sign On > GitHub SSO Requirement**. Enter the GitHub organization ID for SSO, check **Enable**, and click Save.
 
 ## Related topics
 

--- a/security/sso.html.markerb
+++ b/security/sso.html.markerb
@@ -16,7 +16,7 @@ From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization f
 
 ## Set up SSO using GitHub organization access
 
-Install the [Fly.io Github app](https://github.com/apps/fly-io/installations/select_target+external) on the GitHub organization you want to use for SSO.
+Install the [Fly.io GitHub app](https://github.com/apps/fly-io/installations/select_target+external) on the GitHub organization you want to use for SSO.
 
 From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization from the dropdown. Go to **Settings > Single Sign On > GitHub SSO Requirement**. Enter the GitHub organization ID for SSO, check **Enable**, and click Save.
 


### PR DESCRIPTION
### Summary of changes

Fix typo on `Set up SSO using GitHub organization access` block.

### Preview
From:
<img width="786" alt="Screenshot 2024-07-15 at 12 03 02" src="https://github.com/user-attachments/assets/c8561f54-f52e-47cf-80e8-6a6b4e9badd7">

To:
<img width="771" alt="Screenshot 2024-07-15 at 12 01 07" src="https://github.com/user-attachments/assets/a8e65ffc-fc32-4341-b7e7-a032f86c6b3e">


