### PR TITLE
initial improvements to support docs page

### DIFF
--- a/about/support.html.md
+++ b/about/support.html.md
@@ -26,7 +26,11 @@ All customers have access to our active [community forum](https://community.fly.
 
 Customers also frequently help each other out and share insights on running their apps on Fly.io. Especially helpful contributors can earn a special "Aeronaut" badge to signify their troubleshooting prowess, great advice, and exceptional kindness.
 
-## Email support
+## Paid support plans
+
+**Find out more:** Want to learn more about our different support plans or ready to get started? Just head over to our [Support page](https://fly.io/support). We've got all the details there to help you choose what works best for you!
+
+### Email support
 
 **Who can use this:** Organizations who have purchased a Standard, Premium, or Enterprise Support package or organizations with legacy Launch or Scale plans. 
 
@@ -36,7 +40,7 @@ Our Standard, Premium, and Enterprise packages have access to email support. The
 
 You can find your support address is in the [Fly.io dashboard](https://fly.io/dashboard). Select your organization, and look for your unique email address in the **Support** section. You'll also find a form to submit new support tickets, as well as an overview of recent support interactions.
 
-## Support Portal
+### Support Portal
 
 **Who can use this:** Organizations who have purchased a Standard, Premium, or Enterprise Support package or organizations with legacy Launch or Scale plans.
 

--- a/about/support.html.md
+++ b/about/support.html.md
@@ -2,7 +2,6 @@
 title: Support
 layout: docs
 nav: firecracker
-toc: false
 ---
 
 <figure>
@@ -29,7 +28,7 @@ Customers also frequently help each other out and share insights on running thei
 
 ## Email support
 
-**Who can use this:** Organizations who have purchased a Standard, Premium, or Enterprise Support package or organizations with legacy Launch or Scale plans.
+**Who can use this:** Organizations who have purchased a Standard, Premium, or Enterprise Support package or organizations with legacy Launch or Scale plans. 
 
 **Use this for:**  Technical support for issues or questions specific to you.
 


### PR DESCRIPTION
### Summary of changes
The page is long, first of more improvements to come is: 
- adding a TOC to the page
- changing the headings to group paid support items
- adding a section and link to the main support page so users can compare and select a plan

### Preview
Previewed in local env

<img width="1121" height="803" alt="Screenshot 2025-08-06 at 10 47 56 AM" src="https://github.com/user-attachments/assets/46b66353-b286-4c60-888b-046b8c3e99f8" />
