### PR TITLE
Update going-to-production.html.markerb

### DIFF
--- a/apps/going-to-production.html.markerb
+++ b/apps/going-to-production.html.markerb
@@ -88,7 +88,7 @@ Use this checklist to help you set up a production environment on Fly.io.
 
 <%= render ChecklistComponent.new(
   items: [
-    { id: "machine-sizing", title: "Get Machine sizing right", description: "Most conventional production web apps require performance CPUs. Also make sure you have enough RAM for your app and/or enable [swapping to disk](https://fly.io/docs/reference/configuration/#swap_size_mb-option) to deal with brief spikes in memory use. See [Machine sizing](docs/machines/guides-examples/machine-sizing/)."},
+    { id: "machine-sizing", title: "Get Machine sizing right", description: "Most conventional production web apps require performance CPUs. Also make sure you have enough RAM for your app and/or enable [swapping to disk](https://fly.io/docs/reference/configuration/#swap_size_mb-option) to deal with brief spikes in memory use. See [Machine sizing](/docs/machines/guides-examples/machine-sizing/)."},
     { id: "fine-tune-app", title: "Fine-tune your app", description: "Learn about optimizing your app on Fly.io. See [Tips to fine-tune your app on Fly.io](/docs/reference/fine-tune-apps/)."}
   ],
   c: params[:c] || "",


### PR DESCRIPTION
Fix incorrect relative path linking

### Summary of changes
"Machine sizing" link is 404 https://fly.io/docs/apps/going-to-production/

### Preview

### Related Fly.io community and GitHub links

### Notes

