### PR TITLE
Fix: Typo in url

### DIFF
--- a/index.html.md
+++ b/index.html.md
@@ -37,7 +37,7 @@ brew install flyctl
     <li><a href="/docs/networking/">Networking</a></li>
     <li><a href="/docs/kubernetes/">Fly Kubernetes</a></li>
     <li><a href="/docs/database-storage-guides/">Database & Storage</a></li>
-    <li><a href="/docs/moitoring/">Monitoring</a></li>
+    <li><a href="/docs/monitoring/">Monitoring</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
### Summary of changes
Fixed typo in URL towards monitoring.
Link will now point at `https://fly.io/docs/monitoring/` instead of `https://fly.io/docs/moitoring/`


