### PR TITLE
Free allowances / trial credit / legacy plans clarifications

### DIFF
--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -97,9 +97,9 @@ be advantageous from a security standpoint.
 
 ---
 
-## Free resource allowances
+## Free resource allowances for Legacy Plan users
 
-Fly.io has deprecated plans as of October 7, 2024, but is still honoring them for users who purchased them prior to that date. If your plan includes [free allowances](https://fly.io/docs/about/pricing/#free-allowances), we subtract them off the top of your usage total. Once your usage exceeds the free allowance on any given resource, we start metering usage of that resource for billing purposes.
+Fly.io has deprecated plans as of October 7, 2024, but is still honoring them for users who purchased them prior to that date. If your plan includes [free allowances](https://fly.io/docs/about/pricing/#legacy-free-allowances), we subtract them off the top of your usage total. Once your usage exceeds the free allowance for any given resource, we start metering usage of that resource for billing purposes.
 
 ---
 
@@ -127,7 +127,7 @@ You can't use a prepaid card as a default (or saved) payment method. You can, ho
 
 ---
 
-## Understand charges beyond the free allowances
+## Understand your invoice charges
 
 The prices of provisioned services are mostly fixed. If you provision Machines and leave them running all month, we’ll charge you a predictable amount for that Machine.
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -274,9 +274,9 @@ Outbound data transfer:
 * 30 GB Asia Pacific, Oceania & South America
 * 30 GB Africa & India
 
-#### Legacy (Paid) Hobby plan and Free Trial credit
+#### Paid Hobby plan and Free Trial credit (deprecated)
 
-If you signed up for the now deprecated $5/month Hobby plan before the release of the Pay As You Go plan, you got a one-time $5 free trial credit to let you test-drive Fly.io at no cost. When the free trial credit is used up, we automatically place your organization on the $5/month Hobby plan, which includes $5/month of usage and free allowances. There are no free allowances during the free trial. We'll send you an email when your free trial credit is used up and you won't be charged before that. The free trial credit doesn't expire and applies only to the default (“personal”) organization that we created for you on sign-up.
+If you signed up for the now deprecated $5/month paid Hobby plan prior the release of the Pay As You Go plan, you got a one-time $5 free trial credit to let you test-drive Fly.io at no cost. When the free trial credit was used up, we automatically placed your organization on the $5/month Hobby plan, which included $5/month of usage and free allowances. There are no free allowances during the free trial. We'll send you an email when your free trial credit is used up and you won't be charged before that. The free trial credit doesn't expire and applies only to the default (“personal”) organization that we created for you on sign-up.
 
 To change your plan to the Pay As You Go plan, go to the [**Organizations** page](https://fly.io/organizations) in the dashboard, click the organization name to change, then click **Choose Pay As You Go**. If you change your plan, you won't be able to return to the paid Hobby Plan.
 

--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -274,13 +274,13 @@ Outbound data transfer:
 * 30 GB Asia Pacific, Oceania & South America
 * 30 GB Africa & India
 
-#### Paid Hobby plan and free trial
+#### Legacy (Paid) Hobby plan and Free Trial credit
 
 If you signed up for the now deprecated $5/month Hobby plan before the release of the Pay As You Go plan, you got a one-time $5 free trial credit to let you test-drive Fly.io at no cost. When the free trial credit is used up, we automatically place your organization on the $5/month Hobby plan, which includes $5/month of usage and free allowances. There are no free allowances during the free trial. We'll send you an email when your free trial credit is used up and you won't be charged before that. The free trial credit doesn't expire and applies only to the default (“personal”) organization that we created for you on sign-up.
 
 To change your plan to the Pay As You Go plan, go to the [**Organizations** page](https://fly.io/organizations) in the dashboard, click the organization name to change, then click **Choose Pay As You Go**. If you change your plan, you won't be able to return to the paid Hobby Plan.
 
-#### Legacy Hobby plan
+#### Legacy (Free) Hobby plan
 
 If you were on the free Hobby plan at the time that the paid Hobby plan became the default for new organizations, your plan is now called the Legacy Hobby plan. Your costs stay the same as they were, with no monthly subscription fee, and no included usage beyond the free resource allowances.
 


### PR DESCRIPTION
### Summary of changes
Our billing and pricing docs are unclear about free allowances, free trial credits and labeling of Legacy plans
This PR will clarify that information

Relevant docs: 
https://fly.io/docs/about/pricing/
https://fly.io/docs/about/billing/

### Preview

### Related Fly.io community and GitHub links

### Notes

