### PR TITLE
Remove incorrect mention of Tigris

### DIFF
--- a/apps/move-app-org.html.markerb
+++ b/apps/move-app-org.html.markerb
@@ -30,7 +30,6 @@ The following app resources are transferred to the new org automatically:
 - environment variables and secrets
 - certificates and domain names
 - LiteFS databases (when `$FLY_APP_NAME` is used for your Consul key in `litefs.yml`)
-- Tigris object storage
 
 ## Resources that you need to manually reconfigure
 

--- a/apps/move-app-org.html.markerb
+++ b/apps/move-app-org.html.markerb
@@ -36,3 +36,4 @@ The following app resources are transferred to the new org automatically:
 The following extension services need to be reconfigured for the app after the move:
 
 - **[Upstash for Redis](https://fly.io/docs/upstash/redis/):** Upstash Redis is only available over an organization's private network. After you move the app, you'll need to provision a new database for the new org.
+- **[Tigris object storage](https://fly.io/docs/tigris/):** Before moving the app, you'll need to delete the bucket, then recreate it in the new org and set the new secrets. Billing for the new bucket will be tied to the new org.


### PR DESCRIPTION
### Summary of changes
Tigris reached out and said that they don't support moving buckets between orgs, and asked if we could remove this line from the docs.

### Related Fly.io community and GitHub links
Slack thread: https://flyio.slack.com/archives/C053VNRRERW/p1730157072437689

