### PR TITLE
flyctl install: "work with Fly.io using fly commands"

### DIFF
--- a/partials/docs/_flyctl_install.html.erb
+++ b/partials/docs/_flyctl_install.html.erb
@@ -1,4 +1,4 @@
-flyctl is a command-line utility that lets you work with Fly.io, from creating your account to deploying your applications. It runs on your local device so you'll want to install the version that's appropriate for your operating system.
+flyctl is a command-line utility that lets you work with Fly.io using `fly` commands, from creating your account to deploying your applications. It runs on your local device so you'll want to install the version that's appropriate for your operating system.
 
 <h3 id="macos" class="group flex items-center relative mt-14 sm:mt-16 mb-10 group text-navy font-heading pb-1 border-b">
   <a href="#macos" class="absolute ml-[-1em] pr-[0.5em] after:hash opacity-0 group-hover:opacity-50 transition-all" aria-label="Anchor"></a>


### PR DESCRIPTION
### Summary of changes

Updated the first sentence of the install flyctl doc to include "flyctl is a command-line utility that lets you work with Fly.io using `fly` commands..."

### Preview

### Related Fly.io community and GitHub links

fixes #559 

### Notes

