### PR TITLE
Add index for FKS + make other index pages consistent

### DIFF
--- a/about/index.html.markerb
+++ b/about/index.html.markerb
@@ -8,12 +8,20 @@ nav: firecracker
 
 More details about using and working with the Fly.io platform.
 
-* [_Pricing_](/docs/about/pricing/) : Pricing for compute, storage, and all the FLy.io platform services.
-* [_Billing_](/docs/about/pricing/) : How billing works on Fly.io.
-* [_Healthcare_](/docs/about/healthcare/) : Controls relevant to running healthcare apps on Fly.io.
-* [_Support_](/docs/about/support) : Who to contact and where to go when you need Fly.io support.
-* [_Extensions program_](/docs/about/extensions/) and [_Extensions API_](/docs/reference/extensions_api/): Learn about becoming an extensions partner.
-* [_Open Source_](/docs/about/open-source/) : How we help those OSS projects that help us.
-* [_Using Our Brand_](/docs/about/brand/) : Assets and guidelines to help represent our brand.
-* [_Privacy Policy_](/legal/privacy-policy/) : Our policy on privacy, detailed here.
-* [_Terms of Service_](/legal/terms-of-service) : The legal terms of service for Fly.io users.
+* **[Pricing](/docs/about/pricing/):** Pricing for compute, storage, and all the FLy.io platform services.
+
+* **[Billing](/docs/about/pricing/):** How billing works on Fly.io.
+
+* **[Healthcare](/docs/about/healthcare/):** Controls relevant to running healthcare apps on Fly.io.
+
+* **[Support](/docs/about/support):** Who to contact and where to go when you need Fly.io support.
+
+* **[Extensions program](/docs/about/extensions/) and [Extensions API](/docs/reference/extensions_api/):** Learn about becoming an extensions partner.
+
+* **[Open Source](/docs/about/open-source/):** How we help those OSS projects that help us.
+
+* **[Using Our Brand](/docs/about/brand/):** Assets and guidelines to help represent our brand.
+
+* **[Privacy Policy](/legal/privacy-policy/):** Our policy on privacy, detailed here.
+
+* **[Terms of Service](/legal/terms-of-service):** The legal terms of service for Fly.io users.

--- a/apps/index.html.markerb
+++ b/apps/index.html.markerb
@@ -12,8 +12,9 @@ An app on Fly.io can be anything from a simple frontend web app to a complex arr
 
 _If you're looking to deploy an app on Fly.io, you probably want Fly Launch. Use Fly Launch to create your app and then manage the whole lifecycle, from starting to scaling to changing and redeploying._
 
-- [Get started](/docs/getting-started/) with Fly Launch
-- [Use Fly Launch](/docs/launch/) to create, configure, deploy, and scale your app
+- **[Get started](/docs/getting-started/):** Launch your own app or try a demo app.
+
+- **[Use Fly Launch](/docs/launch/):** Learn how to create, configure, deploy, and scale your app.
 
 ---
 

--- a/getting-started/get-started-by-framework.html.markerb
+++ b/getting-started/get-started-by-framework.html.markerb
@@ -5,13 +5,11 @@ nav: firecracker
 toc: false
 ---
 
-Fly Launch can deploy almost any app from a [Dockerfile](/docs/languages-and-frameworks/dockerfile/). 
-
-Fly Launch scanners also detect and deploy the following kinds of apps automatically:
+Fly Launch scanners detect and deploy the following kinds of apps automatically:
 
 <%= partial "/docs/languages-and-frameworks/partials/scanner_guides" %>
 
-Learn more about what [Fly Launch](/docs/launch/) does.
+Don't see your framework or language in the list? Fly Launch can deploy almost any app from a [Dockerfile](/docs/languages-and-frameworks/dockerfile/). Learn more about what [Fly Launch](/docs/launch/) does.
 
 <figure class="text-center">
   <img src="/static/images/speedrun-guidebooks.webp" srcset="/static/images/speedrun-guidebooks@2x.webp 2x" alt="Illustration by Annie Ruygt of Frankie the Fly.io hot air balloon character with one hand on their hip and the other hand out, palm up, with images floating above the hand representing the Elixir, Ruby, Laravel, and Django programming languages">

