### PR TITLE
Homepage link to flyctl installation details

### DIFF
--- a/index.html.md
+++ b/index.html.md
@@ -10,13 +10,15 @@ nav: firecracker
   <div>
 ## Ready to get started?
 
-Step 1: Install `flyctl`
+**Step 1:** Install `flyctl`
 
 ```cmd
 brew install flyctl
 ```
 
-Step 2: Run `fly launch`
+<small>Not using `brew`? Check out the [installation guide](/docs/flyctl/install/)</small>
+
+**Step 2:** Run `fly launch`
   </div>
 
   <figure>


### PR DESCRIPTION
### Summary of changes
Add link to flyctl installation details on the homepage

### Preview

### Related Fly.io community and GitHub links

### Notes

