### PR TITLE
Corrected links for LiteFS Docs

### DIFF
--- a/litefs/index.html.markerb
+++ b/litefs/index.html.markerb
@@ -28,12 +28,12 @@ You can get up and running quickly with one of our guides:
 
 - [Speedrun: Adding LiteFS to your app](/docs/litefs/speedrun) the fastest way to get started with LiteFS on Fly.io.
 
-- [Getting Started on Fly.io][] helps you add LiteFS to an existing application and deploy to Fly.io. This guide
+- [Getting Started on Fly.io](/docs/litefs/getting-started-fly) helps you add LiteFS to an existing application and deploy to Fly.io. This guide
 provides more details and explanation than the Speedrun.
 
-- [Getting Started with Docker][] helps you add LiteFS to an existing application that you want to run outside of Fly.io.
+- [Getting Started with Docker](/docs/litefs/getting-started-docker) helps you add LiteFS to an existing application that you want to run outside of Fly.io.
 
-- [How LiteFS Works][] explains the concepts behind LiteFS.
+- [How LiteFS Works](/docs/litefs/how-it-works) explains the concepts behind LiteFS.
 
 [Getting Started on Fly.io]: /docs/litefs/getting-started-fly
 [Getting Started with Docker]: /docs/litefs/getting-started-docker


### PR DESCRIPTION
The links in the index of this markdown file were incomplete.

### Summary of changes
I added the correct routing to each link.

### Preview

### Related Fly.io community and GitHub links
problem document - https://fly.io/docs/litefs/
related links:
- https://fly.io/docs/litefs/getting-started-fly/
- https://fly.io/docs/litefs/getting-started-docker/
- https://fly.io/docs/litefs/how-it-works/


### Notes

