### PR TITLE
Update _cargo-new.html.erb

### DIFF
--- a/rust/partials/_cargo-new.html.erb
+++ b/rust/partials/_cargo-new.html.erb
@@ -1,4 +1,4 @@
-If you don't already have an existing Axum application, you can create one with `cargo`:
+If you don't already have an existing <%= runtime %>application, you can create one with `cargo`:
 
 ```cmd
 cargo new <%= runtime %>-on-fly


### PR DESCRIPTION
###  Correction in Rust framework

### Summary of changes
Dynamically insert the correct framework name based on the runtime variable passed in the locals object when rendering the partial.
The documentation will reference the correct framework instead of Axum as a default framework.

### Preview

### Related Fly.io community and GitHub links

### Notes

