### PR TITLE
Fix issue with Tiemscale DB setup guide

### DIFF
--- a/postgres/getting-started/enabling-timescale.html.markerb
+++ b/postgres/getting-started/enabling-timescale.html.markerb
@@ -17,7 +17,7 @@ provision a new Postgres app using our TimescaleDB-adapted image.
 Specify the `postgres-flex-timescaledb` image with the `--image-ref` flag:
 
 ```cmd
-fly pg create --image-ref flyio/postgres-flex-timescaledb:15
+fly pg create --image-ref flyio/postgres-flex-timescaledb:16
 ```
 
 ## Create the extension
@@ -25,10 +25,15 @@ fly pg create --image-ref flyio/postgres-flex-timescaledb:15
 Connect to your postgres database:
 ```cmd
 # Connect to your target database
-fly pg connect --app <app-name> --database <db-name>
+fly pg connect --app <database-app-name>
 ```
 
 From the `postgres=# %` prompt, create the extension:
 ```sql
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+```
+
+## (Optional) Attach to an app
+```
+ fly pg attach <database-app-name> --app <app-name>
 ```


### PR DESCRIPTION
### Summary of changes
The guide didn't work if followed in order as the user doesn't know the database name until it's attached to an app. Instead, we connect to the database server without a database specified to create the extension, then attached to an app to create a database.

Also updated to timescale 16

### Preview

### Related Fly.io community and GitHub links

### Notes

