### PR TITLE
Bad link in SSO docs

### DIFF
--- a/security/sso.html.markerb
+++ b/security/sso.html.markerb
@@ -16,7 +16,7 @@ From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization f
 
 ## Set up SSO using GitHub organization access
 
-Install the [Fly.io GitHub app](https://github.com/apps/fly-io/installations/select_target+external) on the GitHub organization you want to use for SSO.
+Install the [Fly.io GitHub app](https://fly.io/app/auth/github_app+external) on the GitHub organization you want to use for SSO.
 
 From the Fly.io [dashboard](https://fly.io/dashboard/), select an organization from the dropdown. Go to **Settings > Single Sign On > GitHub SSO Requirement**. Enter the GitHub organization ID for SSO, check **Enable**, and click Save.
 


### PR DESCRIPTION
### Summary of changes

For installing the Fly.io GitHub App, we link to https://github.com/apps/fly-io/installations/select_target. We actually need to set a `state` query parameter on this request. We have an endpoint at https://fly.io/app/auth/github_app that adds the parameter and redirects to the GitHub URL.

### Preview

### Related Fly.io community and GitHub links

### Notes

