### PR TITLE
Update golang Dockerfile docs to match template changes

### DIFF
--- a/languages-and-frameworks/golang.html.markerb
+++ b/languages-and-frameworks/golang.html.markerb
@@ -146,7 +146,7 @@ You can see in the `[build]` section the builder image and the version of Go tha
 
 ## _Inside `Dockerfile`_
 
-[We use an debian base image](https://github.com/superfly/flyctl/blob/master/scanner/templates/go/Dockerfile) which has `CGO` enabled by default. A minimal alternative without CGO is Alpine:
+[We use a Debian base image](https://github.com/superfly/flyctl/blob/master/scanner/templates/go/Dockerfile) which has `CGO` enabled by default. A minimal alternative without CGO is Alpine:
 
 ```diff
 # ...

--- a/languages-and-frameworks/golang.html.markerb
+++ b/languages-and-frameworks/golang.html.markerb
@@ -146,18 +146,18 @@ You can see in the `[build]` section the builder image and the version of Go tha
 
 ## _Inside `Dockerfile`_
 
-To keep Docker images small, [we use an Alpine base image](https://github.com/superfly/flyctl/blob/master/scanner/templates/go/Dockerfile). However, if you need `CGO` you may want to instead use Debian base images:
+[We use an debian base image](https://github.com/superfly/flyctl/blob/master/scanner/templates/go/Dockerfile) which has `CGO` enabled by default. A minimal alternative without CGO is Alpine:
 
 ```diff
 # ...
 
-- FROM golang:${GO_VERSION}-alpine as builder
-+ FROM golang:${GO_VERSION}-bookworm as builder
+- FROM golang:${GO_VERSION}-bookworm as builder
++ FROM golang:${GO_VERSION}-alpine as builder
 
 # ...
 
-- FROM alpine:latest
-+ FROM debian:bookworm
+- FROM debian:bookworm
++ FROM alpine:latest
 ```
 
 If you want to use Alpine with `CGO` enabled, [read here](https://megamorf.gitlab.io/2019/09/08/alpine-go-builds-with-cgo-enabled/).


### PR DESCRIPTION
fixes https://github.com/superfly/docs/issues/1869

### Summary of changes

The golang Dockerfile template was updated in https://github.com/superfly/flyctl/pull/3312 to use Debian instead of Alpine -- this change brings the relevant docs up to date.

### Preview

### Related Fly.io community and GitHub links

### Notes

just a quick attempt to make the docs correct -- i imagine you'll want to reword in a brand-consistent voice and maybe rethink the section anyway in light of the new default.