### PR TITLE
Update configuration.html.markerb

### DIFF
--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -98,13 +98,19 @@ The optional build section contains key/values concerned with how the applicatio
 
 ```toml
 [build]
-  builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/nodejs"]
+  builder = "paketobuildpacks/builder-jammy-base"
 ```
 
 The builder "builder" uses CNB Buildpacks and Builders to create the application image. These are third party toolkits which can use Heroku compatible build processes or other tools. The tooling is all managed by the buildpacks and buildpacks are assembled into CNB Builders - images complete with the buildpacks and OS to run the tool chains.
 
-In our example above, the builder is being set to use [Paketo's all-purpose builder](https://paketo.io) with the NodeJS buildpack.
+In our example above, the builder is being set to use [Paketo's all-purpose builder](https://paketo.io) which automatically detects needed buildpacks.
+
+You can also explicitly define buildpacks:
+```toml
+[build]
+  builder = "paketobuildpacks/builder:base"
+  buildpacks = ["gcr.io/paketo-buildpacks/nodejs"]
+```
 
 ### Specify a Docker image
 

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -108,8 +108,8 @@ In our example above, the builder is being set to use [Paketo's all-purpose buil
 You can also explicitly define buildpacks:
 ```toml
 [build]
-  builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/nodejs"]
+  builder = "paketobuildpacks/builder-jammy-base"
+  buildpacks = ["docker.io/paketobuildpacks/nodejs"]
 ```
 
 ### Specify a Docker image


### PR DESCRIPTION
### Summary of changes
Changed to a builder that is still maintained.

Not sure if the separate buildpacks parameter is needed, but kept that as as separate example.

### Preview

### Related Fly.io community and GitHub links

### Notes

I wonder why you don't fall back to buildpacks if Dockerfile does not exist🤷‍♂️ At least it could do a priming build if it succeeds and if so, then drop this line to the tly.toml. Tried your platform first time today and experience was not very good. With your docs and google I expected things would work and then from docs I got snippet that brought me outdated buildpack. Implicitly using up-to-date buildpacks might make me try this again (or promote this service to our developer audience)
