### PR TITLE
Merged MPG index + overview page

### DIFF
--- a/mpg/index.html.md
+++ b/mpg/index.html.md
@@ -5,6 +5,128 @@ nav: firecracker
 toc: false
 ---
 
-Fly.io's Managed Postgres is our fully-managed database service that handles all aspects of running production PostgreSQL databases. We take care of backups, high availability, failover, security patches, and version upgrades, allowing you to focus on your application. Cluster storage automatically grows up to 1TB.
+<figure class="flex justify-center">
+  <img src="/static/images/Managed_Postgres.png" alt="Illustration by Annie Ruygt of a balloon doing a lot of tasks" class="w-full max-w-lg mx-auto">
+</figure>
 
-- **[Managed Postgres Overview](/docs/mpg/overview/):** Learn about what Managed Postgres includes, how to create instances, connection details, pricing, and available regions.
+## What is Managed Postgres?
+
+Fly.io's Managed Postgres is our fully-managed database service that handles all aspects of running production PostgreSQL databases where we take care of:
+
+- Automatic backups and recovery
+- High availability with automatic failover
+- Performance monitoring and metrics
+- Resource scaling (CPU, RAM, storage)
+- 24/7 support and incident response
+- Automatic encryption of data at rest and in transit
+
+### What's included
+
+You'll be able to access:
+
+- A highly-available Postgres cluster within your Fly.io organization's [private network](/docs/networking/private-networking/)
+- A single database on that cluster
+- Fly.io Support Portal to log tickets and get help
+- Any modules and extensions included in the [default Postgres 16 distribution](https://www.postgresql.org/docs/16/contrib.html)
+- The third party `pgvector` extension for vector similarity search, if enabled when provisioning your database
+
+### What's not there yet
+
+At the moment, the following features are under development:
+
+- Security patches and version upgrades
+- Multiple databases or schemas per cluster
+- Third Party Postgres extensions besides `pgvector`
+- Customer-facing monitoring and alerting
+- Database migration tools
+
+We're working on expanding these capabilities and will provide updates as they become available.
+
+## Creating a Managed Postgres Instance
+
+To create a new Managed Postgres cluster, visit your Fly.io dashboard and click the "Create new cluster" button in the Managed Postgres section.
+
+You'll be prompted to choose:
+
+- Cluster name (must be unique within your organization)
+- Region (see available regions below)
+- A plan with predefined hardware resources:
+  - Basic: 2 shared vCPUs, 1GB RAM
+  - Launch: 2 Performance vCPUs, 8GB RAM
+  - Scale: 4 Performance vCPUs, 32GB RAM
+- Storage size (up to 500GB at creation)
+
+<div>
+    <img src="/static/images/create-mpg.webp" alt="A screenshot of the Managed Postgres creation page.">
+</div>
+
+## Connecting to Your Managed Postgres Database
+
+To connect your Fly.io application to your Managed Postgres instance:
+
+1. After creation, the "Connection" tab will display your connection string
+2. Set it as a secret in your Fly.io application:
+
+```cmd
+fly secrets set DATABASE_URL="postgres://username:password@host:port/database"
+```
+
+3. Your application can now use the `DATABASE_URL` environment variable to connect
+
+For security, the connection string uses SSL by default. Make sure your application's Postgres client is configured to use SSL.
+
+## Using flyctl with Managed Postgres
+
+You can interact with your Managed Postgres instances using the Fly.io CLI (`flyctl`). Here are the key commands:
+
+### Connecting with psql
+
+To connect directly to your Managed Postgres database using psql:
+
+```cmd
+fly mpg connect [flags]
+```
+
+This command will establish a direct connection to your database using the psql client. You'll need psql installed locally.
+
+### Setting up a Proxy Connection
+
+To create a proxy connection to your Managed Postgres database:
+
+```cmd
+fly mpg proxy [flags]
+```
+
+This command is useful when you want to connect to your database from your local machine using tools other than psql, such as database management tools or your application in development.
+
+## Regions
+
+The current regions available for deploying Fly.io Managed Postgres are:
+
+- `fra` - Frankfurt, Germany
+- `gru` - São Paulo, Brazil
+- `iad` - Ashburn, USA
+- `lax` - Los Angeles, USA
+- `ord` - Chicago, USA
+- `syd` - Sydney, Australia
+
+We'll be rolling out more regions as soon as we can. Choose a region close to your application for optimal performance.
+
+## Database Storage
+
+Managed Postgres storage features:
+
+- Maximum storage limit: 1 TB
+- Initial storage size: Up to 500 GB at creation
+- Storage is replicated across all nodes in your cluster
+- Storage growth is monitored and managed automatically
+
+## Pricing
+
+The price of running Fly.io Managed Postgres depends on:
+
+- CPU/Memory configuration (Launch, Performance, or Enterprise plans)
+- Region in which you're deploying
+- Storage usage
+
+Database storage is priced at **$0.30 per GB for a 30-day month**, with each node (primary + replica) incurring its own cost. You can view detailed pricing in your Fly.io dashboard.

--- a/partials/_accordion_nav.html.erb
+++ b/partials/_accordion_nav.html.erb
@@ -2,14 +2,16 @@
   def section_open?(section)
     (!section[:path].nil? && current_page?(section[:path])) ||
     (!section[:open].nil? && section[:open]) ||
-    section[:links].any? { |page| current_page?(page[:path]) || (page[:links] && section_open?(page)) }
+    (section[:links] && section[:links].any? { |page| current_page?(page[:path]) || (page[:links] && section_open?(page)) })
   end
 
   nav.each { |nav| nav[:open] = section_open?(nav) unless nav[:title].nil? }
 
   nav.each do |nav| 
 %>
-  <% if nav[:text] %>
+  <% if nav[:links].nil? %>
+    <%= nav_link nav[:title], nav[:path], class: "title-link" %>
+  <% elsif nav[:text] %>
     <%= nav_link nav[:text], nav[:path], class: "#{nav[:type]}-link" %>
   <% elsif nav[:accordion] == false %>
     <dl>
@@ -18,7 +20,7 @@
       </dt>
       <dd>
         <ul>
-          <% nav[:links].each do |page| %>
+          <% nav[:links]&.each do |page| %>
             <li><%= nav_link page[:text], page[:path], class: "subpage-link" %></li>
           <% end %>
         </ul>
@@ -32,13 +34,16 @@
         <% else %>
           <span class="accordion-title"><%= nav[:title] %></span>
         <% end %>
-        <button class="accordion-trigger" aria-expanded="<%= nav[:open] %>">
-          <span class="sr-only">Toggle <%= nav[:title] %> section</span>
-        </button>
+        <%# Only show the accordion trigger if there are real subpages %>
+        <% if nav[:links] && nav[:links].size > 0 %>
+          <button class="accordion-trigger" aria-expanded="<%= nav[:open] %>">
+            <span class="sr-only">Toggle <%= nav[:title] %> section</span>
+          </button>
+        <% end %>
       </dt>
       <dd class="accordion-target">
         <ul class="accordion-content" role="region" aria-label="<%= nav[:title] %>">
-          <% nav[:links].each do |page| %>
+          <% nav[:links]&.each do |page| %>
             <% if page[:links] %>
               <li>
                 <dl class="accordion<%= section_open?(page) ? " open" : "" %>">
@@ -54,7 +59,7 @@
                   </dt>
                   <dd class="accordion-target">
                     <ul class="accordion-content" role="region" aria-label="<%= page[:title] %>">
-                      <% page[:links].each do |subpage| %>
+                      <% page[:links]&.each do |subpage| %>
                         <li>
                           <% if subpage[:type] == "flyctl" %>
                             <%= flyctl_nav_link subpage[:text], subpage[:path] %>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -71,11 +71,8 @@
     },
     {
       title: "Managed Postgres",
-      path: "/docs/mpg/overview",
-      open: false,
-      links: [
-        { text: "Managed Postgres Overview", path: "/docs/mpg/overview/" }
-      ]
+      path: "/docs/mpg",
+      open: false
     },
     {
       title: "Fly GPUs",


### PR DESCRIPTION
### Summary of changes
Previously we had this redundant index page for MPG:

<img width="919" height="540" alt="image" src="https://github.com/user-attachments/assets/8dd7f4a1-a208-47d4-955b-21e8f36f9730" />

Instead of having a separate Overview page, I added the Overview content to the MPG index page:

<img width="2612" height="1908" alt="image" src="https://github.com/user-attachments/assets/94b755cc-0d3c-4c18-bf42-2ab3b75f741e" />

### Notes

Our nav used to assume that EVERY nav link would have subpages. I've updated it so that some pages can just be a single page, like Managed Postgres. In this case, there will be no dropdown icon.

