### PR TITLE
Update nav to add links for the "one app per customer" doc

### DIFF
--- a/machines/guides-examples/one-app-per-user-why.html.markerb
+++ b/machines/guides-examples/one-app-per-user-why.html.markerb
@@ -1,8 +1,10 @@
 ---
-title: One app per customer - why?
+title: One App Per Customer - Why?
 layout: docs
 order: 15
 nav: machines
+categories:
+  - machines
 ---
 
 We recommend that you create one app, with one or more machines, **for each customer** you have. You'll gain a lot from this: 
@@ -24,7 +26,7 @@ Each Fly.io organization gets an isolated network that connects all machines in 
 
 However, at application creation time, a `--network` parameter can be passed, to create a [custom private network](https://fly.io/docs/networking/custom-private-networks/) for that application. This subnet will not be connected to the organization’s, meaning this application will be isolated from others (although it can still provide a public internet-facing service as configured in `fly.toml`). 
 
-The [Custom private networks](https://fly.io/docs/networking/custom-private-networks/#private-apps-with-flycast) document details a few ways an isolated app can talk to other applications in a controlled manner, including:
+The [custom private networks](https://fly.io/docs/networking/custom-private-networks/#private-apps-with-flycast) document details a few ways an isolated app can talk to other applications in a controlled manner, including:
 
 * Application A (non-isolated) can have a `.flycast` IP address in application B’s (isolated) subnet, so they can talk to each other over that IP address. You can do this using `fly ips allocate-v6 --private -a APP_A --network APP_B_NETWORK`. App A can then contact “app-b.flycast” directly.
 * Using the [fly-replay header](https://fly.io/docs/networking/dynamic-request-routing/), an application can direct requests to machines in another application, even if that one resides on a private subnet.

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -65,6 +65,7 @@
         { text: "Machine Restart Policy", path: "/docs/machines/guides-examples/machine-restart-policy/" },
         { text: "Machine States", path: "/docs/machines/machine-states/" },
         { text: "Run User Code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" },
+        { text: "One App Per Customer - Why?", path: "/docs/machines/guides-examples/one-app-per-user-why/" },
         { text: "The Machine Runtime Environment", path: "/docs/machines/runtime-environment/" }
       ]
     },

--- a/partials/_machines_nav.html.erb
+++ b/partials/_machines_nav.html.erb
@@ -37,7 +37,8 @@
       links: [
         { text: "Machine restart policy", path: "/docs/machines/guides-examples/machine-restart-policy/" },
         { text: "Machine sizing", path: "/docs/machines/guides-examples/machine-sizing/" },
-        { text: "Run user code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" }
+        { text: "Run user code on Fly Machines", path: "/docs/machines/guides-examples/functions-with-machines/" },
+        { text: "One app per customer - why?", path: "/docs/machines/guides-examples/one-app-per-user-why/" }
       ]
     },
     {


### PR DESCRIPTION
### Summary of changes
- Added a link to the new "one app per customer" to both the main side navbar and the Fly Machines detail page side navbar
- Updated the title casing to match the conventions for the other pages

### Screenshots
Main side navbar | Fly Machines side navbar
-----|-----
![image](https://github.com/user-attachments/assets/653a4df8-97b3-4bf2-bc94-6be09f0d0568) | ![image](https://github.com/user-attachments/assets/e2fb170b-7375-4e20-933e-ef6bacf0a216)