### PR TITLE
fully write out powershell commands

### DIFF
--- a/partials/docs/_flyctl_install.html.erb
+++ b/partials/docs/_flyctl_install.html.erb
@@ -46,7 +46,7 @@ curl -L https://fly.io/install.sh | sh
 Run the PowerShell install script:
 
 ```cmd
-pwsh -Command "iwr https://fly.io/install.ps1 -useb | iex"
+powershell -Command "Invoke-WebRequest https://fly.io/install.ps1 -UseBasicParsing | Invoke-Expression"
 ```
 
 If you encounter an error saying the `pwsh` command is not found, `powershell` can be used instead, though we recommend [installing the latest version of PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows).


### PR DESCRIPTION
If you have Elixir installed, using the short version of the command `iex` breaks the install. Better to fully write it out. People will copy and paste it anyway.