### PR TITLE
fix typos in app handover guide

### DIFF
--- a/apps/app-handover-guide.html.md
+++ b/apps/app-handover-guide.html.md
@@ -7,7 +7,7 @@ date: 2025-07-03
 ---
 
 <div class="callout">
-**If you're building an app for someone else and they’re going to run it themselves on Fly, you’ve got two good options. You can either start development inside their Fly organization, or build it in yours and move it over later. Here’s how both paths work, and what can get messy during the move.**
+**If you're building an app for someone else and they’re going to run it themselves on Fly.io, you’ve got two good options. You can either start development inside their Fly.io organization, or build it in yours and move it over later. Here’s how both paths work, and what can get messy during the move.**
 </div>
 
 ---
@@ -16,9 +16,9 @@ date: 2025-07-03
 
 The cleanest handoff is no handoff at all. Have the customer create their own Fly.io organization before you start building.
 
-1. **They create the organization and add a payment method.** Basic stuff. This is what Fly bills against.
+1. **They create the organization and add a payment method.** Basic stuff. This is what Fly.io bills against.
 1. **They invite your devs to their org.** They can do this in the dashboard under “Team → Invite Member.” You now have access to deploy apps directly into their account.
-1. **You build inside their org.** Fly treats organizations as isolated namespaces, so there’s no awkward boundary crossing here. It’s just your team shipping code, in their environment.
+1. **You build inside their org.** Fly.io treats organizations as isolated namespaces, so there’s no awkward boundary crossing here. It’s just your team shipping code, in their environment.
 1. **They remove you when it’s over.** Or not—you can stick around for maintenance if that’s part of the deal.
 1. **What can get messy.** Make sure that the invited developer is not the only admin user in your customer's org. Double-check that your customer has at least two admins in their org.
 
@@ -40,7 +40,7 @@ Here’s how that works:
     - Secrets and environment variables 
     - Certificates and domain names 
     - LiteFS databases (as long as you’re using `$FLY_APP_NAME` for the Consul key) 
-1. What doesn’t: 
+1. What doesn’t move automatically: 
     - **Postgres** **(unmanaged and managed):** Moving Postgres databases across orgs is not supported. You’ll need to spin up a new Fly Postgres app in the target org and restore from a volume snapshot. Or you can use `pgloader` to migrate data. 
     - **Upstash Redis:** This is tied to an org’s private network. You’ll need to provision a new DB in the new org. 
     - **Tigris buckets:** You’ll have to delete the old bucket, recreate it in the new org, and copy data over (try `s3sync`). Don’t forget to reset your app’s secrets. 
@@ -48,11 +48,11 @@ Here’s how that works:
 
 ### Summary
 
-If you know up front that your customer will own the app long-term, starting in their org avoids a bunch of fiddly work later. But if you need to hand over an app from your org to theirs, Fly gives you enough tools to pull it off—just be ready to rewire a few things by hand.
+If you know up front that your customer will own the app long-term, starting in their org avoids a bunch of fiddly work later. But if you need to hand over an app from your org to theirs, Fly.io gives you enough tools to pull it off—just be ready to rewire a few things by hand.
 
 
 
-### Related reading:
+### Related reading
 
 [Fly.io billing](https://fly.io/docs/about/billing)
 


### PR DESCRIPTION
### Summary of changes

- Change Fly to Fly.io
- Minor typos/clarifications

