### PR TITLE
Update sentry docs

### DIFF
--- a/monitoring/sentry.html.md
+++ b/monitoring/sentry.html.md
@@ -3,61 +3,95 @@ title: Application Monitoring by Sentry
 layout: docs
 nav: firecracker
 redirect_from: /docs/reference/sentry/
+date: 2025-07-21
 ---
 
-[Sentry](https://sentry.io) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our partnerships with Sentry, each of your Fly organizations can claim a year's worth of [Team Plan](https://sentry.io/pricing) credits.
+[Sentry](https://sentry.io/) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our partnership with Sentry, each of your Fly organizations can claim a year’s worth of [Team Plan](https://sentry.io/pricing) credits.
 
-To configure your application to use Sentry, run this command from your Fly.io application directory.
+## Set up Sentry for your Fly.io app
 
-```cmd
-flyctl ext sentry create
+In your project source directory, run the following command:
+
+```
+fly ext sentry create
 ```
 
-Use this command to open the dashboard for the Sentry project associated with the current application.
+This command will:
 
-```cmd
-flyctl ext sentry dashboard
+- Create a Sentry account using your Fly.io user email
+- Create a Sentry organization linked to your Fly.io organization
+- Set the `SENTRY_DSN` secret in your app
+
+Once this is complete, your app will have the `SENTRY_DSN` environment variable available at runtime. Most Sentry SDKs will automatically pick this up and begin sending events.
+
+You can open the Sentry dashboard for your app by running:
+
+```
+fly ext sentry dashboard
 ```
 
-This will:
+## Instrument your application
 
-* Create a Sentry account using your Fly.io email address
-* Create a Sentry organization mapped to your Fly.io organization
-* Set `SENTRY_DSN` as a secret on your app
-
-
-`SENTRY_DSN` is available as an environment variable. The Sentry SDK will detect and use it automatically.
-
+To start sending events to Sentry, you’ll need to instrument your app with the relevant SDK. See [Sentry's documentation for supported platforms](https://docs.sentry.io/platforms/).
 
 ## Sentry Plan details
 
-This promotional plan includes, monthly:
+Your organization receives one year of Sentry’s Team plan, which includes monthly:
 
-* 50k errors
-* 100k [performance units](https://docs.sentry.io/product/performance/transaction-summary/?original_referrer=https%3A%2F%2Fduckduckgo.com%2F#what-is-a-transaction)
-* 500 [session replays](https://docs.sentry.io/product/session-replay)
-* 1GB [attachments](https://docs.sentry.io/platforms/native/guides/minidumps/enriching-events/attachments/)
+- 50k errors
+- 100k [performance units](https://sentry.io/changelog/2023-5-9-introducing-performance-units/)
+- 500 [session replays](https://sentry.zendesk.com/hc/en-us/articles/27282849806235-How-are-Replays-charged-Is-it-based-on-when-I-hit-play)
+- 1GB [attachments](https://docs.sentry.io/platforms/native/guides/minidumps/enriching-events/attachments/)
 
-If you need more than this, sign in to your Sentry account and review upgrade options in the **Settings > Usage & Billing > Subscription** section.
+If you need more than these allowances, sign in to your Sentry account and review upgrade options in the **Settings > Usage & Billing > Subscription** section.
 
-Note that if you upgrade from this plan, you may not downgrade back to the promotional Team plan.
+<div class="important">
+If you upgrade to a paid plan, you will not be able to return to the Fly.io‑sponsored promotional plan.
+</div>
 
-## Instrumenting your application with the Sentry SDK
+## After the one-year plan ends
 
-Next, you should instrument your application to start sending exceptions and other events to Sentry.
+At the end of the promotional period, your Sentry organization will no longer have access to the sponsored Team plan. You have two options:
 
-### Ruby on Rails
+### 1. Let the plan expire
 
-Running `bin/rails generate dockerfile --sentry` will:
+- Your organization will be downgraded to the free Developer plan
+- Monitoring will continue, but with lower plan limits
+- Events sent that exceed the quota will be dropped
+- Existing events and logs remain accessible for up to 30 days, based on Sentry's data retention policy
 
-* Install the [Ruby Sentry SDK](https://github.com/getsentry/sentry-ruby) rubygem
-* Add an initializer for automatic exception handling and performance tracing
+For more information, see [https://sentry.zendesk.com/hc/en-us/articles/27118913621019](https://sentry.zendesk.com/hc/en-us/articles/27118913621019).
 
-Sentry can also instrument specific libraries like Sidekiq, Delayed Job, Resque, and more. Check the [Sentry Ruby documentation](https://docs.sentry.io/platforms/ruby/) for more information.
+### 2. Upgrade to a paid Sentry plan
 
-### Other runtimes and frameworks
+- You can maintain access to higher quotas and additional features
+- You can enable new SSO options (Google, GitHub, etc.)
+- You can optionally disable Fly.io SSO
 
-Learn how to set up your application with the Sentry SDK for your runtime in their comprehensive [documentation](https://docs.sentry.io/).
+## Updating SSO and login methods
+
+Sentry organizations created via the Fly.io integration use Fly.io SSO by default. After your plan ends (or if you upgrade), you can switch to standard login:
+
+1. Go to **Organization Settings > Auth Settings** in Sentry
+1. Click **Disable Fly.io Auth**
+1. Sentry will email each organization member to set a password for their account
+
+This allows you to log in with email and password, and to enable other SSO providers depending on your Sentry subscription level.
+
+For details, see [https://sentry.zendesk.com/hc/en-us/articles/24206530196251](https://sentry.zendesk.com/hc/en-us/articles/24206530196251).
+
+## Do I need to migrate anything after my plan expires?
+
+No migration steps are needed. Your existing Sentry organization, project, data, alerts, and SDK configuration remain intact.
+
+When your plan changes:
+
+- Sentry will retain historical data according to the new plan’s retention limits
+- The `SENTRY_DSN` will continue working unless you explicitly remove or rotate it
+- The Sentry SDK will continue to send events, but any events that exceed quota will be dropped
+
+For more details, see [https://sentry.zendesk.com/hc/en-us/articles/36501551064219](https://sentry.zendesk.com/hc/en-us/articles/36501551064219).
+
 
 
 


### PR DESCRIPTION
### Summary of changes
Updates the sentry docs to answer more question that customers typically have when it comes to what happens after the one year promotional trial ends and how to cancel the trial.

