### PR TITLE
Update Upstash Redis Standard plan description to clarify replica region pricing

### DIFF
--- a/upstash/redis.html.md
+++ b/upstash/redis.html.md
@@ -118,7 +118,7 @@ Upstash Redis is available in all Fly regions via a [private IPv6 address](/docs
 
 ### Writing to replica regions
 
-**Replicas forward writes to the primary**. Replicas can't be written to. Writes are synchronous, and synchronous writes over geographical distance experience latency. Plan for this latency in your application design.
+**Replicas forward writes to the primary**. Replicas can't be written to. Writes are synchronous, and synchronous writes over geographic distance experience latency. Plan for this latency in your application design.
 
 If you're using Redis as region-local cache and don't require a shared cache, setup separate databases per-region and enable object eviction.
 


### PR DESCRIPTION
The previous wording (“$50 per month, per region”) was unclear and could be misinterpreted. The new description explicitly states the cost for the primary region and for each read replica region, reducing potential confusion for users.

