### PR TITLE
Start replacing `fly auth token` with more limited tokens

### DIFF
--- a/blueprints/review-apps-guide.html.md
+++ b/blueprints/review-apps-guide.html.md
@@ -17,7 +17,7 @@ Review apps are a great way to preview new features, changes, and bug fixes. Thi
 
 If you've worked with GitHub Actions before and want to jump right in, here are the steps to take:
 
-1. Create a new repository secret on your GitHub repository called `FLY_API_TOKEN` and provide it with the returned value of `fly auth token`
+1. Create a new repository secret on your GitHub repository called `FLY_API_TOKEN` and provide it with the returned value of `fly tokens org <ORG NAME>`
 1. Create a new workflow in your project at `.github/workflows/fly-review.yml` and add the following [YAML code](https://gist.github.com/anniebabannie/3cb800f2a890a6f3ed3167c09a0234dd).
 1. Commit and push the changes containing your GitHub workflow.
 
@@ -37,10 +37,10 @@ For more details about each step, follow the guide below.
 Your GitHub Action will need a Fly API token to deploy and manage new review apps on Fly.io. You can get this token using the following [flyctl](/docs/flyctl/install/) command:
 
 ```cmd
-fly auth token
+fly tokens org <ORG NAME>
 ```
 
-This token is specific to a single Fly.io account and is valid for applications belonging the that account.
+This token is specific to a single Fly.io organization and is valid for applications belonging the that organization.
 
 Next, let's save our API token as a secret in our GitHub repository. Visit the Settings tab in your repository, then Secrets and variables → Actions. Alternatively, you can visit `https://github.com/<username or org>/<repository>/settings/secrets/actions`. There, create a new **Repository Secret** called `FLY_API_TOKEN` with the value of your token.
 

--- a/django/advanced-guides/staging-environments-with-github-actions.html.md
+++ b/django/advanced-guides/staging-environments-with-github-actions.html.md
@@ -35,6 +35,10 @@ next, create a new secret called `FLY_API_TOKEN` with a value from:
 fly tokens org <ORG NAME>
 ```
 
+<section class="callout">
+It's also possible to create a token from the organization dashboard, under the "Tokens" tab.
+</section>
+
 Now, we're ready to add a new flow. This is how we can define it in the
 `.github/workflows/fly_pr_preview.yml` file:
 

--- a/django/advanced-guides/staging-environments-with-github-actions.html.md
+++ b/django/advanced-guides/staging-environments-with-github-actions.html.md
@@ -32,11 +32,8 @@ repository page and open:
 next, create a new secret called `FLY_API_TOKEN` with a value from:
 
 ```cmd
-fly auth token
+fly tokens org <ORG NAME>
 ```
-<section class="callout">
-It's also possible to create a new token on the [dashboard](https://fly.io/user/personal_access_tokens).
-</section>
 
 Now, we're ready to add a new flow. This is how we can define it in the
 `.github/workflows/fly_pr_preview.yml` file:

--- a/flyctl/cmd/fly_auth_token.md
+++ b/flyctl/cmd/fly_auth_token.md
@@ -1,6 +1,6 @@
-Shows the authentication token that is currently in use by flyctl.
-
-This can be used as an authentication token with API services. These tokens may expire quickly and shouldn't be used in places where the token needs to keep working for a long time. Use `fly tokens create` instead for creating narrowly scoped tokens that can have a custom expiry.
+Shows the authentication token that is currently in use.
+This can be used as an authentication token with API services,
+independent of flyctl.
 
 
 ## Usage
@@ -26,3 +26,4 @@ fly auth token [flags]
 ## See Also
 
 * [fly auth](/docs/flyctl/auth/)	 - Manage authentication
+

--- a/flyctl/cmd/fly_auth_token.md
+++ b/flyctl/cmd/fly_auth_token.md
@@ -1,6 +1,6 @@
-Shows the authentication token that is currently in use.
-This can be used as an authentication token with API services,
-independent of flyctl.
+Shows the authentication token that is currently in use by flyctl.
+
+This can be used as an authentication token with API services. These tokens may expire quickly and shouldn't be used in places where the token needs to keep working for a long time. Use `fly tokens create` instead for creating narrowly scoped tokens that can have a custom expiry.
 
 
 ## Usage
@@ -26,4 +26,3 @@ fly auth token [flags]
 ## See Also
 
 * [fly auth](/docs/flyctl/auth/)	 - Manage authentication
-

--- a/laravel/advanced-guides/github-actions.html.md
+++ b/laravel/advanced-guides/github-actions.html.md
@@ -1,7 +1,7 @@
 ---
 title: "Laravel GitHub Actions: CICD"
 layout: framework_docs
-objective: Configure continuous integration and development on your Laravel Fly App through GitHub. 
+objective: Configure continuous integration and development on your Laravel Fly App through GitHub.
 order: 3
 ---
 
@@ -20,7 +20,7 @@ In this section, you'll create a new Laravel application, configure and deploy i
 composer create-project laravel/laravel fly-laravel
 cd fly-laravel
 
-# Auto generate your `fly.toml` configuration file: 
+# Auto generate your `fly.toml` configuration file:
 # Add in the ams region with --region
 # Auto deploy using --now while your at it!
 flyctl launch --region ams --now
@@ -43,11 +43,11 @@ git remote add origin git@github.com:<username>/<repository-name>.git
 
 ## GitHub CI Action: Auto Deploy to Fly.io
 
-Once you have your Laravel application set up with a github repository, you can configure some GitHub Actions to auto deploy your changes. 
+Once you have your Laravel application set up with a github repository, you can configure some GitHub Actions to auto deploy your changes.
 
 In this guide, you'll be using `Fly.io`'s very own [GitHub action template here](https://github.com/superfly/flyctl-actions) to help deploy your application.
 
-1) Generate a `Fly token` with `fly auth token`
+1) Generate a `Fly token` with `fly tokens deploy`
 
 2) Then save your newly generated `FLY_API_TOKEN` in your github repository either through the GitHub Console or GitHub CLI:
 

--- a/machines/api/working-with-machines-api.html.markerb
+++ b/machines/api/working-with-machines-api.html.markerb
@@ -46,15 +46,15 @@ For local development, you might set them as follows, assuming you have flyctl i
 
 ```bash
 $ export FLY_API_HOSTNAME="https://api.machines.dev" # set to http://_api.internal:4280 when using WireGuard
-$ export FLY_API_TOKEN=$(fly auth token)
+$ export FLY_API_TOKEN=$(fly tokens deploy)
 ```
 
-The `fly auth token` command returns the token currently in use by `flyctl`. You can also create a new auth token in the Tokens section of the Fly.io dashboard.
+The `fly tokens deploy` command creates a token capable of managing the application in your current directory. See `fly tokens create --help` for information on other types of tokens you can generate.
 
 To set an access token as an environment variable on Fly Machines, use a [secret](/docs/apps/secrets/); for example:
 
 ```cmd
-fly secrets set FLY_API_TOKEN=$(fly auth token)
+fly secrets set FLY_API_TOKEN=$(fly tokens deploy)
 ```
 
 ## Response Codes

--- a/monitoring/exporting-logs.html.md
+++ b/monitoring/exporting-logs.html.md
@@ -3,7 +3,7 @@ title: Export logs
 layout: docs
 objective: Aggregate your logs to a service of your choice.
 nav: firecracker
-redirect_from: 
+redirect_from:
   - /docs/going-to-production/monitoring/exporting-logs/
   - /docs/metrics-and-logs/exporting-logs/
 ---
@@ -38,8 +38,9 @@ fly launch --no-deploy --image ghcr.io/superfly/fly-log-shipper:latest
 
 # Set some secrets. The secret / env var you set
 # determines which "sinks" are configured
-fly secrets set ORG=personal
-fly secrets set ACCESS_TOKEN=$(fly auth token)
+ORG=personal
+fly secrets set ORG=$ORG
+fly secrets set ACCESS_TOKEN=$(fly tokens create readonly $ORG)
 fly secrets set LOGTAIL_TOKEN=<token provided by logtail source>
 ```
 

--- a/rails/advanced-guides/machine.html.md
+++ b/rails/advanced-guides/machine.html.md
@@ -73,10 +73,10 @@ ENV PATH="$FLYCTL_INSTALL/bin:$PATH"
 
 A good place to put these lines is immediately before the `# Deploy your application` comment.
 
-Next we need to make our Fly token available to our application:
+Next we need to make a Fly token available to our application:
 
 ```cmd
-fly secrets set FLY_API_TOKEN=$(fly auth token)
+fly secrets set FLY_API_TOKEN=$(fly tokens deploy)
 ```
 
 ## Add a controller
@@ -144,7 +144,7 @@ Overall the tasks to be performed by this job:
   * Specify a machine configuration.  For simplicity we will use the
     same Fly application name and the same Fly image as our Rails
     application.  The server command will be `curl` specifying the
-    URL that was passed as an argument to the job. 
+    URL that was passed as an argument to the job.
   * Start a machine using this configuration, and
     check for errors, and log the results.
   * Query the status of the machine every 10 seconds for a maximum


### PR DESCRIPTION
### Summary of changes

This is mostly a conversation starter. We need to move away from telling users to configure things with the output from `fly auth token`. For most users, this output is flyctl's own token, which is invalidated if the user logs out of flyctl and almost certainly has access to more things than necessary. For members of organizations that require SSO, the output from `fly auth token` is a bundle of short-lived tokens (one for each org) that can only be used by flyctl, who knows how to refresh the tokens so they keep working. Eventually, `fly auth token` will return this kind of token bundle for all users, making it inappropriate for use other than by flyctl itself.

We need to move towards recommending `fly tokens create <token-type>`:

- `fly tokens create deploy [-a app-name]` - Token for accessing a single Fly App.
- `fly tokens create org <org-slug>` - Token for accessing all apps within a single Fly.io organization.
- `fly tokens create readonly <org-slug>` - Token with readonly access to a single Fly.io organization.

I updated a few commands in guides and updated a bit of language. This almost certainly needs some tweaking by someone who's better at writing docs :smile:

### Preview

### Related Fly.io community and GitHub links

### Notes

