### PR TITLE
Update connecting-external.html.markerb

### DIFF
--- a/postgres/connecting/connecting-external.html.markerb
+++ b/postgres/connecting/connecting-external.html.markerb
@@ -69,19 +69,19 @@ fly image show --app <pg-app-name>
 ```
 ```out
 Image Details
-  Registry   = registry-1.docker.io
-  Repository = flyio/postgres
-  Tag        = 14.4
-  Version    = v0.0.32
+  Registry   = docker-hub-mirror.fly.io
+  Repository = flyio/postgres-flex
+  Tag        = 16.4
+  Version    = v0.0.62
 ```
 
 Deploy your cluster, using `--image` with the `image:tag` found in the previous step:
 
 ```cmd
-fly deploy . --app <pg-app-name> --image flyio/postgres:<major-version>
+fly deploy . --app <pg-app-name> --image flyio/postgres-flex:<major-version>
 ```
 
-As an example, if you are running Postgres 14.x you would specify `flyio/postgres:14` as your target image.
+As an example, if you are running Postgres 16.x you would specify `flyio/postgres-flex:16` as your target image.
 
 After the deployment completes, you can verify your `services` configuration by running the `fly services list` command:
 


### PR DESCRIPTION
Fixing this documentation page as it causes an error which i found the solution to here: https://community.fly.io/t/failed-to-fetch-an-image-or-build-from-source-could-not-find-image-docker-io-flyio-postgres-xx-x/19602

Requires using the image postgres-flex not just postgres

### Summary of changes

Update this page so it works with Fly today

### Preview

### Related Fly.io community and GitHub links

https://community.fly.io/t/failed-to-fetch-an-image-or-build-from-source-could-not-find-image-docker-io-flyio-postgres-xx-x/19602

### Notes

