### PR TITLE
Update dockerfile package name in docs

### DIFF
--- a/js/frameworks/astro.html.markerb
+++ b/js/frameworks/astro.html.markerb
@@ -107,4 +107,4 @@ This will install `@astrojs/node` and make the appropriate changes to your `astr
 
 ## Generating your Astro Dockerfile
 
-As discussed earlier, running `fly launch` will generate a Dockerfile for you if one does not already exist. Separately, you can also generate your Dockerfile using [Dockerfile generator](https://www.npmjs.com/package/@flydotio/dockerfile). Once installed, it can be run using `npx dockerfile` for Node applications or `bunx dockerfile` for Bun applications. You'll see it referenced throughout this article for various use cases.
+As discussed earlier, running `fly launch` will generate a Dockerfile for you if one does not already exist. Separately, you can also generate your Dockerfile using [Dockerfile generator](https://www.npmjs.com/package/@flydotio/dockerfile). Once installed, it can be run using `npx @flydotio/dockerfile` for Node applications or `bunx @flydotio/dockerfile` for Bun applications. You'll see it referenced throughout this article for various use cases.

--- a/js/frameworks/nextjs.html.markerb
+++ b/js/frameworks/nextjs.html.markerb
@@ -253,7 +253,7 @@ for you.
 Next, you need to modify your Dockerfile to mount a secret. The easiest way to do this is using the [Dockerfile generator](https://www.npmjs.com/package/@flydotio/dockerfile), like so:
 
 ```cmd
-npx dockerfile --mount-secret=DATABASE_URL
+npx @flydotio/dockerfile --mount-secret=DATABASE_URL
 ```
 
 It is possible to mount multiple secrets, and you can read more about [mounting secrets](/docs/apps/build-secrets/#mounting-secrets) for further details.
@@ -281,7 +281,7 @@ You can let the [Dockerfile generator](https://www.npmjs.com/package/@flydotio/d
 changes for you:
 
 ```
-npx dockerfile --build=defer
+npx @flydotio/dockerfile --build=defer
 ```
 
 Downsides of this approach:
@@ -310,7 +310,7 @@ ARG NEXT_PUBLIC_OTHER="Other value"
 Alternatively, if you'd prefer to use the Dockerfile generator, you can do so by running the following:
 
 ```cmd
-npx dockerfile "--arg-build=NEXT_PUBLIC_EXAMPLE:value" \
+npx @flydotio/dockerfile "--arg-build=NEXT_PUBLIC_EXAMPLE:value" \
   "--arg-build=NEXT_PUBLIC_OTHER=Other value"
 ```
 
@@ -328,7 +328,7 @@ https://nextjs.org/telemetry
 The following command can be used to modify your Dockerfile to disable telemetry:
 
 ```cmd
-npx dockerfile --env-base=NEXT_TELEMETRY_DISABLED:1
+npx @flydotio/dockerfile --env-base=NEXT_TELEMETRY_DISABLED:1
 ```
 
 

--- a/js/frameworks/nextjs.html.markerb
+++ b/js/frameworks/nextjs.html.markerb
@@ -116,7 +116,7 @@ CMD [ "node", "server.js" ]
 
 ## Generating your Next.js Dockerfile
 
-While you're welcome to write your own Dockerfile, the easiest way to get started with this is to use the [Dockerfile generator](https://www.npmjs.com/package/@flydotio/dockerfile). Once installed, it can be run using `npx dockerfile` for Node applications or `bunx dockerfile` for Bun applications. You'll see it referenced throughout this article for various use cases.
+While you're welcome to write your own Dockerfile, the easiest way to get started with this is to use the [Dockerfile generator](https://www.npmjs.com/package/@flydotio/dockerfile). Once installed, it can be run using `npx @flydotio/dockerfile` for Node applications or `bunx @flydotio/dockerfile` for Bun applications. You'll see it referenced throughout this article for various use cases.
 
 ## Connecting to databases
 

--- a/js/the-basics/database.html.md
+++ b/js/the-basics/database.html.md
@@ -94,5 +94,5 @@ For databases other than Sqlite3, this is best done as a one-off command run in 
 For sqlite3, a different approach is required as the migration will need to be run on each machine that has a volume mounted.  This can be accomplished by creating a small script that first runs the migrate command then run the web server start script.  You can place this script in your source tree, and then use the following command to replace the CMD in the Dockerfile:
 
 ```cmd
-npx dockerfile --cmd=file
+npx @flydotio/dockerfile --cmd=file
 ```

--- a/js/the-basics/dependencies.html.md
+++ b/js/the-basics/dependencies.html.md
@@ -38,7 +38,7 @@ the `package.json`.  An alternative when this isn't feasible or desired is to re
 dockerfile to include _all_ dependencies at deployment:
 
 ```cmd
-npx dockerfile --dev
+npx @flydotio/dockerfile --dev
 ```
 
 ## Legacy peer dependencies
@@ -50,7 +50,7 @@ necessary to indicate that these dependencies are _legacy_.  The way to do this 
 based on the package manager, and dockerfile-node can take care of this for you:
 
 ```cmd
-npx dockerfile --legacy-peer-deps
+npx @flydotio/dockerfile --legacy-peer-deps
 ```
 
 ## Native modules
@@ -59,9 +59,9 @@ Some npm modules are _native_ modules which may require additional libraries to 
 installed, either at build time, or at deploy time, or both.
 
 ```
-npx dockerfile --add-base=libxml2
-npx dockerfile --add-build=babel
-npx dockerfile --add-deploy=fontconfig
+npx @flydotio/dockerfile --add-base=libxml2
+npx @flydotio/dockerfile --add-build=babel
+npx @flydotio/dockerfile --add-deploy=fontconfig
 ```
 
 If you find yourself needing to do this, and your need is a consequence of using a

--- a/js/the-basics/dockerfiles.html.md
+++ b/js/the-basics/dockerfiles.html.md
@@ -22,5 +22,5 @@ able to use one or more of the many [options](https://github.com/fly-apps/docker
 to make changes.  For example:
 
 ```cmd
-npx dockerfile --add=dnsutils
+npx @flydotio/dockerfile --add=dnsutils
 ```


### PR DESCRIPTION
### Summary of changes
Update dockerfile package name in docs (https://fly.io/docs/js/frameworks/nextjs/#generating-your-next-js-dockerfile)

### Preview
Before:
![before](https://github.com/user-attachments/assets/c68048ce-2ab4-4c9c-9253-5e8f9232594c)
After:
![after](https://github.com/user-attachments/assets/58f55cf2-207f-4de1-a2a3-0fbd3798b546)

### Related Fly.io community and GitHub links
N/A

### Notes
Don't merge this yet, I'll check for other references.

