### PR TITLE
Machine reservations docs

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -154,9 +154,10 @@ regionSelect.addEventListener("change", function () {
 
 For stopped Machines we charge only for the root file system (rootfs) needed for each Machine. Each 1GB of rootfs for a Machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/+external) tweaks on the underlying file system.
 
-### Machine Reservation Blocks
+### Machine reservation blocks
 
-We have a block-based commit scheme. Reserve a block of compute time, either for `performance` Machines or `shared` Machines, for a 40% discount. Reservations apply to any number of Machines in that class, in a specific region.
+You'll get a 40% discount when you reserve a block of compute time, either for `performance` Machines or `shared` Machines, in a specific region.
+Reservations apply to any number of Machines in that class.
 
 The available reservation sizes are:
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -173,7 +173,9 @@ The available reservation sizes are:
 * $360/yr for $50/mo of usage
 * $3,600/yr for $500/mo of usage
 
-There's no limit on the number or combinations of blocks that can be purchased. Reservations are backdated to the first day of the current month.
+You pay the "per year" amount upfront, and each month receive a credit worth the "per month" amount. The credit does not rollover; it's only valid for the month in which it's granted.
+
+There's no limit on the number or combinations of blocks that can be purchased. Reservations are backdated to the first day of the month in which they're purchased.
 
 Email reservations@fly.io with a list of the reservations you’d like to purchase along with which regions, and we’ll set them up for you.
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -163,13 +163,13 @@ The available reservation sizes are:
 
 **Performance Machines**
 
-* $144/yr for $20/mo of usage (i.e. $12/mo amortised with a 12 month commit)
+* $144/yr for $20/mo of usage
 * $1,440/yr for $200/mo of usage
 * $14,400/yr for $2,000/mo of usage
 
 **Shared Machines**
 
-* $36/yr for $5/mo of usage (i.e. $3/mo amortised with a 12 month commit)
+* $36/yr for $5/mo of usage
 * $360/yr for $50/mo of usage
 * $3,600/yr for $500/mo of usage
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -166,7 +166,7 @@ The available reservation sizes are:
 * $1,440/yr for $200/mo of usage
 * $14,400/yr for $2,000/mo of usage
 
-**Shared Machines:**
+**Shared Machines**
 
 * $36/yr for $5/mo of usage (i.e. $3/mo amortised with a 12 month commit)
 * $360/yr for $50/mo of usage

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -163,19 +163,21 @@ The available reservation sizes are:
 
 **Performance Machines**
 
-* $144/yr for $20/mo of usage
-* $1,440/yr for $200/mo of usage
-* $14,400/yr for $2,000/mo of usage
+* $144/year for $20/month of usage
+* $1,440/year for $200/month of usage
+* $14,400/year for $2,000/month of usage
 
 **Shared Machines**
 
-* $36/yr for $5/mo of usage
-* $360/yr for $50/mo of usage
-* $3,600/yr for $500/mo of usage
+* $36/year for $5/month of usage
+* $360/year for $50/month of usage
+* $3,600/year for $500/month of usage
 
 You pay the "per year" amount upfront, and each month receive a credit worth the "per month" amount. The credit does not rollover; it's only valid for the month in which it's granted.
 
 There's no limit on the number or combinations of blocks that can be purchased. Reservations are backdated to the first day of the month in which they're purchased.
+
+For example, if you purchase a $36/year `shared` Machines block in `cdg`, you'll pay $36 upfront and receive $5/month of credits applicable to `shared` Machines in `cdg` for 12 months, starting with the month of the purchase. Amortised over 12 months, the $36 upfront cost is $3/month, which is a 40% discount on the $5/month of credits you receive.
 
 Email reservations@fly.io with a list of the reservations you’d like to purchase along with which regions, and we’ll set them up for you.
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -154,6 +154,28 @@ regionSelect.addEventListener("change", function () {
 
 For stopped Machines we charge only for the root file system (rootfs) needed for each Machine. Each 1GB of rootfs for a Machine stopped for 30 days is $0.15. The amount of rootfs needed is defined by your OCI image generated on your app plus a few [containerd](https://containerd.io/+external) tweaks on the underlying file system.
 
+### Machine Reservation Blocks
+
+We have a block-based commit scheme. Reserve a block of compute time, either for `performance` Machines or `shared` Machines, for a 40% discount. Reservations apply to any number of Machines in that class, in a specific region.
+
+The available reservation sizes are:
+
+**Performance Machines**
+
+* $144/yr for $20/mo of usage (i.e. $12/mo amortised with a 12 month commit)
+* $1,440/yr for $200/mo of usage
+* $14,400/yr for $2,000/mo of usage
+
+**Shared Machines:**
+
+* $36/yr for $5/mo of usage (i.e. $3/mo amortised with a 12 month commit)
+* $360/yr for $50/mo of usage
+* $3,600/yr for $500/mo of usage
+
+There's no limit on the number or combinations of blocks that can be purchased. Reservations are backdated to the first day of the current month.
+
+Email reservations@fly.io with a list of the reservations you’d like to purchase along with which regions, and we’ll set them up for you.
+
 ### GPUs and Fly Machines
 
 Pricing for a GPU-enabled Fly Machine is the price of a standard Fly Machine (see above) plus the price of the attached GPU. Like Machines, GPUs are billed by the second when the attached Machine is running.


### PR DESCRIPTION
### Summary of changes

Docs for [machine reservations](https://community.fly.io/t/reservation-blocks-40-discount-on-machines-when-youre-ready-to-commit/20858).

### Preview

<img width="803" alt="image" src="https://github.com/user-attachments/assets/c33f7d62-263f-4743-a10a-b0570f4a7742">


### Related Fly.io community and GitHub links

https://community.fly.io/t/reservation-blocks-40-discount-on-machines-when-youre-ready-to-commit/20858

### Notes

N/A