### PR TITLE
Remove reference to Tigris data transfer being free

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -193,7 +193,6 @@ The following types of traffic are free:
 * All inbound data transfer
 * Data transfer between apps or Machines in the same region (for organizations using granular data transfer rates)
 * Data transfer from apps without an assigned IP address (for organizations not using granular data transfer rates)
-* Data transfer to Tigris Object Storage
 
 Fly.io pricing is per region group for outbound data transfer. You'll see a more detailed breakdown of cost per region and per traffic type on your monthly invoice.
 

--- a/launch/autoscale-by-metric.html.markerb
+++ b/launch/autoscale-by-metric.html.markerb
@@ -44,10 +44,10 @@ fly secrets set -a my-autoscaler --stage FAS_API_TOKEN="FlyV1 ..."
 The next auth token you'll need is one that has permissions to read from your organization's Prometheus data on Fly:
 
 ```cmd
-fly tokens create readonly
+fly tokens create readonly my-org
 ```
 
-You'll be prompted to choose which org you want to create it for. Afterwards, copy the token and use it as a secret on your autoscaler app:
+Copy the token and use it as a secret on your autoscaler app:
 
 ```cmd
 fly secrets set -a my-autoscaler --stage FAS_PROMETHEUS_TOKEN="FlyV1 ..."

--- a/launch/autoscale-by-metric.html.markerb
+++ b/launch/autoscale-by-metric.html.markerb
@@ -44,10 +44,10 @@ fly secrets set -a my-autoscaler --stage FAS_API_TOKEN="FlyV1 ..."
 The next auth token you'll need is one that has permissions to read from your organization's Prometheus data on Fly:
 
 ```cmd
-fly tokens create readonly -o my-org
+fly tokens create readonly
 ```
 
-Copy the token and use it as a secret on your autoscaler app:
+You'll be prompted to choose which org you want to create it for. Afterwards, copy the token and use it as a secret on your autoscaler app:
 
 ```cmd
 fly secrets set -a my-autoscaler --stage FAS_PROMETHEUS_TOKEN="FlyV1 ..."
@@ -126,7 +126,7 @@ You can scale multiple independent applications with the same autoscaler by usin
 To enable multi-app scaling, you will need to use an organization-wide auth token rather than an app-specific deploy token:
 
 ```cmd
-fly tokens create org -o my-org
+fly tokens create org my-org
 ```
 
 and then set the resulting token on your autoscaler application:


### PR DESCRIPTION
### Summary of changes
- Removed line about data transfer to Tigris being free.
- Removed references to the `-o` flag for the `fly tokens create` command, which is not a valid flag.

### Related Fly.io community and GitHub links
- [Community forum post](https://community.fly.io/t/tigris-billing-for-inbound-data-from-fly-tigris/24164) about Tigris data transfer
- [Internal Discourse discussion](https://flyio.discourse.team/t/customer-getting-billed-for-data-transfer-into-tigris/8107) about Tigris data transfer pricing
- [HS ticket](https://secure.helpscout.net/conversation/2865475001/124530?viewId=6664451) for the `-o` flag
