### PR TITLE
API docs: make the lists of endpoints into links

### DIFF
--- a/machines/api/apps-resource.html.markerb
+++ b/machines/api/apps-resource.html.markerb
@@ -14,19 +14,19 @@ You can use the Apps resource to create and manage Fly Apps. A Fly App is an abs
       Endpoints
     </div>
     <div class="highlight">
-      <a class="endpoint">
+      <a class="endpoint" href="#create-a-fly-app">
         <span class="post-badge">post</span>
         <span>/v1/apps</span>
       </a>
-      <a class="endpoint">
+      <a class="endpoint" href="#get-app-details">
         <span class="get-badge">get</span>
         <span>/v1/apps/{app\_name}</span>
       </a>
-      <a class="endpoint">
+      <a class="endpoint" href="#delete-a-fly-app">
         <span class="delete-badge">delete</span>
         <span>/v1/apps/{app\_name}</span>
       </a>
-      <a class="endpoint">
+      <a class="endpoint" href="#list-apps-in-an-organization">
         <span class="get-badge">get</span>
         <span>/v1/apps?org_slug=</span>
       </a>

--- a/machines/api/machines-resource.html.markerb
+++ b/machines/api/machines-resource.html.markerb
@@ -13,71 +13,71 @@ You can use the Machines resource to create, stop, start, update, and delete Fly
     Endpoints
   </div>
   <div class="highlight">
-    <a class="endpoint">
+    <a class="endpoint" href="#list-machines">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/machines</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#create-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#wait-for-a-machine-to-reach-a-specified-state">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/wait</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#get-a-machine">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#update-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#stop-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/stop</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#suspend-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/suspend</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#start-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/start</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#delete-a-machine-permanently">
       <span class="delete-badge">delete</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#create-a-machine-lease">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/lease</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#get-a-machine-lease">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/lease</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#release-a-machine-lease">
       <span class="delete-badge">delete</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/lease</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#route-requests-away-from-or-back-to-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/cordon</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#route-requests-away-from-or-back-to-a-machine">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/uncordon</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#get-a-machines-metadata">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/metadata</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#add-or-update-machine-metadata">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/metadata/{key}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#delete-machine-metadata">
       <span class="delete-badge">delete</span>
       <span>/v1/apps/{app\_name}/machines/{machine\_id}/metadata/{key}</span>
     </a>
@@ -847,7 +847,7 @@ Release the lease of a specific Machine within an app. Machine leases can be use
   </div>
 </div>
 
-## Route requests away from or back to a Machine (cordon/uncordon)
+## Route requests away from or back to a Machine
 
 Given the name of a Fly App and the Machine ID of a Fly Machine, instruct the Fly Proxy not to send requests to a Machine or to start sending requests again to a previously cordoned Machine.
 

--- a/machines/api/volumes-resource.html.markerb
+++ b/machines/api/volumes-resource.html.markerb
@@ -13,35 +13,35 @@ You can use the Volumes resource to create and delete volumes. A Fly Volume is p
     Endpoints
   </div>
   <div class="highlight">
-    <a class="endpoint">
+    <a class="endpoint" href="#list-all-the-volumes-in-an-app">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/volumes</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#create-a-volume">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/volumes</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#get-a-specific-volume">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/volumes/{volume\_id}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#update-a-volume">
       <span class="put-badge">put</span>
       <span>/v1/apps/{app\_name}/volumes/{volume\_id}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#delete-a-volume-permanently">
       <span class="delete-badge">delete</span>
       <span>/v1/apps/{app\_name}/volumes/{volume\_id}</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#extend-a-volume">
       <span class="put-badge">put</span>
       <span>/v1/apps/{app\_name}/volumes/{volume\_id}/extend</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#get-a-list-of-snapshots-for-a-volume">
       <span class="get-badge">get</span>
       <span>/v1/apps/{app\_name}/volumes/{volume\_id}/snapshots</span>
     </a>
-    <a class="endpoint">
+    <a class="endpoint" href="#create-an-on-demand-volume-snapshot-beta">
       <span class="post-badge">post</span>
       <span>/v1/apps/{app\_name}/volumes/{volume\_id}/snapshots</span>
     </a>


### PR DESCRIPTION
### Summary of changes

The list of endpoints at the top of the page links to relevant section now. 🎉  This always bugged me.

### Preview

### Related Fly.io community and GitHub links

### Notes

