### PR TITLE
Fix: missing LiteFS guide links

### DIFF
--- a/litefs/index.html.markerb
+++ b/litefs/index.html.markerb
@@ -28,12 +28,12 @@ You can get up and running quickly with one of our guides:
 
 - [Speedrun: Adding LiteFS to your app](/docs/litefs/speedrun) the fastest way to get started with LiteFS on Fly.io.
 
-- [Getting Started on Fly.io][] helps you add LiteFS to an existing application and deploy to Fly.io. This guide
+- [Getting Started on Fly.io](docs/litefs/getting-started-fly) helps you add LiteFS to an existing application and deploy to Fly.io. This guide
 provides more details and explanation than the Speedrun.
 
-- [Getting Started with Docker][] helps you add LiteFS to an existing application that you want to run outside of Fly.io.
+- [Getting Started with Docker](/docs/litefs/getting-started-docker) helps you add LiteFS to an existing application that you want to run outside of Fly.io.
 
-- [How LiteFS Works][] explains the concepts behind LiteFS.
+- [How LiteFS Works](/docs/litefs/how-it-works) explains the concepts behind LiteFS.
 
 [Getting Started on Fly.io]: /docs/litefs/getting-started-fly
 [Getting Started with Docker]: /docs/litefs/getting-started-docker


### PR DESCRIPTION
Whiling browsing the docs on on the [LiteFS page](https://fly.io/docs/litefs/) I noticed that three of the four links were missing. The links seem to just be links to the other guides in the section which seemed like an easy enough fix so here we are!