### PR TITLE
Update runtime-environment.html.md

### DIFF
--- a/machines/runtime-environment.html.md
+++ b/machines/runtime-environment.html.md
@@ -48,5 +48,5 @@ Useful if your app needs to launch Machine instances of itself to scale backgrou
 **Machine memory**: The memory allocated to the Machine, in MB. It's the same value you'll find under https://fly.io/dashboard/personal/machines and VM Memory in the output of `fly machine status`. Learn more about [Machine sizing](/docs/machines/guides-examples/machine-sizing/).
 
 ### `PRIMARY_REGION`
-**Primary region**: This is set in your `fly.toml` or with the `--region` flag during deploys. Learn more about [configuring the primary region](/docs/reference/configuration/#primary-region).
+**Primary region**: This is set in your `fly.toml` or with the `--region` flag when using `fly launch`. Learn more about [configuring the primary region](/docs/reference/configuration/#primary-region).
  


### PR DESCRIPTION
Clarified when its possible to set `--region` flag. 

### Summary of changes
Currently the docs for "PRIMARY_REGION" says "during deploys". This PR tries to clarify it by replacing it with "when using `fly launch`".

### Preview

### Related Fly.io community and GitHub links

### Notes

