### PR TITLE
update-rust-docs

### DIFF
--- a/rust/partials/_cargo-new.html.erb
+++ b/rust/partials/_cargo-new.html.erb
@@ -1,4 +1,4 @@
-If you don't already have an existing Axum application, you can create one with `cargo`:
+If you don't already have an existing <%= runtime.titleize %> application, you can create one with `cargo`:
 
 ```cmd
 cargo new <%= runtime %>-on-fly


### PR DESCRIPTION
### Summary of changes
Under the rust framework guides it refers to Axum as that was hardcoded into cargo_new.makerb
Updated the file to refer to runtime passed 


https://fly.io/docs/rust/frameworks/actix-web/
![image](https://github.com/user-attachments/assets/eddf441f-e67d-4464-b89a-1fe100ff0702)
https://fly.io/docs/rust/frameworks/warp/
![image](https://github.com/user-attachments/assets/18f5aec6-0d58-4c4d-ae78-b06da0619690)


### Preview

### Related Fly.io community and GitHub links

### Notes

