### PR TITLE
Update mysql-on-fly.html.markerb to use at least mysql:8.0.37

### DIFF
--- a/app-guides/mysql-on-fly.html.markerb
+++ b/app-guides/mysql-on-fly.html.markerb
@@ -29,7 +29,7 @@ cd my-mysql
 # Run `fly launch` to create an app
 # Use the --no-deploy option since we'll make changes before first deploy
 # Use the --image option to specify a MySQL Docker image
-fly launch --no-deploy --image mysql:8
+fly launch --no-deploy --image mysql:8.0.37
 ```
 
 Type `y` when prompted to tweak the default app settings. Then, on the Fly Launch page:


### PR DESCRIPTION
as reported also elsewhere (e.g. https://community.fly.io/t/error-deploying-mysql-database/20008/4 ) the mysql:8 image suggested in the example fails to work in the end (mysqld keeps erroring out due to missing mysql.component and unknown default auth plugin).

This is quickly fixed by using at least v 8.0.37. 

Haven't checked other versions, this is good enough for anyone taking this for a quick spin

