### PR TITLE
Update app-services page to include network-debugging tip

### DIFF
--- a/networking/app-services.html.md
+++ b/networking/app-services.html.md
@@ -147,7 +147,7 @@ cURL is a useful tool for checking that a service is reachable where it should b
 
 [3] [Except UDP services.](#udp-is-special) 
 
-[4] If this fails, but the local check succeeded, the next thing to confirm is that the app or Machine config includes a properly configured `services` or `http_service` section, with `internal_port` matching `<port>` used in this test.
+[4] If this fails, but the local check succeeded, the next thing to confirm is that the app or Machine config includes a properly configured `services` or `http_service` section, with `internal_port` matching `<port>` used in this test. Some environments still run IPv4 only, so you may need to assign your app a shared IPv4 address to keep it reachable from those networks.
 
 [5] The HTTP URL always elicits a 301 redirect, because the Fly Proxy upgrades HTTP connections to HTTPS. To get cURL to follow the redirect to see if there's anything there, use the `-L` flag. This example has the services configured to handle HTTP and HTTPS requests on the conventional ports 80 and 443 respectively; if you're using different ports, substitute those in.
 

--- a/networking/app-services.html.md
+++ b/networking/app-services.html.md
@@ -147,7 +147,7 @@ cURL is a useful tool for checking that a service is reachable where it should b
 
 [3] [Except UDP services.](#udp-is-special) 
 
-[4] If this fails, but the local check succeeded, the next thing to confirm is that the app or Machine config includes a properly configured `services` or `http_service` section, with `internal_port` matching `<port>` used in this test. Some environments still run IPv4 only, so you may need to assign your app a shared IPv4 address to keep it reachable from those networks.
+[4] If this fails, but the local check succeeded, the next thing to confirm is that the app or Machine config includes a properly configured `services` or `http_service` section, with `internal_port` matching `<port>` used in this test. Also check `fly ips list`: if the app has only an IPv6 address, it won't be reachable from IPv4-only networks. You can [allocate a free shared IPv4 address](/docs/networking/services/#shared-ipv4) with `fly ips allocate-v4 --shared`.
 
 [5] The HTTP URL always elicits a 301 redirect, because the Fly Proxy upgrades HTTP connections to HTTPS. To get cURL to follow the redirect to see if there's anything there, use the `-L` flag. This example has the services configured to handle HTTP and HTTPS requests on the conventional ports 80 and 443 respectively; if you're using different ports, substitute those in.
 

--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -18,6 +18,7 @@ centiseconds
 cgroup
 cgroups
 cleartext
+configs?\b
 containerd
 cron
 datacenters?\b
@@ -56,6 +57,7 @@ idempotently
 IEx
 incentivizes?\b
 initializer
+IP('s)?\b
 IPs
 IPSec
 ISPs?\b
@@ -143,6 +145,7 @@ unmount
 Upstash
 Valkey
 vCPUs?\b
+VM('s)?\b
 virtualized
 Vite
 VSCode


### PR DESCRIPTION
### Summary of changes
Some environments still run IPv4 only. If a user only assigns an IPv6 address to their service, it be difficult to debug why a typical `curl https://<app>.fly.dev` command does not work.

Adds a debugging tip for users in these network situations.

### Preview

### Related Fly.io community and GitHub links

### Notes

