### PR TITLE
Fixes for multi-container machines guide

### DIFF
--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -151,7 +151,7 @@ There are several ways to deploy multi-container machines on Fly.io. Choose the 
 You can define your Machine configuration in a JSON file (e.g., `machine-config.json`) and create the Machine using the Fly CLI:
 
 ```bash
-flyctl machines create -f machine-config.json
+flyctl machines create --machine-config machine-config.json
 ```
 
 You can also launch a multi-container app interactively using `flyctl machine run`:
@@ -166,7 +166,7 @@ flyctl machine run --machine-config cli-config.json \
 Alternatively, you can make a direct API call using `curl`:
 
 ```bash
-curl -X POST "https://api.fly.io/v1/apps/your-app-name/machines" \
+curl -X POST "https://api.machines.dev/v1/apps/your-app-name/machines" \
   -H "Authorization: Bearer your-api-token" \
   -H "Content-Type: application/json" \
   -d @machine-config.json

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -180,7 +180,7 @@ Note: When using `--machine-config`, your JSON file must include a containers ar
 
 ### Using fly launch & fly deploy
 
-Starting with `flyctl v0.3.113`, you can run multiple containers using `fly deploy`. This example demonstrates using a nginx container as a rate limiter and a custom app container.
+Starting with `flyctl v0.3.147`, you can run multiple containers using `fly deploy`. This example demonstrates using a nginx container as a rate limiter and a custom app container.
 
 #### 1. Create cli-config.json
 
@@ -220,6 +220,8 @@ Starting with `flyctl v0.3.113`, you can run multiple containers using `fly depl
 ```
 
 #### 2. Update fly.toml
+
+**Note:** `flyctl` [version 0.3.147](https://github.com/superfly/flyctl/releases/tag/v0.3.147) or later is required to use this config
 
 ```
 [experimental]

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -174,6 +174,10 @@ curl -X POST "https://api.machines.dev/v1/apps/your-app-name/machines" \
 
 Refer to the [Machines API documentation](https://docs.machines.dev/#tag/machines) for more details.
 
+<div class="callout">
+Note: When using `--machine-config`, your JSON file must include a containers array with at least one container defined
+</div>
+
 ### Using fly launch & fly deploy
 
 Starting with `flyctl v0.3.113`, you can run multiple containers using `fly deploy`. This example demonstrates using a nginx container as a rate limiter and a custom app container.


### PR DESCRIPTION
### Summary of changes

The following items are taken from this [Discourse post](https://flyio.discourse.team/t/docs-for-multi-container-pilot-machines-has-problems/8754)

- [x] `flyctl machines create -f machine-config.json` command doesnt work and has invalid flag.

- [x] `curl -X POST "https://api.fly.io/v1/apps/your-app-name/machines"` references the wrong url (`api.machines.dev`).

- [x] I couldnt get the `flyctl machine run --machine-config cli-config.json` command to work, not sure if its me or the docs.
             See this [comment](https://github.com/superfly/docs/pull/2103#discussion_r2178445854)

- [x] The instructions for using `fly deploy` with the `experimental machine_config = 'cli-config.json'` setting in `fly.toml` didn't work for me, and ended up deploying a non-pilot machine.





