### PR TITLE
Clarify that Machine health checks are supported only for rolling and canary deployments

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -415,7 +415,7 @@ Times are in milliseconds unless units are specified.
 
 ### The `http_service.machine_checks` section
 
-You can use the same `machine_checks` section for HTTP services as for [`services`](#services-machine-checks). The `machine_checks` section defines parameters for checking the health of a service.
+You can use the same `machine_checks` section for HTTP services as for [`services`](#services-machine_checks). The `machine_checks` section defines parameters for checking the health of a service.
 
 ```toml
 [[http_service.machine_checks]]

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -693,7 +693,9 @@ This example uses the `curl` image to run a test. It checks that the Machine is 
 * `kill_signal`: The signal to send to the test process if it runs too long. Defaults to the signal of the image, if a custom image is set.
 * `kill_timeout`: The time to wait before sending the kill signal. Defaults to the timeout of the image, if a custom image is set.
 
-Machine checks are especially useful for canary deploys. `flyctl` will spawn a new Machine, ensure all machine capabilities are functional, and then deploy the rest of the Machines in your app.
+Machine checks are especially useful for `canary` deploys. `flyctl` will spawn a new Machine, ensure all machine capabilities are functional, and then deploy the rest of the Machines in your app.
+
+Machine checks are supported for apps using the `rolling` and `canary` deployment strategies.
 
 ## The `mounts` section
 

--- a/reference/health-checks.html.markerb
+++ b/reference/health-checks.html.markerb
@@ -43,7 +43,7 @@ Service-level checks are configured using the [`[[services.tcp_checks]]`](/docs/
 
 ## Machine checks 
 
-Machine health checks run only during deployments. They run a custom command inside an ephemeral Machine and can be used to verify app behavior beyond port or endpoint availability. They're useful for validating app readiness in more complex scenarios, such as confirming database connectivity or verifying that a key background service is up. These checks don't impact routing, but if a Machine check fails, the deployment will be stopped.
+Machine health checks run only during deploys and are supported for apps using the `rolling` and `canary` deployment strategies. They run a custom command inside an ephemeral Machine and can be used to verify app behavior beyond port or endpoint availability. They're useful for validating app readiness in more complex scenarios, such as confirming database connectivity or verifying that a key background service is up. These checks don't impact routing, but if a Machine check fails, the deployment will be stopped.
 
 Machine checks are configured using the [`[[services.machine_checks]]`](/docs/reference/configuration/#services-machine_checks) and [`[[http_service.machine_checks]]`](/docs/reference/configuration/#the-http_service-machine_checks-section) sections.
 


### PR DESCRIPTION
### Summary of changes
Updated fly.toml and health check documentation with the above-mentioned clarification. Also fixed a broken link in the fly.toml doc.

