### PR TITLE
Fix /monitoring link in index.html.md

### DIFF
--- a/index.html.md
+++ b/index.html.md
@@ -37,7 +37,7 @@ brew install flyctl
     <li><a href="/docs/networking/">Networking</a></li>
     <li><a href="/docs/kubernetes/">Fly Kubernetes</a></li>
     <li><a href="/docs/database-storage-guides/">Database & Storage</a></li>
-    <li><a href="/docs/moitoring/">Monitoring</a></li>
+    <li><a href="/docs/monitoring/">Monitoring</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
There's a type in the link to /monitoring on the Explore Fly.io by features section.

### Summary of changes
Fix the link from `/moitoring/` to `/monitoring/`


