### PR TITLE
Updates for Machine suspension

### DIFF
--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -313,7 +313,7 @@ Create a Machine with services defined on app. Learn more about [services and ne
     <% api_info.add_info(
       name: 'state',
       type: 'string enum',
-      description: 'The Machine state to wait for. Values are: `started`, `stopped`, or `destroyed`. Default is `started`.'
+      description: 'The Machine state to wait for. Values are: `started`, `stopped`, `suspended`, or `destroyed`. Default is `started`.'
     ) %>
     <%= render(api_info) %>
     <% api_info = ApiInfoComponent.new(

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -479,7 +479,7 @@ This is, in particular, how you would update the running image of a Machine (whe
 
 ## Stop a Machine
 
-Stopping a started Machine will shut down the Machine, but not destroy it. The Machine may be started again with `machines/<machine_id>/start`.
+Stopping a started Machine will shut down the Machine, but not destroy it. The Machine can be started again with `machines/<machine_id>/start`.
 
 Stopping a suspended Machine will invalidate its snapshot, forcing it to perform a cold boot the next time it is started.
 

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -528,6 +528,53 @@ Stopping a Machine will shut down the Machine, but not destroy it. The Machine m
   </div>
 </div>
 
+## Suspend a Machine
+
+Suspending a Machine pauses the Machine and takes a snapshot of its state, including its memory. The next start operation will attempt (but is not guaranteed) to resume the Machine from the snapshot, rather than performing a cold boot.
+
+<div class="api-section" data-exclude-render>
+  <div>
+    <% api_info = ApiInfoComponent.new(
+      heading: 'Path parameters',
+      name: 'app_name',
+      type: 'string',
+      required: true,
+      description: 'The name of the Fly App the Machine belongs to.'
+    ) %>
+    <% api_info.add_info(
+      name: 'machine_id',
+      type: 'string',
+      required: true,
+      description: 'The ID of the Machine to suspend.'
+    ) %>
+    <%= render(api_info) %>
+    <% api_info = ApiInfoComponent.new(
+      heading: 'Responses',
+      name: '200',
+      description: 'OK'
+    ) %>
+    <%= render(api_info) %>
+  </div>
+  <div>
+    <%= render(CodeToggleComponent.new(badge: 'POST', title: '/v1/apps/{app_name}/machines/{machine_id}/suspend')) do |component| %>
+      <% component.with_curl do %>
+        <%= partial "/docs/reference/machines/machines_suspend_req" %>
+      <% end %>
+      <% component.with_json do %>
+      no body
+      <% end %>
+      <% component.with_json_table do %>
+      | Property | Type | Required | Description |
+      | --- | --- | --- | --- |
+      | no body |  |  |  |
+      <% end %>
+    <% end %>
+    <%= render(CodeSampleComponent.new(title: 'Status: 200 OK', language: 'json')) do %>
+      <%= partial "/docs/reference/machines/machines_ok_true_resp" %>
+    <% end %>
+  </div>
+</div>
+
 ## Start a Machine
 
 Start a stopped Machine. Machines that are restarted are completely reset to their original state so that they start clean on the next run.

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -479,7 +479,9 @@ This is, in particular, how you would update the running image of a Machine (whe
 
 ## Stop a Machine
 
-Stopping a Machine will shut down the Machine, but not destroy it. The Machine may be started again with `machines/<machine_id>/start`.
+Stopping a started Machine will shut down the Machine, but not destroy it. The Machine may be started again with `machines/<machine_id>/start`.
+
+Stopping a suspended Machine will invalidate its snapshot, forcing it to perform a cold boot the next time it is started.
 
 <div class="api-section" data-exclude-render>
   <div>
@@ -577,7 +579,11 @@ Suspending a Machine pauses the Machine and takes a snapshot of its state, inclu
 
 ## Start a Machine
 
-Start a stopped Machine. Machines that are restarted are completely reset to their original state so that they start clean on the next run.
+Start a Machine.
+
+Stopped Machines that are restarted are completely reset to their original state so that they start clean on the next run.
+
+Suspended Machines that are started attempt to resume from the snapshot taken when they were suspended. If this is not possible, then they will perform a normal cold boot.
 
 <div class="api-section" data-exclude-render>
   <div>

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -583,7 +583,7 @@ Start a Machine.
 
 Stopped Machines that are restarted are completely reset to their original state so that they start clean on the next run.
 
-Suspended Machines that are started attempt to resume from the snapshot taken when they were suspended. If this is not possible, then they will perform a normal cold boot.
+Suspended Machines that are started attempt to resume from the snapshot taken when they were suspended. If this is not possible, then they will perform a cold boot, as though starting from the stopped state; however, their root file systems will not be reset.
 
 <div class="api-section" data-exclude-render>
   <div>

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -1262,7 +1262,7 @@ Properties of the `config` object for Machine configuration. See [Machine proper
       + `proxy_proto_options`: Configure the version of the PROXY protocol that your app accepts. Version 1 is the default.
         - `version`: A string to indicate that the TCP connection uses PROXY protocol version 2. The default when not set is version 1.
   - `autostart`: bool (false) - If true, Fly Proxy starts Machines when requests for this service arrive.
-  - `autostop`: bool (false) - If true, Fly Proxy stops Machines when this service goes idle.
+  - `autostop`: string or bool (`off`) - One of `off` (or false), `stop` (or true), `suspend`. If `stop`, Fly Proxy stops Machines when this service goes idle. If `suspend`, Fly Proxy instead suspends Machines if possible and stops them if not.
   - `min_machines_running`: int (nil) - When `autostart` is true, the minimum number of Machines to keep running at all times in the primary region.
 
 ---

--- a/machines/machine-states.html.markerb
+++ b/machines/machine-states.html.markerb
@@ -10,10 +10,12 @@ This table explains the possible Machine states. A Machine may only be in one st
 |                |                                                                        |
 |----------------|------------------------------------------------------------------------|
 | **created**    | Initial status                                                         |
-| **starting**   | Transitioning from `stopped` to `started`                              |
+| **starting**   | Transitioning from `stopped` or `suspended` to `started`               |
 | **started**    | Running and network-accessible                                         |
 | **stopping**   | Transitioning from `started` to `stopped`                              |
 | **stopped**    | Exited, either on its own or explicitly stopped                        |
+| **suspending** | Transitioning from `started` to `suspended`                            |
+| **suspended**  | Suspended to disk; will attempt to resume on next start                |
 | **replacing**  | User-initiated configuration change (image, VM size, etc.) in progress |
 | **destroying** | User asked for the Machine to be completely removed                    |
 | **destroyed**  | No longer exists                                                       |

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -275,7 +275,7 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
   [http_service.concurrency]
@@ -287,12 +287,12 @@ As with the more verbose [`[[services]]`](#the-services-sections), you can speci
 * `processes`: For apps with multiple processes. The process group that this service belongs to. Define process groups in the [processes](#the-processes-section) section.
 * `internal_port`: The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `force_https`: A Boolean which determines whether to enforce HTTP to HTTPS redirects.
-* `auto_stop_machines`: Whether to automatically stop an application's Machines when there's excess capacity, per region. If there's only one Machine in a region, then the Machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop Machines every few minutes. The default if not set is `false`.
+* `auto_stop_machines`: Whether to automatically stop or suspend an application's Machines when there's excess capacity, per region. Options are `"off"`, `"stop"`, and `"suspend"`. If there's only one Machine in a region, then the Machine is stopped or suspended if it has no traffic. The Fly Proxy runs a process to automatically stop Machines every few minutes. The default if not set is `"off"`.
 * `auto_start_machines`: Whether to automatically start an application's Machines when a new request is made to the application and there's no excess capacity, per region. If there's only one Machine in a region, then it's started whenever a request is made to the application. The default if not set is `true`.
-* `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines = true`.
+* `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines` is `"stop"` or `"suspend"`.
 
 <div class="important icon">
-We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having Machines that either never start or never stop. Learn more about [automatically starting and stopping Machines](/docs/launch/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
+We recommend configuring `auto_stop_machines` and `auto_start_machines` so that they are both enabled or both disabled, to avoid having Machines that either never start or never stop. Learn more about [automatically starting and stopping Machines](/docs/launch/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
 ### `http_service.concurrency`
@@ -427,7 +427,7 @@ Example (note the double square brackets):
 [[services]]
   internal_port = 8080
   protocol = "tcp"
-  auto_stop_machines = true
+  auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
 ```
@@ -437,12 +437,12 @@ Settings:
 * `processes`: For apps with multiple process groups, the process group or groups that this service belongs to. Define process groups in the [processes](#the-processes-section) section.
 * `internal_port` : The port this service (and application) will use to communicate with clients. The default is 8080. We recommend applications use the default.
 * `protocol` : The protocol that this service will use to communicate. Typically `tcp` for most applications, but can also be `udp`.
-* `auto_stop_machines`: Whether to automatically stop an application's Machines when there's excess capacity, per region. If there's only one Machine in a region, then the Machine is stopped if it has no traffic. The Fly Proxy runs the checks to automatically stop Machines every few minutes. The default if not set is `false`.
+* `auto_stop_machines`: Whether to automatically stop or suspend an application's Machines when there's excess capacity, per region. Options are `"off"`, `"stop"`, and `"suspend"`. If there's only one Machine in a region, then the Machine is stopped or suspended if it has no traffic. The Fly Proxy runs a process to automatically stop Machines every few minutes. The default if not set is `"off"`.
 * `auto_start_machines`: Whether to automatically start an application's Machines when a new request is made to the application and there's no excess capacity, per region. If there's only one Machine in a region, then it's started whenever a request is made to the application. The default if not set is `true`.
-* `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines = true`.
+* `min_machines_running`: The number of Machines to keep running, in the primary region only, when `auto_stop_machines` is `"stop"` or `"suspend"`.
 
 <div class="callout">
-We recommend setting `auto_stop_machines` and `auto_start_machines` to the same value to avoid having Machines that either never start or never stop. Learn more about [automatically starting and stopping Machines](/docs/launch/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
+We recommend configuring `auto_stop_machines` and `auto_start_machines` so that they are both enabled or both disabled, to avoid having Machines that either never start or never stop. Learn more about [automatically starting and stopping Machines](/docs/launch/autostart-stop/), including how Fly Proxy determines excess capacity in a region using the `soft_limit` setting.
 </div>
 
 ### `services.ports`

--- a/reference/machines/_machines_suspend_req.erb
+++ b/reference/machines/_machines_suspend_req.erb
@@ -1,0 +1,3 @@
+curl -i -X POST \\
+    -H "Authorization: Bearer ${FLY_API_TOKEN}" -H "Content-Type: application/json" \\
+    "${FLY_API_HOSTNAME}/v1/apps/my-app-name/machines/73d8d46dbee589/suspend"


### PR DESCRIPTION
### Summary of changes

Update documentation to account for the new Machine suspension feature, including proxy autosuspend:

* Reference the new `suspending` and `suspended` Machine states
* Document the `suspend` Machines API endpoint
* Explain how the `start` and `stop` Machines API endpoints affect `suspended` Machines
* Document new autostop settings in the Machines API and in `fly.toml`

### Related Fly.io community and GitHub links

* https://community.fly.io/t/new-feature-in-preview-suspend-resume-for-machines/20672

### Notes

Still a work in progress right now!