### PR TITLE
Change number of regions

### DIFF
--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -4,7 +4,7 @@ layout: docs
 nav: firecracker
 ---
 
-Fly.io runs applications physically close to users: in datacenters around the world, on servers we run ourselves. You can currently deploy your apps in 38 regions, connected to a global Anycast network that makes sure your users hit our nearest server, whether they’re in Tokyo, São Paulo, or Amsterdam.
+Fly.io runs applications physically close to users: in datacenters around the world, on servers we run ourselves. You can currently deploy your apps in 35 regions, connected to a global Anycast network that makes sure your users hit our nearest server, whether they’re in Tokyo, São Paulo, or Amsterdam.
 
 <div class="callout">
 Run <code>fly platform regions</code> to get a list of regions.


### PR DESCRIPTION
There are 38 regions in total, but users can only deploy to 35.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

