### PR TITLE
Remove --max-time option in queue:listen

### DIFF
--- a/laravel/the-basics/cron-and-queues.html.md
+++ b/laravel/the-basics/cron-and-queues.html.md
@@ -42,7 +42,7 @@ We can start an instance of our queue worker by adding another process. In this 
   worker = "php artisan queue:listen"
 ```
 
-Note that you may want to expand on the `queue:listen` command. For example, you could run `php artisan queue:listen sqs --sleep=3 --tries=3 --max-time=3600` to use the `sqs` driver and determine other behaviors.
+Note that you may want to expand on the `queue:listen` command. For example, you could run `php artisan queue:listen sqs --sleep=3 --tries=3` to use the `sqs` driver and determine other behaviors.
 
 ## Extra Credit
 


### PR DESCRIPTION
Remove --max-time option because it doesn't exist in php artisan queue:listen command.

### Summary of changes

This PR is intended to remove ambiguity of `--max-time` option exist in `queue:listen`. I use Laravel version 11 to check the options available in `queue:listen` command.

I try to run command `php artisan queue:listen` with `--max-time` option but it gets error because the `--max-time` doesn't exist. I check the detail options available in `queue:listen` in Laravel project and `--max-time` doesn't exist. The `--max-time` exist in `queue:work`.

```bash
php artisan queue:listen --help

Description:
  Listen to a given queue

Usage:
  queue:listen [options] [--] [<connection>]

Arguments:
  connection               The name of connection

Options:
      --name[=NAME]        The name of the worker [default: "default"]
      --delay[=DELAY]      The number of seconds to delay failed jobs (Deprecated) [default: "0"]
      --backoff[=BACKOFF]  The number of seconds to wait before retrying a job that encountered an uncaught exception [default: "0"]
      --force              Force the worker to run even in maintenance mode
      --memory[=MEMORY]    The memory limit in megabytes [default: "128"]
      --queue[=QUEUE]      The queue to listen on
      --sleep[=SLEEP]      Number of seconds to sleep when no job is available [default: "3"]
      --rest[=REST]        Number of seconds to rest between jobs [default: "0"]
      --timeout[=TIMEOUT]  The number of seconds a child process can run [default: "60"]
      --tries[=TRIES]      Number of times to attempt a job before logging it failed [default: "1"]
  -h, --help               Display help for the given command. When no command is given display help for the list command
  -q, --quiet              Do not output any message
  -V, --version            Display this application version
      --ansi|--no-ansi     Force (or disable --no-ansi) ANSI output
  -n, --no-interaction     Do not ask any interactive question
      --env[=ENV]          The environment the command should run under
  -v|vv|vvv, --verbose     Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

```
php artisan queue:work --help  
Description:
  Start processing jobs on the queue as a daemon

Usage:
  queue:work [options] [--] [<connection>]

Arguments:
  connection                 The name of the queue connection to work

Options:
      --name[=NAME]          The name of the worker [default: "default"]
      --queue[=QUEUE]        The names of the queues to work
      --daemon               Run the worker in daemon mode (Deprecated)
      --once                 Only process the next job on the queue
      --stop-when-empty      Stop when the queue is empty
      --delay[=DELAY]        The number of seconds to delay failed jobs (Deprecated) [default: "0"]
      --backoff[=BACKOFF]    The number of seconds to wait before retrying a job that encountered an uncaught exception [default: "0"]
      --max-jobs[=MAX-JOBS]  The number of jobs to process before stopping [default: "0"]
      --max-time[=MAX-TIME]  The maximum number of seconds the worker should run [default: "0"]
      --force                Force the worker to run even in maintenance mode
      --memory[=MEMORY]      The memory limit in megabytes [default: "128"]
      --sleep[=SLEEP]        Number of seconds to sleep when no job is available [default: "3"]
      --rest[=REST]          Number of seconds to rest between jobs [default: "0"]
      --timeout[=TIMEOUT]    The number of seconds a child process can run [default: "60"]
      --tries[=TRIES]        Number of times to attempt a job before logging it failed [default: "1"]
  -h, --help                 Display help for the given command. When no command is given display help for the list command
  -q, --quiet                Do not output any message
  -V, --version              Display this application version
      --ansi|--no-ansi       Force (or disable --no-ansi) ANSI output
  -n, --no-interaction       Do not ask any interactive question
      --env[=ENV]            The environment the command should run under
  -v|vv|vvv, --verbose       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```