### PR TITLE
Update Python docs to use `uv` instead of `poetry`

### DIFF
--- a/django/getting-started/index.html.md
+++ b/django/getting-started/index.html.md
@@ -34,7 +34,11 @@ mkdir hello-django && cd hello-django
 
 ### Virtual Environment
 
-For this guide, we use [venv](https://docs.python.org/3/library/venv.html#module-venv) but any of the other popular choices such as [Poetry](https://python-poetry.org/), [Pipenv](https://github.com/pypa/pipenv), or [pyenv](https://github.com/pyenv/pyenv) work too.
+For this guide, we use [venv](https://docs.python.org/3/library/venv.html#module-venv) but any of the other popular choices such as
+[uv](https://docs.astral.sh/uv/),
+[Poetry](https://python-poetry.org/),
+[Pipenv](https://github.com/pypa/pipenv), or
+[pyenv](https://github.com/pyenv/pyenv) work too.
 
 ```shell
 # Unix/macOS

--- a/python/do-more/add-object-storage.html.markerb
+++ b/python/do-more/add-object-storage.html.markerb
@@ -20,7 +20,7 @@ fly secrets list
 The de-facto library for interacting with s3 storage is [boto3](https://pypi.org/project/boto3/+external), let's add it to the project:
 
 ```cmd
-poetry add boto3
+uv add boto3
 ```
 
 Now we can initialize the client:

--- a/python/do-more/add-ollama.html.markerb
+++ b/python/do-more/add-ollama.html.markerb
@@ -16,7 +16,7 @@ fly secrets set OLLAMA_HOST=http://<your-app>.flycast
 To interact with our new AI friend, we will have to install the `ollama` package:
 
 ```cmd
-poetry add ollama
+uv add ollama
 ```
 
 Now we can initialize the client:

--- a/python/do-more/add-postgres.html.markerb
+++ b/python/do-more/add-postgres.html.markerb
@@ -42,7 +42,7 @@ At this point you can use a database driver to interact with the database. You h
 Let's create a function to get some metadata about the database using `asyncpg`:
 
 ```cmd
-poetry add asyncpg
+uv add asyncpg
 ```
 
 ```python

--- a/python/frameworks/fastapi.html.markerb
+++ b/python/frameworks/fastapi.html.markerb
@@ -28,7 +28,7 @@ Deploying a FastAPI app on Fly.io is... well it's fast! You can be up and runnin
 Then we have to add the FastAPI dependency:
 
 ```cmd
-poetry add "fastapi[standard]"
+uv add "fastapi[standard]"
 ```
 
 Now, let's create a simple FastAPI app in `main.py`:

--- a/python/frameworks/fastapi.html.markerb
+++ b/python/frameworks/fastapi.html.markerb
@@ -22,7 +22,7 @@ Deploying a FastAPI app on Fly.io is... well it's fast! You can be up and runnin
 
 ## _Deploy a FastAPI app from scratch_
 
-<%= partial "/docs/python/partials/poetry_new", locals: { runtime: "FastAPI" }  %>
+<%= partial "/docs/python/partials/uv_init", locals: { runtime: "FastAPI" }  %>
 
 
 Then we have to add the FastAPI dependency:

--- a/python/frameworks/flask.html.markerb
+++ b/python/frameworks/flask.html.markerb
@@ -18,7 +18,7 @@ Spinning up a flask app is fun!
 
 <%= partial "/docs/languages-and-frameworks/partials/flyctl" %>
 
-<%= partial "/docs/python/partials/speedrun", locals: { runtime: "Flask", repo: "hello-flask-poetry" }  %>
+<%= partial "/docs/python/partials/speedrun", locals: { runtime: "Flask", repo: "hello-flask-uv" }  %>
 
 ## _Deploy a Flask app from scratch_
 
@@ -67,4 +67,4 @@ flask --app hello run
 
 If you open http://127.0.0.1:5000/ in your web browser, it should display `hello from fly.io`.
 
-<%= partial "/docs/python/partials/deploy", locals: { runtime: "Flask", repo: "hello-flask-poetry" }  %>
+<%= partial "/docs/python/partials/deploy", locals: { runtime: "Flask", repo: "hello-flask-uv" }  %>

--- a/python/frameworks/flask.html.markerb
+++ b/python/frameworks/flask.html.markerb
@@ -22,7 +22,7 @@ Spinning up a flask app is fun!
 
 ## _Deploy a Flask app from scratch_
 
-<%= partial "/docs/python/partials/poetry_new", locals: { runtime: "Flask" }  %>
+<%= partial "/docs/python/partials/uv_init", locals: { runtime: "Flask" }  %>
 
 To run this app we will need 2 dependencies:
 

--- a/python/frameworks/flask.html.markerb
+++ b/python/frameworks/flask.html.markerb
@@ -30,7 +30,7 @@ To run this app we will need 2 dependencies:
 - gunicorn: the server
 
 ```cmd
-poetry add flask gunicorn
+uv add flask gunicorn
 ```
 
 Now let's create a basic app in `app.py`:

--- a/python/frameworks/streamlit.html.markerb
+++ b/python/frameworks/streamlit.html.markerb
@@ -28,7 +28,7 @@ Spinning up a `streamlit` app takes no time at all!
 Then we have to add the streamlit dependency:
 
 ```cmd
-poetry add streamlit
+uv add streamlit
 ```
 
 Now, let's create a simple streamlit app in `main.py`:

--- a/python/frameworks/streamlit.html.markerb
+++ b/python/frameworks/streamlit.html.markerb
@@ -22,7 +22,7 @@ Spinning up a `streamlit` app takes no time at all!
 
 ## _Deploy a Streamlit from scratch_
 
-<%= partial "/docs/python/partials/poetry_new", locals: { runtime: "Streamlit" }  %>
+<%= partial "/docs/python/partials/uv_init", locals: { runtime: "Streamlit" }  %>
 
 
 Then we have to add the streamlit dependency:

--- a/python/partials/_poetry_new.erb
+++ b/python/partials/_poetry_new.erb
@@ -1,9 +1,0 @@
-For managing our project, we use [Poetry](https://python-poetry.org/). 
-For more information on the initial setup with poetry, refer to [setting up a python environment](/docs/python/the-basics/initial-setup).
-We can initialize a new project like so:
-
-```cmd
-poetry new <%= runtime.downcase %>-app
-cd <%= runtime.downcase %>-app
-poetry shell
-```

--- a/python/partials/_uv_init.erb
+++ b/python/partials/_uv_init.erb
@@ -1,5 +1,5 @@
 For managing our project, we use [uv](https://docs.astral.sh/uv/). 
-For more information on the initial setup with uv, refer to [setting up a python environment](/docs/python/the-basics/initial-setup).
+For more information on the initial setup with uv, refer to ["Setting up a Python Environment"](/docs/python/the-basics/initial-setup).
 We can initialize a new project like so:
 
 ```cmd

--- a/python/partials/_uv_init.erb
+++ b/python/partials/_uv_init.erb
@@ -1,0 +1,9 @@
+For managing our project, we use [uv](https://docs.astral.sh/uv/). 
+For more information on the initial setup with uv, refer to [setting up a python environment](/docs/python/the-basics/initial-setup).
+We can initialize a new project like so:
+
+```cmd
+uv init <%= runtime.downcase %>-app
+cd <%= runtime.downcase %>-app
+uv run python
+```

--- a/python/the-basics/initial-setup.html.md
+++ b/python/the-basics/initial-setup.html.md
@@ -17,48 +17,35 @@ We recommend the latest [supported versions](https://devguide.python.org/version
 
 ## Dependency Management
 
-For project and dependency management we use [Poetry](https://python-poetry.org/). Like most package managers, Poetry combines multiple tools in one. 
+For project and dependency management we use [uv](https://docs.astral.sh/uv/). Like most package managers, uv combines multiple tools in one. 
 
 You have other options:
 - [venv](https://docs.python.org/3/library/venv.html) and [pip](https://pip.pypa.io/)
+- [Poetry](https://python-poetry.org/)
 - [Pipenv](https://github.com/pypa/pipenv)
 - [pyenv](https://github.com/pyenv/pyenv)
 - [pip-tools](https://pypi.org/project/pip-tools/)
 
-If you are just starting out, it is easiest to follow along using `poetry`. 
-After installing it, you will have to set 2 flags for virtual environment management.
-
-```cmd
-poetry config virtualenvs.create true
-poetry config virtualenvs.in-project true
-```
+If you are just starting out, it is easiest to follow along using `uv`. 
 
 This will make your development environment resemble what ends up happening inside the docker image. 
 
 You can create a new project using this command:
 
 ```cmd
-poetry new <app-name>
+uv init <app-name>
 ```
 
 Once inside the project, you can add packages with the add command:
 
 ```cmd
-poetry add <dep>
+uv add <dep>
 ```
 
 This will automatically create a virtual environment for you. 
 
-To interact with your virtual environment, you can prefix your commands with `poetry run`:
+To interact with your virtual environment, you can prefix your commands with `uv run`:
 
 ```cmd
-poetry run python main.py
+uv run python main.py
 ```
-
-Alternatively, you can activate the environment:
-
-```cmd
-poetry shell
-python main.py
-```
-


### PR DESCRIPTION
### Summary of changes

This PR updates the Python guides to use `uv` for dependency management.

### Preview

### Related Fly.io community and GitHub links

https://github.com/superfly/docs/issues/1844

### Notes

- The ["Setting up a Python Environment" guide](https://github.com/superfly/docs/pull/1847/files#diff-2873f777ffeaf6a2b6a1f7e50a8533251fa45a176f4e6867b528efd163d84f7b) is mostly the same. Because `uv` uses venv by default, fewer configuration steps are required.
- The ["Multi-stage Builds" guide](https://github.com/superfly/docs/pull/1847/files#diff-4c97ace71199bd256d3bdf2b3581229dc6bfe1edaa4b5e05f5643aef658fd292) is a more involved change.
- The `poetry_new` partial is replaced with a new [`uv_init` partial](https://github.com/superfly/docs/pull/1847/files#diff-02947418b2c18317c04d287be133d5bac7b31b285c9c6196892c149e792ede96), and all of its references are updated.
- The ["Getting Started"] guide for Django still uses `pip` + `venv`, and is updated only to mention `uv` as an alternative (as it currently does for Poetry)
- The remaining changes are simple replacements of `poetry add` → `uv add`, which does the same thing.
