### PR TITLE
Add new doc: org roles and permissions

### DIFF
--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -167,6 +167,7 @@
       path: "/docs/security/",
       open: false,
       links: [
+        { text: "Organization Roles and Permissions", path: "/docs/security/org-roles-permissions/" },
         { text: "SSO for Organizations", path: "/docs/security/sso/" },
         { text: "Remove a Member from an Org", path: "/docs/security/remove-org-member/" },
         { text: "TLS Termination", path: "/docs/security/tls-termination/" },

--- a/security/index.html.markerb
+++ b/security/index.html.markerb
@@ -17,6 +17,7 @@ Securing a public cloud platform like Fly.io is a hard problem, and we take it s
 
 _Security for customer organizations and apps._
 
+- **[Organization Roles and Permissions](/docs/security/org-roles-permissions/):** Understand what Members and Admins can do in a Fly.io organization, and how to manage access safely.
 - **[Use SSO for organizations](/docs/security/sso/):** Set up org-wide Single Sign-on with Google or GitHub.
 - **[Remove a member from an organization](/docs/security/remove-org-member/):** Remove a user from an organization and take steps to help keep the organization secure.
 - **[Built-in TLS termination](/docs/security/tls-termination/):** You get TLS termination by default for your web apps.

--- a/security/org-roles-permissions.html.md
+++ b/security/org-roles-permissions.html.md
@@ -1,0 +1,81 @@
+---
+title: Organization Roles and Permissions
+layout: docs
+nav: firecracker
+author: kcmartin
+date: 2025-08-04
+---
+
+## Organization Role Types
+
+Fly.io organizations (orgs) have two roles: **Member** and **Admin**. These roles determine what users can do within your org, from deploying apps to managing billing.
+
+### Member
+
+Most people on your team will be Members. They can do everything you'd expect a developer or engineer to need:
+
+- Create and destroy apps
+- Deploy new versions
+- Manage secrets, volumes, and machines
+- View logs and metrics
+- Access the org's private network
+
+What they _can’t_ do: change anything about the org itself. No inviting or removing users, no billing access, no deleting the org.
+
+### Admin
+
+Admins have all the permissions of Members, plus a few critical ones:
+
+- Invite and remove users
+- View and update billing info
+- Permanently delete the organization
+
+Use the admin role sparingly. Admins can burn the place down—on purpose or by accident.
+
+**Note**: For billing and user permission details for our extension partners (e.g. Tigris, Sentry, etc.) please check with the vendor directly.
+
+### Quick Comparison
+
+| Capability | Member | Admin |
+| --- | --- | --- |
+| Deploy & manage apps | ✓ | ✓ |
+| Invite/remove users | X | ✓ |
+| Manage billing | X | ✓ |
+| Delete the org | X | ✓ |
+
+## Strategies for Safer Access Control
+
+Fly.io keeps roles simple on purpose: you get Admins and Members. But that doesn’t mean you’re stuck with a binary choice between “can delete the org” and “can’t deploy apps.” Here are a couple of ways teams carve out safer access patterns using the tools we already support.
+
+### 1. Split Environments into Separate Organizations
+
+Fly.io organizations are free to create, and there's no technical limit to how many you can have. One thing to note, each organization needs a payment method or a linked billing organization.  You can read more about linked organizations and billing [here](/docs/about/billing/#unified-billing).
+
+Let’s say you run a multiplayer game platform. You might set up:
+
+- `arcadia-dev` where every engineer is an Admin, free to deploy test builds, tweak game servers, and experiment with new features.
+- `arcadia-prod` where only ops and senior engineers have Admin rights, and everyone else is a Member.
+
+This setup avoids the classic “accidental prod deploy” scenario. Admins still get full control where it matters, but you’re not handing out the keys to production just so someone can push a staging build.
+
+### 2. Use Read-Only Tokens for Observability-Only Roles
+
+Sometimes people need to see things without touching them. Maybe your support team wants to look at logs to troubleshoot customer issues. Maybe your SREs want to hook into Grafana or another dashboard tool.
+
+You don’t need to make those people Members. Instead, generate a read-only API token:
+
+`flyctl tokens create readonly`
+
+This token can authenticate to Fly.io, but not make any changes. To use it properly, the user should be **logged out** (`fly auth logout`) and run commands with the token set via `FLY_API_TOKEN`. For maximum safety, don’t make these users Members of the org at all. If they are, they could still run `fly auth login` and get full access through their user account, bypassing the token’s restrictions. It’s a great way to integrate observability tools or give your team visibility without risk. You can read more about uses for `fly tokens create` on the [reference page](/docs/flyctl/tokens-create/).
+
+## Summing up
+
+Fly.io keeps roles simple on purpose, but you still have the tools to shape access around how your team actually works. Keep the number of Admins small, make sure Members have only the access they need, and lock down everything else by default.
+
+## Related Reading
+
+- [Moving an application between orgs](/docs/apps/move-app-org/)
+- [Handing over an application](/docs/apps/app-handover-guide/)
+- [Read-only tokens reference](/docs/flyctl/tokens-create-readonly/)
+- [Staging and production isolation](/docs/blueprints/staging-prod-isolation/)
+


### PR DESCRIPTION
### Summary of changes
- New doc: Understand what Members and Admins can do in a Fly.io organization, and how to manage access safely.
- add to navigation and Security index page

### Preview
Previewed in local env

<img width="1504" height="803" alt="Screenshot 2025-08-04 at 12 38 55 PM" src="https://github.com/user-attachments/assets/7d354713-c145-4ea1-af3f-e890eadf2418" />

