### PR TITLE
Add illustrations to various docs

### DIFF
--- a/apps/app-availability.html.markerb
+++ b/apps/app-availability.html.markerb
@@ -5,6 +5,10 @@ nav: apps
 redirect_from: /docs/reference/app-availability/
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/migrating-from-aws.png" alt="Illustration by Annie Ruygt of a figure jumping from one mountian to another" class="w-full max-w-lg mx-auto">
+</figure>
+
 A resilient app is resistant to events like hardware failures or outages. Redundancy, supported by monitoring and scaling, is one of the ways to make your app more resilient, and we provide some built-in features to make this easier.
 
 ## What your app needs to do

--- a/blueprints/staging-prod-isolation.html.md
+++ b/blueprints/staging-prod-isolation.html.md
@@ -5,6 +5,10 @@ nav: firecracker
 redirect_from: /docs/going-to-production/the-basics/production-staging-isolation/
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/staging-prod-iso.png" alt="Illustration by Annie Ruygt of a gateway and buildings" class="w-full max-w-lg mx-auto">
+</figure>
+
 You want to isolate your production environment from your test or staging environments by limiting production access to the smallest possible group. You can get dependable isolation by using multiple organizations. Organization access is invitation-only and orgs are isolated from one another at a low level by our private networking architecture: every organization has its own [private network](/docs/networking/private-networking/) by default.
 
 All Fly.io accounts start with a "personal" organization. You can create as many organizations as you need, not just for different environments, but also for different projects or clients.

--- a/getting-started/essentials.html.md
+++ b/getting-started/essentials.html.md
@@ -4,6 +4,10 @@ layout: docs
 nav: firecracker
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/getting-started.png" alt="Illustration by Annie Ruygt of a figure steering a ship" class="w-full max-w-lg mx-auto">
+</figure>
+
 You really can [get an app up and running in just minutes](https://fly.io/speedrun/) on Fly.io.
 
 But if you want to know a bit more about what's what on the Fly.io platform, then read on. You can skip to the [glossary](#fly-io-glossary) for the tl;dr.

--- a/getting-started/troubleshooting.html.md
+++ b/getting-started/troubleshooting.html.md
@@ -4,8 +4,8 @@ layout: docs
 nav: firecracker
 ---
 
-<figure>
-  <img src="/static/images/docs-magnify.webp" alt="">
+<figure class="flex justify-center">
+  <img src="/static/images/troubleshooting.png" alt="Illustration by Annie Ruygt of a figure looking through a magnifying glass at a balloon" class="w-full max-w-lg mx-auto">
 </figure>
 
 This section gives you some ideas of how to start troubleshooting if your deployment doesn't work as expected. If you're still stuck after reading, then visit our [community forum](https://community.fly.io/) for more help.

--- a/launch/create.html.markerb
+++ b/launch/create.html.markerb
@@ -5,6 +5,10 @@ nav: apps
 redirect_from: /docs/apps/launch/
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/launch-create.png" alt="Illustration by Annie Ruygt of a figure running and carrying a balloon" class="w-full max-w-lg mx-auto">
+</figure>
+
 This guide goes into some detail about using Fly Launch to create and configure an app. See [Getting Started](/docs/getting-started) for ways to get going even faster.
 
 Fly Launch is a collection of opinionated Fly.io platform features that help you configure and orchestrate your app as a unit. 

--- a/reference/health-checks.html.markerb
+++ b/reference/health-checks.html.markerb
@@ -4,6 +4,10 @@ layout: docs
 nav: firecracker
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/health-checks.png" alt="Illustration by Annie Ruygt of a balloon doctor examining a machine" class="w-full max-w-lg mx-auto">
+</figure>
+
 Health checks are a useful way to monitor the state of your app on Fly.io. When configured, they help the platform make decisions about routing traffic and managing deployments. For example, health checks can:
 
 - Confirm that Machines are ready before receiving traffic

--- a/reference/health-checks.html.markerb
+++ b/reference/health-checks.html.markerb
@@ -60,3 +60,4 @@ You don't need to configure them yourself, and they don't impact routing after t
 ## Related topics
 
 - [App configuration (fly.toml)](/docs/reference/configuration/)
+- [Seamless/Zero-downtime deployments](/docs/blueprints/seamless-deployments/)

--- a/reference/machine-migration.html.markerb
+++ b/reference/machine-migration.html.markerb
@@ -4,6 +4,10 @@ layout: docs
 nav: firecracker
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/migrating-from-aws.png" alt="Illustration by Annie Ruygt of a figure jumping from one mountian to another" class="w-full max-w-lg mx-auto">
+</figure>
+
 Fly.io will migrate your Machines from problematic hosts to healthy hosts as required. Some of the reasons for migrating Machines include host overcrowding, deprecation, or scheduled maintenance. The migration process helps your applications run efficiently on the Fly.io platform. You don't need to take any action to migrate your Machines to another host and, if your app has [multiple Machines](/docs/blueprints/resilient-apps-multiple-machines/), migration shouldn't result in any downtime for your app.
 
 ## Machine migration process


### PR DESCRIPTION
### Summary of changes
Add new images:
- https://fly.io/docs/getting-started/essentials/
- https://fly.io/docs/launch/create/
- https://fly.io/docs/blueprints/staging-prod-isolation/
- https://fly.io/docs/apps/app-availability/ AND https://fly.io/docs/reference/machine-migration/ (same image as AWS to Fly guide)
-  https://fly.io/docs/reference/health-checks/

Swap:
- https://fly.io/docs/getting-started/troubleshooting/ (change existing image)


### Preview
Previewed locally

### Related Fly.io community and GitHub links
Tracking issue: https://github.com/superfly/docs-tracking/issues/36
PR to add images to landing repo: https://github.com/superfly/landing/pull/1012

### Notes

