### PR TITLE
Update fly_postgres_import.md

### DIFF
--- a/flyctl/cmd/fly_postgres_import.md
+++ b/flyctl/cmd/fly_postgres_import.md
@@ -6,6 +6,10 @@ Imports database from a specified Postgres URI
 fly postgres import <source-uri> [flags]
 ~~~
 
+~~~
+<source-uri> Can be a postgresql connection string. If your database is local beware that you may need to use a proxy to allow *fly* temporary machine to reach your local database.
+~~~
+
 ## Options
 
 ~~~


### PR DESCRIPTION
The motivation is to clarify a bit about what we can use as a source-uri.

I took hours to discover that I couldn't use localhost as a target in the URI, which makes total sense now that I know :) 

I'm still not convinced this is a good contribution, mainly because the copy is probably not abstract enough. But well, here it is.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

