### PR TITLE
Update PG Snapshot restore instructions

### DIFF
--- a/apps/trouble-host-unavailable.html.markerb
+++ b/apps/trouble-host-unavailable.html.markerb
@@ -76,7 +76,7 @@ Volumes are pinned to physical hosts, so when there's a host outage the volume i
 
 If you're running a high availability Postgres cluster with multiple nodes, a host issue impacting one of your nodes shouldn't cause an issue; by default we run each node on a separate host. If the host your primary node is on goes down, the cluster will fail over to a healthy node. 
 
-However, if your database is running on a single Machine, and you don’t have any replicas to fail over to, then you won’t be able to connect during the host outage. Similar to the single volume steps above, you can create a new Postgres app from your most recent volume snapshot using `fly postgres create --snapshot-id <snapshot_id>`. See [Backup, restores, & snapshots](/docs/postgres/managing/backup-and-restore/) for details.
+However, if your database is running on a single Machine, and you don’t have any replicas to fail over to, then you won’t be able to connect during the host outage. Similar to the single volume steps above, you can create a new Postgres app from your most recent volume snapshot using `fly postgres create --snapshot-id <snapshot_id> --image <image-version>`. See [Backup, restores, & snapshots](/docs/postgres/managing/backup-and-restore/) for details.
 
 ## Prevent downtime when there's a single host issue
 

--- a/apps/trouble-host-unavailable.html.markerb
+++ b/apps/trouble-host-unavailable.html.markerb
@@ -76,7 +76,7 @@ Volumes are pinned to physical hosts, so when there's a host outage the volume i
 
 If you're running a high availability Postgres cluster with multiple nodes, a host issue impacting one of your nodes shouldn't cause an issue; by default we run each node on a separate host. If the host your primary node is on goes down, the cluster will fail over to a healthy node. 
 
-However, if your database is running on a single Machine, and you don’t have any replicas to fail over to, then you won’t be able to connect during the host outage. Similar to the single volume steps above, you can create a new Postgres app from your most recent volume snapshot using `fly postgres create --snapshot-id <snapshot_id> --image <image-version>`. See [Backup, restores, & snapshots](/docs/postgres/managing/backup-and-restore/) for details.
+However, if your database is running on a single Machine, and you don’t have any replicas to fail over to, then you won’t be able to connect during the host outage. Similar to the single volume steps above, you can create a new Postgres app from your most recent volume snapshot using `fly postgres create --snapshot-id <snapshot_id> --image-ref <image-version>`. See [Backup, restores, & snapshots](/docs/postgres/managing/backup-and-restore/) for details.
 
 ## Prevent downtime when there's a single host issue
 

--- a/postgres/managing/backup-and-restore.html.markerb
+++ b/postgres/managing/backup-and-restore.html.markerb
@@ -84,12 +84,25 @@ vs_OPQXXna6kA2Qnhz8 26 MiB 2 days ago
 
 The values under the `ID` columns are what will be used to restore a snapshot.
 
-## Restoring from a snapshot
-
-To restore a Postgres application from a snapshot, simply specify the `--snapshot-id` argument when running the `create` command as shown below:
+## Identifying your Postgres image version
+Depending on when you created your Postgres cluster, it may be running an older image than the default for newly clusters. Different Postgres major versions may not be fully compatible, so it's important to use the same version for your restored cluster.
+To see your Postgres image and version, run `fly image show`. 
 
 ```cmd
-fly postgres create --snapshot-id <snapshot-id>
+fly image show -a <postgres-app-name>
+```
+```output
+MACHINE ID      REGISTRY                REPOSITORY      TAG     VERSION DIGEST                        LABELS                                                                          
+e286004f696700  registry-1.docker.io    flyio/postgres  14.6    v0.0.41 sha256:3c25db96357a78e827ca7d fly.app_role=postgres_clusterfly.pg-version=14.6-1.pgdg110+1fly.version=v0.0.41
+```
+Take note of the REPOSITORY and TAG fields. Legacy postgres images use the `flyio/postgres` repository, while new Postgres Flex images use the flyio/`postgres-flex` repository. In the above example, the machine is running a legacy `flyio/postgres:14.6` image.
+
+## Restoring from a snapshot
+
+To restore a Postgres application from a snapshot, simply specify the `--snapshot-id` argument and the `--image` argument when running the `create` command as shown below:
+
+```cmd
+fly postgres create --snapshot-id <snapshot-id> --image <image-version>
 ```
 ```output
 ? App Name: my-app-db-restored
@@ -108,7 +121,7 @@ Postgres cluster my-app-db-restored created
 Save your credentials in a secure place, you won't be able to see them again!
 ```
 
