### PR TITLE
Fix MD formatting typon in  fastapi.html.markerb

### DIFF
--- a/python/frameworks/fastapi.html.markerb
+++ b/python/frameworks/fastapi.html.markerb
@@ -62,7 +62,7 @@ fastapi run
 <section class="callout">
 The `fastapi` assumes your app is stored in `main.py` or `app.py` - if this is not the case, you must specify that when running the app: 
 
-``fastapi run hello/entrypoint.py`
+`fastapi run hello/entrypoint.py`
 </section>
 
 <%= partial "/docs/python/partials/deploy", locals: { runtime: "FastAPI", repo: "hello-fastapi" }  %>


### PR DESCRIPTION
Fix MD formatting. Not sure if single or triple backticks are appropriate here. Please adjust to whatever looks best.

<img width="812" alt="Screenshot 2024-07-21 at 17 43 19" src="https://github.com/user-attachments/assets/8fafe541-b08f-48c0-9095-fe4cc35b1f73">
