### PR TITLE
Add section on different ways to authenticate to the Prometheus API

### DIFF
--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -412,7 +412,7 @@ Create an org-restricted token:
 fly token create org -o THE_ORGANIZATION
 ```
 
-A read-only token is created like this:
+Create a read-only org-restricted token:
 
 ```
 fly token create readonly

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -388,3 +388,48 @@ processes = ["proxy"]
 Instrument your app and expose your metrics on `0.0.0.0`.
 
 There are many supported [client libraries](https://prometheus.io/docs/instrumenting/clientlibs/) as well as off-the-shelf [exporters](https://prometheus.io/docs/instrumenting/exporters/) able to return Prometheus-formatted metrics.
+
+## Authentication
+
+Authenticating to the Prometheus API can be achieved a few different ways, depending on the level of access you want your token to have.
+
+### Fly Access Token
+
+As in the earlier example, a full access token can be generated with `flyctl auth token` and then passed as a bearer token in the `Authorization` header. The header looks like:
+
+```
+Authorization: Bearer THE_TOKEN
+```
+
+### Fly org-restricted or read-only token
+
+This kind of token or "[macaroon](https://fly.io/blog/macaroons-escalated-quickly/)" can be scoped to a single organization or configured to only allow read operations, which can be safer than using a full-blown read-write token that grants access to all organizations under your account.
+
+### Generating
+An org-restricted token can be generated like so:
+
+```
+fly token create org -o THE_ORGANIZATION
+```
+
+A read-only token is created like this:
+
+```
+fly token create readonly
+```
+
+Note that the read-only token still has access to all organizations in your account (although it cannot modify anything, only read data). These two can be combined to create a read-only token that is restricted to a single organization:
+
+```
+fly token create readonly --from-existing -t "$(fly token create org -o THE_ORGANIZATION)"
+```
+
+These tokens look like this once generated: `FlyV1 fm2_lJPECAAAAAAAAC7txBAzYI6PRWhHLT...(a lot of base64-encoded text)`.
+
+#### Using
+To use one of these tokens in an HTTP header, the "FlyV1" identifier replaces the "Bearer" token identifier. So it would look like this:
+
+
+```
+Authorization: FlyV1 fm2_lJPECAAAAAAAAC7txBAzYI6PRWhHLT...(a lot of base64-encoded text)
+```

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -112,7 +112,7 @@ the user icon in the lower-left of the screen.
 
 ### External or self-hosted Grafana
 
-You can also configure your Prometheus endpoint with an existing Grafana installation, or [host one on Fly.io](https://github.com/fly-apps/grafana). Either way, you set it up thusly:
+You can also configure your Prometheus endpoint with an existing Grafana installation, or [host one on Fly.io](https://github.com/fly-apps/grafana). Either way, you set it up thus:
 
 1. [Add](https://grafana.com/docs/grafana/latest/datasources/add-a-data-source/) a [Prometheus data source](https://grafana.com/docs/grafana/latest/datasources/prometheus/) (Settings -> Data Sources -> Add data source -> Prometheus)
 2. Fill the form with the following:

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -406,7 +406,7 @@ Authorization: Bearer THE_TOKEN
 This kind of token or "[macaroon](https://fly.io/blog/macaroons-escalated-quickly/)" can be scoped to a single organization or configured to only allow read operations, which can be safer than using a full-blown read-write token that grants access to all organizations under your account.
 
 ### Generating tokens
-An org-restricted token can be generated like so:
+Create an org-restricted token:
 
 ```
 fly token create org -o THE_ORGANIZATION

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -112,7 +112,7 @@ the user icon in the lower-left of the screen.
 
 ### External or self-hosted Grafana
 
-You can also configure your Prometheus endpoint with an existing Grafana installation, or [host one on Fly.io](https://github.com/fly-apps/grafana). Either way, you set it up thus:
+You can also configure your Prometheus endpoint with an existing Grafana installation, or [host one on Fly.io](https://github.com/fly-apps/grafana). Either way, you can set it up like this:
 
 1. [Add](https://grafana.com/docs/grafana/latest/datasources/add-a-data-source/) a [Prometheus data source](https://grafana.com/docs/grafana/latest/datasources/prometheus/) (Settings -> Data Sources -> Add data source -> Prometheus)
 2. Fill the form with the following:

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -426,7 +426,7 @@ fly token create readonly --from-existing -t "$(fly token create org -o THE_ORGA
 
 These tokens look like this once generated: `FlyV1 fm2_lJPECAAAAAAAAC7txBAzYI6PRWhHLT...(a lot of base64-encoded text)`.
 
-#### Using
+#### Using tokens
 To use one of these tokens in an HTTP header, the "FlyV1" identifier replaces the "Bearer" token identifier. So it would look like this:
 
 

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -183,7 +183,7 @@ fly_app_tcp_disconnects_count
 
 ### Instance series - `fly_instance_`
 
-Derived from the [`/proc` filesystem](https://www.kernel.org/doc/html/latest/filesystems/proc.html) of your app VMs.
+Derived from the [`/proc` file system](https://www.kernel.org/doc/html/latest/filesystems/proc.html) of your app VMs.
 
 `fly_instance_up = 1` shows the VM is reporting correctly.
 
@@ -283,7 +283,7 @@ fly_instance_filefd_maximum
 Filesystem metrics derived from [VFS File System Information](https://man7.org/linux/man-pages/man0/sys_statvfs.h.0p.html).
 
 Labels:
-- `mount`: mountpoint name(s), `/` and if using [Volumes](https://fly.io/docs/volumes/), the destination name in fly.toml.
+- `mount`: mount point name(s), `/` and if using [Volumes](https://fly.io/docs/volumes/), the destination name in fly.toml.
 
 ```
 fly_instance_filesystem_blocks

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -405,7 +405,7 @@ Authorization: Bearer THE_TOKEN
 
 This kind of token or "[macaroon](https://fly.io/blog/macaroons-escalated-quickly/)" can be scoped to a single organization or configured to only allow read operations, which can be safer than using a full-blown read-write token that grants access to all organizations under your account.
 
-### Generating
+### Generating tokens
 An org-restricted token can be generated like so:
 
 ```

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -418,12 +418,6 @@ Create a read-only org-restricted token:
 fly token create readonly
 ```
 
-Note that the read-only token still has access to all organizations in your account (although it cannot modify anything, only read data). These two can be combined to create a read-only token that is restricted to a single organization:
-
-```
-fly token create readonly --from-existing -t "$(fly token create org -o THE_ORGANIZATION)"
-```
-
 These tokens look like this once generated: `FlyV1 fm2_lJPECAAAAAAAAC7txBAzYI6PRWhHLT...(a lot of base64-encoded text)`.
 
 #### Using tokens

--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -13,6 +13,7 @@ bool
 buildpacks?\b
 bursty
 callouts?\b
+centiseconds
 cleartext
 containerd
 cron


### PR DESCRIPTION
### Summary of changes
* Explain how to create a non-bearer macaroon token with restrictions (per org, read-only)
* Explain how to pass a macaroon token in the Authorization header

This process is known internally and we share it with customers who require it but a customer pointed out it's not documented which makes it difficult to discover.
