### PR TITLE
fix: Make header level of "Fixed price plans" match "Pay-as-you-go plan"

### DIFF
--- a/upstash/redis.html.md
+++ b/upstash/redis.html.md
@@ -138,7 +138,7 @@ Upstash offers a range of payment plans for different use cases.
 
 Upstash Redis databases start on the pay-as-you-go plan at **$0.20 per 100k requests**. This means you only pay for what you use. For most use cases, this is a good starting point.
 
-### Fixed price plans
+#### Fixed price plans
 
 Upstash also offers fixed price plans for when:
 


### PR DESCRIPTION
### Summary of changes

- Header for the two plan types now match, previously they didn't

### Preview

Before:

<img width="212" alt="Screenshot 2024-12-30 at 20 29 32" src="https://github.com/user-attachments/assets/04bbca93-eb4c-49a4-9b20-d66e0b1504d4" />


### Related Fly.io community and GitHub links

### Notes

