### PR TITLE
Remove litefs cloud from nav and change wording of it being deprecated

### DIFF
--- a/partials/_litefs_nav.html.erb
+++ b/partials/_litefs_nav.html.erb
@@ -16,15 +16,6 @@
       ]
     },
     {
-      title: "LiteFS Cloud",
-      accordion: true,
-      links: [
-        { text: "Using LiteFS Cloud for Backups", path: "/docs/litefs/cloud-backups" },
-        { text: "Restoring from a LiteFS Cloud Backup", path: "/docs/litefs/cloud-restore" },
-        { text: "Disaster Recovery from LiteFS Cloud", path: "/docs/litefs/disaster-recovery" }
-      ]
-    },
-    {
       title: "Using LiteFS",
       accordion: true,
       links: [

--- a/partials/docs/_litefs_sunset.html.erb
+++ b/partials/docs/_litefs_sunset.html.erb
@@ -1,3 +1,3 @@
 <div class="warning">
-**LiteFS Cloud will be retired October 15, 2024.** [LiteFS](https://github.com/superfly/litefs) itself is not affected by the retirement of the LiteFS Cloud service. Learn more about how to disconnect from LiteFS Cloud and other options for disaster recovery in our community post: [Sunsetting LiteFS Cloud](https://community.fly.io/t/sunsetting-litefs-cloud/20829).
+**The documentation in this section is deprecated and refers to a product that was retired on October 15, 2024.** [LiteFS](https://github.com/superfly/litefs) itself is not affected by the retirement of the LiteFS Cloud service. Learn more about how to disconnect from LiteFS Cloud and other options for disaster recovery in our community post: [Sunsetting LiteFS Cloud](https://community.fly.io/t/sunsetting-litefs-cloud/20829).
 </div>


### PR DESCRIPTION
### Summary of changes
Removed litefs cloud from the nav, but kept the pages for SEO purposes. Changed the wording in the sunset callout about litefs cloud being deprecated

