### PR TITLE
Fix example YAML for GitHub Review Apps by bumping `superfly/fly-pr-review-apps` version to latest

### DIFF
--- a/blueprints/review-apps-guide.html.md
+++ b/blueprints/review-apps-guide.html.md
@@ -82,13 +82,13 @@ jobs:
       name: review
       # The script in the `deploy` sets the URL output for each review app.
       url: ${{ steps.deploy.outputs.url }}
-
+    steps:
       - name: Get code
         uses: actions/checkout@v4
 
       - name: Deploy PR app to Fly.io
         id: deploy
-        uses: superfly/fly-pr-review-apps@1.2.0
+        uses: superfly/fly-pr-review-apps@1.2.1
 ```
 
 In the `deploy` step, `superfly/fly-pr-review` contains the custom Action with a shell script that creates and deploys your review apps. If you're curious, check out [entrypoint.sh](https://github.com/superfly/fly-pr-review-apps/blob/main/entrypoint.sh) for full details on how the script works.


### PR DESCRIPTION
### Summary of changes

I recently tried to follow this and ran into a few stumbling blocks. 

1. ~~The `steps` property is missing, so the YAML wasn't valid~~ Looks like this was fixed in another PR
2. `superfly/fly-pr-review-apps` was updated, the current version used (`1.2.0`) uses a flag that no longer exists in the flyctl, and thus this errors

### Related Fly.io community and GitHub links

https://github.com/superfly/fly-pr-review-apps/pull/56

### Notes

There's also a link to a gist on Line 21, which should be updated to the latest version of `superfly/fly-pr-review-apps` as well