### PR TITLE
Fix authorization header in metrics docs (fixes #1964)

### DIFF
--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -60,7 +60,7 @@ Queries can be sent to the following endpoint:
 https://api.fly.io/prometheus/<org-slug>/
 ```
 
-You'll need to authenticate with a Fly Access Token sent in the [standard](https://www.rfc-editor.org/rfc/rfc6750.html) Bearer Token format (e.g., an HTTP request header `Authorization: Bearer <TOKEN>`), and you may only query series scoped to your organizations.
+You'll need to authenticate with a Fly Access Token sent in the [standard](https://www.rfc-editor.org/rfc/rfc6750.html) Bearer Token format (e.g., an HTTP request header `Authorization: FlyV1 <TOKEN>`), and you may only query series scoped to your organizations.
 
 #### Manually
 
@@ -84,7 +84,7 @@ TOKEN=$(flyctl auth token)
 ```shell
 curl https://api.fly.io/prometheus/$ORG_SLUG/api/v1/query \
   --data-urlencode 'query=sum(increase(fly_edge_http_responses_count)) by (app, status)' \
-  -H "Authorization: Bearer $TOKEN"
+  -H "Authorization: FlyV1 $TOKEN"
 ```
 
 ## Dashboards


### PR DESCRIPTION
Fixes #1964 
### Summary of changes
The [querying section](https://fly.io/docs/monitoring/metrics/#querying:~:text=number%20of%20series.-,Querying,-Queries%20can%20be) mistakenly refers to the authorization header as using “Bearer” instead of the correct “FlyV1”. Where the API actually expects the header to be “Authorization: FlyV1 <token>”.