### PR TITLE
Removed docs index link on pages that have the same main side nav

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -1,5 +1,3 @@
-<%= partial "/docs/partials/back_to_docs" unless current_page?('/docs') %>
-
 <%
   @nav = [
     {


### PR DESCRIPTION
### Summary of changes
Removed the "Docs Index" backlink on pages that don't have a different side nav.

<img width="838" height="548" alt="image" src="https://github.com/user-attachments/assets/a0056b31-b3d3-434a-bc0e-7b883a199f26" />