-This provisions and launches a new Fly Postgres database server with the specified snapshot.
+This provisions and launches a new Fly Postgres database server with the specified snapshot and the same image as your existing database.
 
 <div class="important icon">
   <b>Important:</b> The size of the volume provisioned for the new Fly Postgres application must be equal to or greater than the volume from where the snapshot was taken.

--- a/postgres/managing/backup-and-restore.html.markerb
+++ b/postgres/managing/backup-and-restore.html.markerb
@@ -101,10 +101,10 @@ Legacy postgres images use the `flyio/postgres` repository, while new Postgres
 
 ## Restoring from a snapshot
 
-To restore a Postgres application from a snapshot, simply specify the `--snapshot-id` argument and the `--image` argument when running the `create` command as shown below:
+To restore a Postgres application from a snapshot, simply specify the `--snapshot-id` argument and the `--image-ref` argument when running the `create` command as shown below:
 
 ```cmd
-fly postgres create --snapshot-id <snapshot-id> --image <image-version>
+fly postgres create --snapshot-id <snapshot-id> --image-ref <image-version>
 ```
 ```output
 ? App Name: my-app-db-restored

--- a/postgres/managing/backup-and-restore.html.markerb
+++ b/postgres/managing/backup-and-restore.html.markerb
@@ -85,7 +85,8 @@ vs_OPQXXna6kA2Qnhz8 26 MiB 2 days ago
 The values under the `ID` columns are what will be used to restore a snapshot.
 
 ## Identifying your Postgres image version
-Depending on when you created your Postgres cluster, it may be running an older image than the default for newly clusters. Different Postgres major versions may not be fully compatible, so it's important to use the same version for your restored cluster.
+Depending on when you created your Postgres cluster, it may be running an older image than the default for newly created clusters. Different Postgres major versions may not be fully compatible, so it's important to use the same version for your restored cluster.
+
 To see your Postgres image and version, run `fly image show`. 
 
 ```cmd
@@ -95,7 +96,8 @@ fly image show -a <postgres-app-name>
 MACHINE ID      REGISTRY                REPOSITORY      TAG     VERSION DIGEST                        LABELS                                                                          
 e286004f696700  registry-1.docker.io    flyio/postgres  14.6    v0.0.41 sha256:3c25db96357a78e827ca7d fly.app_role=postgres_clusterfly.pg-version=14.6-1.pgdg110+1fly.version=v0.0.41
 ```
-Take note of the REPOSITORY and TAG fields. Legacy postgres images use the `flyio/postgres` repository, while new Postgres Flex images use the flyio/`postgres-flex` repository. In the above example, the machine is running a legacy `flyio/postgres:14.6` image.
+The values under the `REPOSITORY and `TAG columns are the image you'll use to restore the snapshot. 
+Legacy postgres images use the `flyio/postgres` repository, while new Postgres Flex images use the flyio/`postgres-flex` repository. In the above example, the machine is running a legacy `flyio/postgres:14.6` image.
 
 ## Restoring from a snapshot
 


### PR DESCRIPTION
### Summary of changes

There's some interop issues with restoring a snapshot for an older stolon PG into a new postgres-flex cluster. It's also not ideal to restore across different major versions of pg-flex. This updates the PG restore docs to add a section on  how to find your image and specify it when restoring the pg cluster. It also updates the PG restore instructions in the single host failure doc.

### Preview

### Related Fly.io community and GitHub links
Resolves https://github.com/superfly/docs/issues/1772
### Notes

