### PR TITLE
Update volume snapshot restore definitions.

### DIFF
--- a/flyctl/cmd/fly_volumes_snapshots.md
+++ b/flyctl/cmd/fly_volumes_snapshots.md
@@ -1,5 +1,4 @@
-Manage volume snapshots. A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state.
-
+Manage volume snapshots. A snapshot is a point-in-time copy of a volume. You can use a volume snapshot to restore the data into a new volume.
 ## Usage
 ~~~
 fly volumes snapshots [command] [flags]


### PR DESCRIPTION
Removes confusing wording, as volume snapshots can't be used to restore a volume to a previous state, only to create new ones.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

