### PR TITLE
Fix issue working-with-machines-api.html.markerb

### DIFF
--- a/machines/api/working-with-machines-api.html.markerb
+++ b/machines/api/working-with-machines-api.html.markerb
@@ -54,7 +54,7 @@ The `fly tokens deploy` command creates a token capable of managing the applicat
 To set an access token as an environment variable on Fly Machines, use a [secret](/docs/apps/secrets/); for example:
 
 ```cmd
-fly secrets set FLY_API_TOKEN=$(fly tokens deploy)
+fly secrets set FLY_API_TOKEN="$(fly tokens deploy)"
 ```
 
 ## Response Codes


### PR DESCRIPTION
### Summary of changes

Quote shell variable

### Preview

N/A

### Related Fly.io community and GitHub links

https://fly.io/docs/machines/api/working-with-machines-api/

### Notes

The previous command results in an error.

```
% fly secrets set FLY_API_TOKEN=$(fly tokens deploy)
Error: Validation failed: Name only allows letters, numbers, and underscores
```