### PR TITLE
Make top-level doc links navigate directly to relevant pages

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -4,7 +4,7 @@
   @nav = [
     {
       title: "Getting Started",
-      path: "/docs/getting-started/",
+      path: "/docs/getting-started/launch",
       open: current_page?("/docs"),
       links: [
         { text: "Quickstart: Launch your app", path: "/docs/getting-started/launch/" },
@@ -25,7 +25,7 @@
     },
     {
       title: "Apps on Fly.io",
-      path: "/docs/apps/",
+      path: "/docs/apps/overview",
       open: false,
       links: [
         { text: "Fly Apps Overview", path: "/docs/apps/overview/" },
@@ -54,7 +54,7 @@
     },
     {
       title: "Fly Machines",
-      path: "/docs/machines/",
+      path: "/docs/machines/overview",
       open: false,
       links: [
         { text: "Introduction to Fly Machines", path: "/docs/machines/overview/" },
@@ -71,7 +71,7 @@
     },
     {
       title: "Managed Postgres",
-      path: "/docs/mpg/",
+      path: "/docs/mpg/overview",
       open: false,
       links: [
         { text: "Managed Postgres Overview", path: "/docs/mpg/overview/" }
@@ -79,7 +79,7 @@
     },
     {
       title: "Fly GPUs",
-      path: "/docs/gpus/",
+      path: "/docs/gpus/gpu-quickstart",
       open: false,
       links: [
         { text: "GPU Quickstart", path: "/docs/gpus/gpu-quickstart/" },
@@ -102,7 +102,7 @@
     },
     {
       title: "Fly Volumes",
-      path: "/docs/volumes/",
+      path: "/docs/volumes/overview",
       open: false,
       links: [
         { text: "Fly Volumes Overview", path: "/docs/volumes/overview/" },
@@ -113,7 +113,7 @@
     },
     {
       title: "Fly Kubernetes",
-      path: "/docs/kubernetes/",
+      path: "/docs/kubernetes/fks-quickstart",
       open: false,
       links: [
         { text: "Fly Kubernetes Quickstart", path: "/docs/kubernetes/fks-quickstart/" },


### PR DESCRIPTION
# This PR updates top-level doc links to navigate directly to the relevant page.

## Description:
- Updated the top-level nav to go directly to the doc page that makes the most sense, rather than an intermediate "overview" page. (Ironically, a lot of those more-relevant pages are referred to as "overviews" in the code.)

NOTE: I left some of the top-level links as-is where it made sense, like for the Blueprints link.

