### PR TITLE
Fix typo on rails getting-started

### DIFF
--- a/rails/getting-started/index.html.md
+++ b/rails/getting-started/index.html.md
@@ -93,7 +93,7 @@ Tigris:       <none>                 (not requested)
 ```
 
 For demo purposes you can accept the defaults.  You can always change these later.
-So respond with "Y" (or simply press enter).
+So respond with "N" (or simply press enter).
 
 This will take a few seconds as it uploads your application, builds a machine image,
 deploys the images, and then monitors to ensure it starts successfully. Once complete


### PR DESCRIPTION
It said "respond with "Y" or press enter" to the question of "do you want to make change) but the default is "N" and it says changes aren't needed, so clearly the intent was "respond with "Y""

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

