### PR TITLE
application.html.markerb: Add the missing word "start".

### DIFF
--- a/deep-dive/application.html.markerb
+++ b/deep-dive/application.html.markerb
@@ -7,7 +7,7 @@ order: 4
 
 Your demo app is running by default on two [Fly Machines](/docs/machines/), our fast-launching VMs.
 
-Both Machines stop when not in use, and automatically when a new request comes in. [Autostop/autostart](/docs/launch/autostop-autostart/) is entirely configurable. You can chose to suspend instead of stop, configure a minimum number of Machines to keep running, or even decide never to stop Machines at all.
+Both Machines stop when not in use, and start automatically when a new request comes in. [Autostop/autostart](/docs/launch/autostop-autostart/) is entirely configurable. You can chose to suspend instead of stop, configure a minimum number of Machines to keep running, or even decide never to stop Machines at all.
 
 The purpose of two Machines is twofold: redundancy and scalability. If one Machine goes down, the other can continue on. If both are available, when your app has higher traffic, both can be started to handle requests. You can [vertically scale](/launch/scale-machine/) the CPU and RAM on Machines.
 


### PR DESCRIPTION
### Summary of changes

The word "start" was missing where it explains about auto start/stop. This PR will add that word.

### Related Fly.io community and GitHub links

Page: https://fly.io/docs/deep-dive/application/
Exact location in the page: https://fly.io/docs/deep-dive/application/#:~:text=Both%20Machines%20stop%20when%20not%20in%20use%2C%20and%20automatically%20when%20a%20new%20request%20comes%20in.
