### PR TITLE
Update index.html.markerb - update LiteFS into links to other LiteFS pages

### DIFF
--- a/litefs/index.html.markerb
+++ b/litefs/index.html.markerb
@@ -28,12 +28,12 @@ You can get up and running quickly with one of our guides:
 
 - [Speedrun: Adding LiteFS to your app](/docs/litefs/speedrun) the fastest way to get started with LiteFS on Fly.io.
 
-- [Getting Started on Fly.io][] helps you add LiteFS to an existing application and deploy to Fly.io. This guide
+- [Getting Started on Fly.io](/docs/litefs/getting-started-fly) helps you add LiteFS to an existing application and deploy to Fly.io. This guide
 provides more details and explanation than the Speedrun.
 
-- [Getting Started with Docker][] helps you add LiteFS to an existing application that you want to run outside of Fly.io.
+- [Getting Started with Docker](/docs/litefs/cloud-backups) helps you add LiteFS to an existing application that you want to run outside of Fly.io.
 
-- [How LiteFS Works][] explains the concepts behind LiteFS.
+- [How LiteFS Works](/docs/litefs/how-it-works) explains the concepts behind LiteFS.
 
 [Getting Started on Fly.io]: /docs/litefs/getting-started-fly
 [Getting Started with Docker]: /docs/litefs/getting-started-docker


### PR DESCRIPTION
### Summary of changes
The LiteFS links in the intro don't link to their respective pages. It looks like the syntax `[Some Text][]` is supposed to use the links at the end of the page, but that doesn't appear to be working. This may be the wrong fix, so please feel free to close it (and make the appropriate one please 🙏 )

### Related Fly.io community and GitHub links

Closes #2028


