### PR TITLE
multi-container-machines: fix container -> name in depends_on

### DIFF
--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -66,7 +66,7 @@ Flyd (our [in-house orchestrator](https://fly.io/blog/carving-the-scheduler-out-
       },
       "depends_on": [
         {
-          "container": "my-app",
+          "name": "my-app",
           "condition": "healthy"
         }
       ]
@@ -84,7 +84,7 @@ You can define dependencies between containers using the `depends_on` field. Sup
 ```json
 "depends_on": [
   {
-    "container": "sidecar1",
+    "name": "sidecar1",
     "condition": "healthy"
   }
 ]
@@ -199,7 +199,7 @@ Starting with `flyctl v0.3.147`, you can run multiple containers using `fly depl
       ],
       "depends_on": [
         {
-          "container": "echo",
+          "name": "echo",
           "condition": "healthy"
         }
       ]


### PR DESCRIPTION
### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

