### PR TITLE
Change `flyio/postgres` to `flyio/postgres-flex`

### DIFF
--- a/postgres/connecting/connecting-external.html.markerb
+++ b/postgres/connecting/connecting-external.html.markerb
@@ -78,10 +78,10 @@ Image Details
 Deploy your cluster, using `--image` with the `image:tag` found in the previous step:
 
 ```cmd
-fly deploy . --app <pg-app-name> --image flyio/postgres:<major-version>
+fly deploy . --app <pg-app-name> --image flyio/postgres-flex:<major-version>
 ```
 
-As an example, if you are running Postgres 14.x you would specify `flyio/postgres:14` as your target image.
+As an example, if you are running Postgres 14.x you would specify `flyio/postgres-flex:14` as your target image.
 
 After the deployment completes, you can verify your `services` configuration by running the `fly services list` command:
 


### PR DESCRIPTION
### Summary of changes
In a nutshell: Change of `flyio/postgres` to `flyio/postgres-flex`

### Preview

### Related Fly.io community and GitHub links

https://community.fly.io/t/failed-to-fetch-an-image-or-build-from-source-could-not-find-image-docker-io-flyio-postgres-xx-x/19602

### Notes
`flyio/postgres` is no longer a valid image, instead we should use `flyio/postgres-flex` and the docs should reflect that.