--- a/index.html.md
+++ b/index.html.md
@@ -69,7 +69,7 @@ _Services from Fly.io and our extension partners to help you run your entire sta
 
 [LiteFS - Distributed SQLite](/docs/litefs/)
 
-[Fly Kubernetes (private beta)](/docs/kubernetes/fks-quickstart/)
+[Fly Kubernetes (private beta)](/docs/kubernetes/)
 
 ---
 
@@ -97,7 +97,7 @@ _Explore built-in and custom Prometheus metrics and Grafana dashboards. Live tai
 
 _Built-in security and partner extensions._
 
-[Security](/docs/security/#fly-io-platform-security) on the Fly.io platform
+[Security](/docs/security/) on the Fly.io platform
 
 [Application security by Arcjet](/docs/reference/arcjet/) for JavaScript apps
 

--- a/index.html.md
+++ b/index.html.md
@@ -75,7 +75,7 @@ _Services from Fly.io and our extension partners to help you run your entire sta
 
 ## Networking
 
-_Private networking, public services, custom domains, routing, and load balancing._
+_Private networking, public networking, custom domains and certificates, UDP apps, and routing._
 
 [Networking](/docs/networking/) on Fly.io
 

--- a/kubernetes/clusters.html.markerb
+++ b/kubernetes/clusters.html.markerb
@@ -61,7 +61,5 @@ kube-system       Active   22d
 
 ## Related topics
 
-- [FKS Quickstart](/docs/kubernetes/fks-quickstart/)
 - [Connect to an FKS cluster](/docs/kubernetes/connect-clusters/)
 - [Configure FKS Services](/docs/kubernetes/services)
-- [Use volumes with FKS](/docs/kubernetes/using-volumes/)

--- a/kubernetes/connect-clusters.html.markerb
+++ b/kubernetes/connect-clusters.html.markerb
@@ -49,7 +49,5 @@ kube-system       Active   22d
 
 ## Related topics
 
-- [FKS Quickstart](/docs/kubernetes/fks-quickstart/)
 - [Create an FKS cluster](/docs/kubernetes/clusters/)
 - [Configure FKS Services](/docs/kubernetes/services)
-- [Use volumes with FKS](/docs/kubernetes/using-volumes/)

--- a/kubernetes/fks-features.html.markerb
+++ b/kubernetes/fks-features.html.markerb
@@ -1,0 +1,53 @@
+---
+title: Fly Kubernetes features
+layout: docs
+nav: firecracker
+---
+
+Fly Kubernetes benefits from the features of the Fly.io platform.
+
+## Fly.io infrastructure
+
+FKS is built on top of Fly.io infrastructure:
+
+* Compute is backed by [Fly Machines](/docs/machines/), our fast-launching VMs built with Firecracker. 
+* Volumes are handled with [Fly Volumes](/docs/volumes/); local, fast NVMe drives.  
+* Networking is built on our [internal WireGuard mesh](/docs/networking/private-networking/#private-network-vpn) with routing performed by Fly Proxy.
+
+## Cluster scalability
+
+Pods are scheduled across our fleet of bare-metal servers, not limited to a specific node. Workloads are automatically distributed across the fleet, enabling a cluster to scale with ease.
+
+## Security
+
+With Fly Kubernetes, you get all the security benefits of our platform.
+
+  * Private network traffic flows over our internal WireGuard mesh, ensuring it is encrypted.
+  * FKS clusters are secured within a private VPN.
+  * Compute is built on Firecracker microVMs — lightweight and secure virtual machines. This provides improved isolation guarantees ensuring your application code is safe.
+  * Volumes are encrypted at rest for additional protection of the data on the volume.
+  * Secrets are automatically stored in an encrypted vault.
+
+## Simple and secure client authentication
+
+Connect to your cluster using kubectl. Clients are authenticated with our API tokens. They expire after an hour and are rotated automatically after expiration.
+
+## Not supported
+
+There are a few features we don't support yet but are part of the roadmap:
+
+  * Sidecars and init processes
+  * EmptyDir volumes
+  * Horizontal pod autoscaling
+  * Network policies
+  * CronJob
+
+Features we don't support:
+
+  * Node affinity
+  * Inter-pod (anti) affinity
+  * DaemonSets
+
+## Pricing
+
+See the [pricing page](/docs/about/pricing/#fly-kubernetes) for information on FKS pricing.

--- a/kubernetes/fks-quickstart.html.markerb
+++ b/kubernetes/fks-quickstart.html.markerb
@@ -156,4 +156,3 @@ Right now we don't get logs from a single pod. If you try to get logs from a sin
 - [Create an FKS cluster](/docs/kubernetes/clusters/)
 - [Connect to an FKS cluster](/docs/kubernetes/connect-clusters/)
 - [Configure FKS Services](/docs/kubernetes/services)
-- [Use volumes with FKS](/docs/kubernetes/using-volumes/)

--- a/kubernetes/index.html.markerb
+++ b/kubernetes/index.html.markerb
@@ -3,73 +3,24 @@ title: Fly Kubernetes
 layout: docs
 toc: false
 nav: firecracker
-redirect_from: /docs/kubernetes/volumes/
 ---
 
 <div class= "important icon">
 Fly Kubernetes is in beta and not recommended for critical production usage. To report issues or provide feedback, email us at beta@fly.io.
 </div>
 
-Fly Kubernetes (FKS) is a fully managed Kubernetes service built on the Fly.io platform. It enables you to easily deploy Kubernetes clusters without the hassle of managing and operating the control plane. Learn more about [why and how we made FKS](https://fly.io/blog/fks/).
+Fly Kubernetes (FKS) is a fully managed Kubernetes service built on the Fly.io platform. Deploy Kubernetes clusters without the hassle of managing and operating the control plane. Learn more about [why and how we made FKS](https://fly.io/blog/fks/) in our blog.
 
-## Getting started
+- **[Fly Kubernetes quickstart](/docs/kubernetes/fks-quickstart/):** Get up and running right away with our quickstart guide.
 
-To get up and running immediately, try the [Fly Kubernetes quickstart](https://fly.io/docs/kubernetes/fks-quickstart/) guide
+- **[Fly Kubernetes features](/docs/kubernetes/fks-features/):** An overview of FKS benefits and supported features.
 
-## Features
+- **[Create an FKS cluster](/docs/kubernetes/clusters/):** Create an FKS cluster with flyctl.
 
-Fly Kubernetes benefits from the features of the Fly.io platform.
+- **[Connect to an FKS cluster](/docs/kubernetes/connect-clusters/):** Connect to an FKS cluster on your private network.
 
-### Fly.io infrastructure
+- **[Configure FKS Services](/docs/kubernetes/services):** Configure ClusterIP and LoadBalancer services.
 
-FKS is built on top of Fly.io infrastructure:
+- **[Use GPUs with FKS](/docs/kubernetes/using-gpus/):** Use Fly GPU Machines in your FKS cluster.
 
-* Compute is backed by [Fly Machines](/docs/machines/), our fast-launching VMs built with Firecracker. 
-* Volumes are handled with [Fly Volumes](/docs/volumes/); local, fast NVMe drives.  
-* Networking is built on our [internal WireGuard mesh](/docs/networking/private-networking/#private-network-vpn) with routing performed by Fly Proxy.
-
-### Cluster scalability
-
-Pods are scheduled across our fleet of bare-metal servers, not limited to a specific node. Workloads are automatically distributed across the fleet, enabling a cluster to scale with ease.
-
-### Security
-
-With Fly Kubernetes, you get all the security benefits of our platform.
-
-  * Private network traffic flows over our internal WireGuard mesh, ensuring it is encrypted.
-  * FKS clusters are secured within a private VPN.
-  * Compute is built on Firecracker microVMs — lightweight and secure virtual machines. This provides improved isolation guarantees ensuring your application code is safe.
-  * Volumes are encrypted at rest for additional protection of the data on the volume.
-  * Secrets are automatically stored in an encrypted vault.
-
-### Simple and secure client authentication
-
-Connect to your cluster using kubectl. Clients are authenticated with our API tokens. They expire after an hour and are rotated automatically after expiration.
-
-### Not supported
-
-There are a few features we don't support yet but are part of the roadmap:
-
-  * Sidecars and init processes
-  * EmptyDir volumes
-  * Horizontal pod autoscaling
-  * Network policies
-  * CronJob
-
-Features we don't support:
-
-  * Node affinity
-  * Inter-pod (anti) affinity
-  * DaemonSets
-
-### Pricing
-
-See the [pricing page](/docs/about/pricing/#fly-kubernetes) for information on FKS pricing.
-
-## Related topics
-
-- [FKS Quickstart](/docs/kubernetes/fks-quickstart/)
-- [Create an FKS cluster](/docs/kubernetes/clusters/)
-- [Connect to an FKS cluster](/docs/kubernetes/connect-clusters/)
-- [Configure FKS Services](/docs/kubernetes/services)
-- [Use volumes with FKS](/docs/kubernetes/using-volumes/)
+- **[Use volumes with FKS](/docs/kubernetes/using-volumes/):** Use Fly Volumes for PersistentVolumes in FKS.

--- a/kubernetes/services.html.markerb
+++ b/kubernetes/services.html.markerb
@@ -180,7 +180,5 @@ We currently do not support:
 
 ## Related topics
 
-- [FKS Quickstart](/docs/kubernetes/fks-quickstart/)
 - [Create an FKS cluster](/docs/kubernetes/clusters/)
 - [Connect to an FKS cluster](/docs/kubernetes/connect-clusters/)
-- [Use volumes with FKS](/docs/kubernetes/using-volumes/)

--- a/kubernetes/using-gpus.html.markerb
+++ b/kubernetes/using-gpus.html.markerb
@@ -41,10 +41,3 @@ spec:
 ```
 
 This will deploy a GPU Machine with the size `a100-80gb` with 1 GPU core in the region `ams`.
-
-## Related topics
-
-- [FKS Quickstart](/docs/kubernetes/fks-quickstart/)
-- [Create an FKS cluster](/docs/kubernetes/clusters/)
-- [Configure FKS Services](/docs/kubernetes/services)
-- [Use volumes with FKS](/docs/kubernetes/using-volumes/)

--- a/kubernetes/using-volumes.html.markerb
+++ b/kubernetes/using-volumes.html.markerb
@@ -165,10 +165,3 @@ spec:
 ```
 
 For generic ephemeral volumes to work as expected, `storageClassName` must be set to `flyio-volume`.
-
-## Related topics
-
-- [FKS Quickstart](/docs/kubernetes/fks-quickstart/)
-- [Create an FKS cluster](/docs/kubernetes/clusters/)
-- [Connect to an FKS cluster](/docs/kubernetes/connect-clusters/)
-- [Configure FKS Services](/docs/kubernetes/services)

--- a/languages-and-frameworks/partials/_scanner_guides.html.erb
+++ b/languages-and-frameworks/partials/_scanner_guides.html.erb
@@ -12,6 +12,12 @@
     <a href="/docs/elixir/getting-started">Elixir</a>
   </li>
   <li>
+    <a href="/docs/python/frameworks/fastapi/">FastAPI</a>
+  </li>
+  <li>
+    <a href="/docs/python/frameworks/flask/">Flask</a>
+  </li>
+  <li>
     <a href="/docs/languages-and-frameworks/golang/">Go</a>
   </li>
   <li>
@@ -52,6 +58,9 @@
   </li>
   <li>
     <a href="/docs/languages-and-frameworks/static/">Static Website</a>
+  </li>
+  <li>
+    <a href="/docs/python/frameworks/streamlit/">Streamlit</a>
   </li>
   <li>
     <a href="/docs/js/frameworks/svelte/">SvelteKit</a>

--- a/machines/index.html.md
+++ b/machines/index.html.md
@@ -7,7 +7,9 @@ nav: machines
 Fly Machines are fast-launching VMs; they can be started and stopped at subsecond speeds. We give you control of your Machine count and each Machine's lifecycle, resources, and region placement with a simple REST API or flyctl commands.
 
 - [**Introduction to Fly Machines**:](/docs/machines/overview/) Learn whether you need low-level Machine control. Find out more about the lifecycle of Fly Machines and about scaling and placement.
+
 - [**Machines API:**](/docs/machines/api/) A simple and fast REST API for full control over our fast-launching Machines.
+
 - **[Run a New Machine](/docs/machines/flyctl/fly-machine-run/) or [Update a Machine](/docs/machines/flyctl/fly-machine-update/) with flyctl:** Configure, build, and start new Machines with a single command or update some or all of a Machine's configuration.
 
 On the other hand, try [Fly Launch](/docs/reference/fly-launch/) if you prefer easy app-wide configuration and containerized deployment for your app.

--- a/networking/index.html.markerb
+++ b/networking/index.html.markerb
@@ -18,13 +18,16 @@ Networking on Fly.io.
 
 - **[Custom domains](/docs/networking/custom-domain/):** Add a custom domain for your app and troubleshoot certificate creation.
 
-- **[Automate the certificate process for custom domains with the GraphQL API](/docs/networking/custom-domain-api):** If you need to issue multiple certificates automatically for custom domains, you can do that with the GraphQL API.
+- **[Automate the certificate process with the GraphQL API](/docs/networking/custom-domain-api):** If you need to issue multiple certificates automatically for custom domains, you can do that with the GraphQL API.
 
-- **[Run UDP services](/docs/networking/udp-and-tcp/):** Understand the gotchas of running Fly Apps on UDP.
+- **[HTTP request headers](/docs/networking/request-headers/):** Fly.io-specific and standard HTTP headers added by the HTTP connection handler.
+
+- **[Run UDP services](/docs/networking/udp-and-tcp/):** How to set up apps that use UDP.
 
 - **[TLS support](/docs/networking/tls/):** Supported TLS cipher suites.
 
 ## Related topics
 
-- How Fly.io does [load balancing](/docs/reference/load-balancing/)
-- Fly [Regions](/docs/reference/regions/)
+- [Fly Proxy](/docs/reference/fly-proxy)
+- [How Fly Proxy does load balancing](/docs/reference/load-balancing/)
+- [Fly Regions](/docs/reference/regions/)

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -108,12 +108,13 @@
       path: "/docs/kubernetes/",
       open: false,
       links: [
-        { text: "Kubernetes Quickstart", path: "/docs/kubernetes/fks-quickstart/" },
-        { text: "Create an FKS cluster", path: "/docs/kubernetes/clusters/" },
-        { text: "Connect to an FKS cluster", path: "/docs/kubernetes/connect-clusters/" },
+        { text: "Fly Kubernetes Quickstart", path: "/docs/kubernetes/fks-quickstart/" },
+        { text: "Fly Kubernetes Features", path: "/docs/kubernetes/fks-features/" },
+        { text: "Create an FKS Cluster", path: "/docs/kubernetes/clusters/" },
+        { text: "Connect to an FKS Cluster", path: "/docs/kubernetes/connect-clusters/" },
         { text: "Configure FKS Services", path: "/docs/kubernetes/services/" },
-        { text: "Use volumes with FKS", path: "/docs/kubernetes/using-volumes/" },
         { text: "Use GPUs with FKS", path: "/docs/kubernetes/using-gpus/" },
+        { text: "Use Volumes with FKS", path: "/docs/kubernetes/using-volumes/" }
       ]
     },
     {
@@ -153,7 +154,8 @@
       links: [
         { text: "SSO for organizations", path: "/docs/security/sso/" },
         { text: "TLS termination", path: "/docs/security/tls-termination/" },
-        { text: "Deploy Tokens", path: "/docs/security/deploy-tokens/" },      
+        { text: "Deploy Tokens", path: "/docs/security/deploy-tokens/" },
+        { text: "OpenID Connect", path: "/docs/reference/openid-connect/" },     
         { text: "Security practices and compliance", path: "/docs/security/security-at-fly-io/" },
         { text: "App Security by Arcjet", path: "/docs/reference/arcjet/" }
       ]
@@ -172,7 +174,6 @@
         { text: "Load Balancing", path: "/docs/reference/load-balancing/" },
         { text: "Machine migration", path: "/docs/reference/machine-migration/" },
         { text: "Multiple Processes in Apps", path: "/docs/app-guides/multiple-processes/" },
-        { text: "OpenID Connect", path: "/docs/reference/openid-connect/" },
         { text: "Fly Proxy", path: "/docs/reference/fly-proxy/" },
         { text: "Regions", path: "/docs/reference/regions/" }
       ]

--- a/reference/index.html.md
+++ b/reference/index.html.md
@@ -8,31 +8,32 @@ Quick references for often-used resources like flyctl and `fly.toml`. Or dig a l
 
 ## About Fly.io
 
-* [**Architecture**](/docs/reference/architecture/):
-A brief overview of how Firecracker VMs, Anycast networking, Fly Proxy, and the backhaul network come together to create Fly.io's infrastructure.
+* **[Architecture](/docs/reference/architecture/):** A brief overview of how Firecracker VMs, Anycast networking, Fly Proxy, and the backhaul network come together to create Fly.io's infrastructure.
 
-* [**Regions**](/docs/reference/regions/):
-The regions around the world where we run servers so your apps can run close to your users.
+* **[Regions](/docs/reference/regions/):** The regions around the world where we run servers so your apps can run close to your users.
+
+* **[Machine migration](/docs/reference/machine-migration/):** How Fly.io automatically migrates your app's Machines from problematic hosts to healthy hosts.
 
 ---
 
 ## Reference docs
 
-* [**flyctl**](/docs/flyctl/):
-The Fly CLI reference documentation.
+* **[flyctl](/docs/flyctl/):** The flyctl CLI reference documentation.
 
-* [**App Configuration (fly.toml)**](/docs/reference/configuration/):
-The settings for configuring your app in the `fly.toml` configuration file. The Fly Launch configuration includes how the app is built, its volume mounts, network services, and more.
+* **[App Configuration (fly.toml)](/docs/reference/configuration/):** The settings for configuring your app in the `fly.toml` configuration file. The Fly Launch configuration includes how the app is built, its volume mounts, network services, and more.
+
+* **[Fly Launch](/docs/reference/fly-launch/):** A deeper dive into how Fly Launch creates and configures new apps.
+
+* **[Fly Proxy](/docs/reference/fly-proxy/):** Learn about how Fly Proxy routes requests, handles connections, and does load balancing.
 
 ---
 
 ## Working with Fly.io
 
-* [**Autoscaling**](/docs/reference/autoscaling/):
-Adjust the number of running or created Fly Machines dynamically.
+* **[Autoscaling](/docs/reference/autoscaling/):** Adjust the number of running or created Fly Machines dynamically.
 
-* [**Builders**](/docs/reference/builders/):
-The different ways you can assemble applications into deployable images for Fly.io.
+* **[Builders](/docs/reference/builders/):** The different ways you can assemble applications into deployable images for Fly.io.
 
-* [**Load Balancing**](/docs/reference/load-balancing/):
-How Fly Proxy distributes traffic to your application instances based on load, closeness, and concurrency settings.
+* **[Load Balancing](/docs/reference/load-balancing/):** How Fly Proxy distributes traffic to your application instances based on load, closeness, and concurrency settings.
+
+* **[Multiple processes inside a Fly.io app](/docs/app-guides/multiple-processes/):** The different ways to run multiple processes inside a Fly App.

--- a/security/index.html.markerb
+++ b/security/index.html.markerb
@@ -9,16 +9,30 @@ Securing a public cloud platform like Fly.io is a hard problem, and we take it s
 
 ## Fly.io platform security
 
+_Fly.io security practices and features._ 
+
 - **[SSO for organizations](/docs/security/sso/):** Set up org-wide Single Sign-on with Google or GitHub.
 - **[Built-in TLS termination](/docs/security/tls-termination/):** You get TLS termination by default for your web apps.
-- **[Deploy tokens](/docs/security/deploy-tokens/):** Create tokens to manage and deploy individual apps.
 - **[Fly.io security practices and compliance](/docs/security/security-at-fly-io/):** Learn about our security practices for the Fly.io platform.
+
+---
+
+## Tokens
+
+_Authentication tokens on Fly.io._
+
+- **[Deploy tokens](/docs/security/deploy-tokens/):** Create tokens to manage and deploy individual apps.
+- **[OpenID Connect](/docs/security/openid-connect/):** Use OpenID Connect (OIDC) to manage access to 3rd party services.
+
+---
 
 ## Security extensions
 
-Security add-ons from our extension partners.
+_Security add-ons from our extension partners._
 
 - **[Application Security by Arcjet](/docs/reference/arcjet/):** Use the Arcjet security layer to protect your JavaScript app with just a few lines of code.
+
+---
 
 ## Talk to the security team
 

--- a/security/openid-connect.html.markerb
+++ b/security/openid-connect.html.markerb
@@ -2,8 +2,8 @@
 title: OpenID Connect
 layout: docs
 nav: firecracker
+redirect_from: /docs/reference/openid-connect/
 ---
-
 
 Fly Machines sometimes need to access 3rd-party services or cloud providers like AWS, Azure, or GCP. To authenticate against these 3rd parties, your Machines need to supply credentials such as a password or token to the cloud provider; usually these are stored as `fly secrets` and then passed into your Machine's environment variables.
 

--- a/volumes/index.html.markerb
+++ b/volumes/index.html.markerb
@@ -9,18 +9,18 @@ order: 10
 Fly Volumes are local persistent storage for [Fly Machines](/docs/machines/). A Fly Volume is a slice of an NVMe drive on the same physical server as the Machine on which it's mounted.
 
 
-**[Fly Volumes overview](/docs/volumes/overview/):** Learn how volumes work and whether they're right for your use case.
+* **[Fly Volumes overview](/docs/volumes/overview/):** Learn how volumes work and whether they're right for your use case.
 
-**[Fly Launch apps - Add volume storage](/docs/apps/volume-storage/):** Launch an app with volumes or add volume storage to an existing app.
+* **[Fly Launch apps - Add volume storage](/docs/apps/volume-storage/):** Launch an app with volumes or add volume storage to an existing app.
 
-**[Create and manage volumes with flyctl](/docs/volumes/volume-manage/):** Create, extend, copy, destroy, and restore volumes.
+* **[Create and manage volumes with flyctl](/docs/volumes/volume-manage/):** Create, extend, copy, destroy, and restore volumes.
 
-**[Manage volume snapshots](/docs/volumes/snapshots/):** We back up your data with volume snapshots. Create a volume snapshot on-demand, change the retention time for automatic snapshots, and restore data from a snapshot.
+* **[Manage volume snapshots](/docs/volumes/snapshots/):** We back up your data with volume snapshots. Create a volume snapshot on-demand, change the retention time for automatic snapshots, and restore data from a snapshot.
 
 ## Volume references
 
-[Volume states](/docs/volumes/volume-states/)
+* [Volume states](/docs/volumes/volume-states/)
 
-[flyctl commands - `fly volumes`](/docs/flyctl/volumes/)
+* [flyctl commands - `fly volumes`](/docs/flyctl/volumes/)
 
-[Machines API - Volumes](/docs/machines/api/volumes-resource/)
+* [Machines API - Volumes](/docs/machines/api/volumes-resource/)


### PR DESCRIPTION
### Summary of changes

- Get started by language/framework - simplify the intro and add the missing python-based scanners to the list
- give Kubernetes an index page and adjust related topic links
- move OIDC tokens into Security section
- format index pages to be more consistent (one of two "styles")

### Preview

### Related Fly.io community and GitHub links

### Notes

