### PR TITLE
Remove bit about using pg import across orgs

### DIFF
--- a/apps/move-app-org.html.markerb
+++ b/apps/move-app-org.html.markerb
@@ -15,7 +15,7 @@ fly apps move <app name> --org <target organization name>
 ```
 
 <div class="important">
-**Fly Postgres:** You can't use the `fly apps move` command for Fly Postgres apps. To move a Postgres app to another organization, create a new Postgres app under the target organization, and then either [restore the data from your current Postgres app volume snapshot](/docs/postgres/managing/backup-and-restore/#restoring-from-a-snapshot), or [import the data](/docs/flyctl/postgres-import/).
+**Fly Postgres:** You can't use the `fly apps move` command for Fly Postgres apps. To move a Postgres app to another organization, create a new Postgres app under the target organization, and then [restore the data from your current Postgres app volume snapshot](/docs/postgres/managing/backup-and-restore/#restoring-from-a-snapshot).
 </div>
 
 ## App downtime


### PR DESCRIPTION
### Summary of changes

Mistakenly included a note that said you could use 'fly pg import" to import data across orgs. That's currently incorrect!

### Preview

### Related Fly.io community and GitHub links

### Notes

