### PR TITLE
Update how to remove a standby Machine

### DIFF
--- a/apps/app-availability.html.markerb
+++ b/apps/app-availability.html.markerb
@@ -79,8 +79,6 @@ The standby Machine doesn't consume resources or start up until it's needed.
 
 #### Remove a standby Machine
 
-If you destroy a standby Machine, it is not recreated when you [scale up or back down](/docs/apps/scale-count/) using `fly scale count`.
-
 To remove a standby Machine, run `fly status` and copy the ID of the Machine that displays the `†` symbol beside the process group name. For example:
 
 ```
@@ -88,7 +86,9 @@ PROCESS	ID            	VERSION	REGION	STATE  	ROLE	CHECKS	LAST UPDATED
 task†  	784e469a443e38	43     	yul   	stopped	    	      	2024-08-06T20:48:10Z
 ```
 
-Then destroy the standby with `fly machine destroy <machine id>`.
+Then destroy the standby Machine with `fly machine destroy <machine id>`.
+
+If you destroy a standby Machine, it is not recreated when you [scale up or back down](/docs/apps/scale-count/) using `fly scale count`.
 
 If you add services for a process group in `fly.toml` that previously had no services, then the standby designation is removed from the standby Machine on the next deploy.
 

--- a/apps/app-availability.html.markerb
+++ b/apps/app-availability.html.markerb
@@ -79,9 +79,18 @@ The standby Machine doesn't consume resources or start up until it's needed.
 
 #### Remove a standby Machine
 
-When an app or process group has one Machine and one standby Machine, the standby Machine is destroyed first if you scale down to one Machine. The standby Machine isn't subsequently recreated when you [scale up or back down](/docs/apps/scale-count/) using `fly scale count`.
+If you destroy a standby Machine, it is not recreated when you [scale up or back down](/docs/apps/scale-count/) using `fly scale count`.
 
-If you add services to the process group in `fly.toml`, then the standby designation is removed from the standby Machine on the next deploy.
+To remove a standby Machine, run `fly status` and copy the ID of the Machine that displays the `†` symbol beside the process group name. For example:
+
+```
+PROCESS	ID            	VERSION	REGION	STATE  	ROLE	CHECKS	LAST UPDATED
+task†  	784e469a443e38	43     	yul   	stopped	    	      	2024-08-06T20:48:10Z
+```
+
+Then destroy the standby with `fly machine destroy <machine id>`.
+
+If you add services for a process group in `fly.toml` that previously had no services, then the standby designation is removed from the standby Machine on the next deploy.
 
 #### Create a standby Machine
 


### PR DESCRIPTION
### Summary of changes

Testing shows that the behaviour whereby we delete the standby first when scaling with `fly scale count` doesn't apply anymore. Updating docs to show how to identify and delete the standby.

### Preview

### Related Fly.io community and GitHub links

### Notes

