### PR TITLE
Add fastapi-cli while instaling fastapi

### DIFF
--- a/python/frameworks/fastapi.html.markerb
+++ b/python/frameworks/fastapi.html.markerb
@@ -28,7 +28,7 @@ Deploying a FastAPI app on Fly.io is... well it's fast! You can be up and runnin
 Then we have to add the FastAPI dependency:
 
 ```cmd
-poetry add fastapi
+poetry add fastapi fastapi-cli
 ```
 
 Now, let's create a simple FastAPI app in `main.py`:


### PR DESCRIPTION
### Summary of changes

The official doc said We can then serve the development version of the app using the fastapi cli tool - `fastapi run`.
But the doc has never mentioned installing fastapi-cli.
Thus, `poetry add fastapi` has to include fastapi-cli

`poetry add fastapi fastapi-cli`

### Preview

![image](https://github.com/user-attachments/assets/974fed2f-2b4e-42ed-aad1-65056aee59c8)


### Related Fly.io community and GitHub links

#1738 

### Notes

