### PR TITLE
Fix `http_service.machine_checks` code example

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -406,7 +406,7 @@ Times are in milliseconds unless units are specified.
 You can use the same `machine_checks` section for HTTP services as for [`services`](#services-machine-checks). The `machine_checks` section defines parameters for checking the health of a service.
 
 ```toml
-[http_service.machine_checks]
+[[http_service.machine_checks]]
   image = "curlimages/curl"
   entrypoint = ["/bin/sh", "-c"]
   command = ["curl http://[$FLY_TEST_MACHINE_IP] | grep 'Hello, World!'"]


### PR DESCRIPTION
Much like the `[[http_service.checks]]` section, the `[[http_service.machine_checks]]` needs to be in double parenthesis.

- [x] Tested via fly CLI. 