### PR TITLE
Clarify fly scale vm flag/wording

### DIFF
--- a/flyctl/cmd/fly_scale_vm.md
+++ b/flyctl/cmd/fly_scale_vm.md
@@ -1,6 +1,6 @@
 Change an application's VM size to one of the named VM sizes.
 
-For a full list of supported sizes use the command 'flyctl platform vm-sizes'
+For a full list of supported sizes use the command `flyctl platform vm-sizes`
 
 Memory size can be set with the `--vm-memory` flag followed by the number of MB.
 

--- a/flyctl/cmd/fly_scale_vm.md
+++ b/flyctl/cmd/fly_scale_vm.md
@@ -2,8 +2,9 @@ Change an application's VM size to one of the named VM sizes.
 
 For a full list of supported sizes use the command 'flyctl platform vm-sizes'
 
-Memory size can be set with --memory=number-of-MB
-e.g. flyctl scale vm shared-cpu-1x --memory=2048
+Memory size can be set with the `--vm-memory` flag followed by the number of MB.
+
+For example: `flyctl scale vm shared-cpu-1x --vm-memory=2048`
 
 For pricing, see https://fly.io/docs/about/pricing/
 


### PR DESCRIPTION
### Summary of changes
Wraps --vm-memory in backticks so the double dashes render correctly instead of being converted by markdown. Makes it more readable with clearer phrasing and formatting as well
