### PR TITLE
added http handler to limitations section

### DIFF
--- a/networking/dynamic-request-routing.html.markerb
+++ b/networking/dynamic-request-routing.html.markerb
@@ -36,6 +36,7 @@ If your service is simply proxying uploads to object storage, some services like
 
 If you can perform uploads via `fetch` or `XMLHttpRequest`, you can prepend the [fly-prefer-region](#the-fly-prefer-region-request-header) or [fly-force-instance-id](#the-fly-force-instance-id-request-header) header to send the request directly to a specific region.
 
+Your app should use the [http handler](/docs/networking/services/#http-handler) in order to use fly-replay.
 
 ## `fly-replay` use cases
 


### PR DESCRIPTION
clarifies that fly-replay won't work for services without the http handler.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

