### PR TITLE
Fix links in LiteFS docs

### DIFF
--- a/litefs/index.html.markerb
+++ b/litefs/index.html.markerb
@@ -16,10 +16,8 @@ application on the edge. You can run LiteFS anywhere!
 
 LiteFS is stable and running in production environments. The project is still
 pre-1.0 so APIs may change and features could be removed. Please remember that
-all software has bugs so we recommend you set up [regular off-site backups][backup] 
+all software has bugs so we recommend you set up [regular off-site backups](/docs/litefs/backup/)
 in case of malfunction or disk corruption.
-
-[backup]: /docs/litefs/backup/
 
 
 ## Exploring our guides
@@ -28,14 +26,9 @@ You can get up and running quickly with one of our guides:
 
 - [Speedrun: Adding LiteFS to your app](/docs/litefs/speedrun) the fastest way to get started with LiteFS on Fly.io.
 
-- [Getting Started on Fly.io][] helps you add LiteFS to an existing application and deploy to Fly.io. This guide
+- [Getting Started on Fly.io](/docs/litefs/getting-started-fly) helps you add LiteFS to an existing application and deploy to Fly.io. This guide
 provides more details and explanation than the Speedrun.
 
-- [Getting Started with Docker][] helps you add LiteFS to an existing application that you want to run outside of Fly.io.
+- [Getting Started with Docker](/docs/litefs/getting-started-docker) helps you add LiteFS to an existing application that you want to run outside of Fly.io.
 
-- [How LiteFS Works][] explains the concepts behind LiteFS.
-
-[Getting Started on Fly.io]: /docs/litefs/getting-started-fly
-[Getting Started with Docker]: /docs/litefs/getting-started-docker
-[Using LiteFS Cloud for Backups]: /docs/litefs/cloud-backups
-[How LiteFS Works]: /docs/litefs/how-it-works
+- [How LiteFS Works](/docs/litefs/how-it-works) explains the concepts behind LiteFS.


### PR DESCRIPTION
### Summary of changes
Fix the links in the LifeFS docs index. It looks like there was some variable setting that was not working for any of the links on this page, so they've been set as explicit links.

### Preview

### Related Fly.io community and GitHub links
- https://fly.io/docs/litefs/

### Notes

