### PR TITLE
Update fly_scale_vm.md

### DIFF
--- a/flyctl/cmd/fly_scale_vm.md
+++ b/flyctl/cmd/fly_scale_vm.md
@@ -2,8 +2,8 @@ Change an application's VM size to one of the named VM sizes.
 
 For a full list of supported sizes use the command 'flyctl platform vm-sizes'
 
-Memory size can be set with --memory=number-of-MB
-e.g. flyctl scale vm shared-cpu-1x --memory=2048
+Memory size can be set with --vm-memory=number-of-MB
+e.g. flyctl scale vm shared-cpu-1x --vm-memory=2048
 
 For pricing, see https://fly.io/docs/about/pricing/
 


### PR DESCRIPTION
This pull request updates the documentation for scaling VM sizes in the `flyctl` CLI tool to clarify the memory size flag.

* [`flyctl/cmd/fly_scale_vm.md`](diffhunk://#diff-4e23d08d8096cf72b70d3d03fd4dc74fed4b8b74718dd237aa20fe49adb73efaL5-R6): Changed the memory size flag from `--memory` to `--vm-memory` in the example command for consistency and clarity.

Related with: #2080 