### PR TITLE
Add best-effort warning about kill_timeout

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -68,7 +68,7 @@ For example, to set the timeout to two minutes:
 kill_timeout = 120
 ```
 
-<section class="warning">Note: `kill_timeout` times should be considered best-effort, and your app needs to be prepared to handle shorter stopping times</section>
+<section class="warning">Note: `kill_timeout` settings should be considered best-effort, and your app needs to be prepared to handle shorter stopping times</section>
 
 ## Console command
 


### PR DESCRIPTION
### Summary of changes
Add warning that the `kill_timeout` setting should be considered best-effort. There are times, for example, that it can interfere with required infra operations like host drain, so the customer's app needs to be able to handle that.

### Preview
Previewed in local env
