### PR TITLE
Fix machine_checks example error

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -409,7 +409,7 @@ You can use the same `machine_checks` section for HTTP services as for [`service
 [http_services.machine_checks]
   image = "curlimages/curl"
   entrypoint = ["/bin/sh", "-c"]
-  command = ["curl", "$FLY_TEST_MACHINE_IP", "|", "grep", "Hello, World!"]
+  command = ["curl http://[$FLY_TEST_MACHINE_IP] | grep 'Hello, World!'"]
   kill_signal = "SIGKILL"
   kill_timeout = "5s"
 ```
@@ -662,13 +662,13 @@ Times are in milliseconds unless units are specified.
 
 ### `services.machine_checks`
 
-Machine checks work a bit differently than the other checks. They run on each deploy, and if they fail, the deploy is stopped. A new Machine is spawned with the environment variable `FLY_TEST_MACHINE_IP` set to the IP address of the Machine being tested. This is useful for running integration tests on Machines before a deployment. Here's an example:
+Machine checks work a bit differently than the other checks. They run on each deploy, and if they fail, the deploy is stopped. A new Machine is spawned with the environment variable `FLY_TEST_MACHINE_IP` set to the [6PN IPv6 address](/docs/networking/private-networking/#6pn-addresses-in-detail) of the Machine being tested. This is useful for running integration tests on Machines before a deployment. Here's an example:
 
 ```toml
   [[services.machine_checks]]
     image = "curlimages/curl"
     entrypoint = ["/bin/sh", "-c"]
-    command = ["curl", "$FLY_TEST_MACHINE_IP", "|", "grep", "Hello, World!"]
+    command = ["curl http://[$FLY_TEST_MACHINE_IP] | grep 'Hello, World!'"]
     kill_signal = "SIGKILL"
     kill_timeout = "5s"
 ```


### PR DESCRIPTION
The machine_checks toml example showed `/bin/sh -c` being given multiple arguments. But /bin/sh -c should be given a single argument that's a long single string containing the bash to execute.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

