### PR TITLE
Add mounting secrets section and headings to Secrets doc

### DIFF
--- a/apps/secrets.html.markerb
+++ b/apps/secrets.html.markerb
@@ -81,7 +81,7 @@ Secrets must be base64‑encoded before setting.
 
 `secret_name`: The name of an app secret that’s been set with `fly secrets set`. The value of the secret will be written to the file. The referenced secret’s value must be base64 encoded.
 
-`guest_path`: The full path inside the Machine where the file will be written at boot/
+`guest_path`: The full path inside the Machine where the file will be written at boot.
 
 ```toml
 [[files]]

--- a/apps/secrets.html.markerb
+++ b/apps/secrets.html.markerb
@@ -20,7 +20,7 @@ Secrets are stored in an encrypted vault. When you set a secret through `flyctl`
 When we launch a Machine for your app, we issue a temporary auth token to the host it runs on. The Fly.io agent on the host uses this token to decrypt your app secrets and inject them into your Machine as environment variables at boot time. When you destroy your Machines, the host environment no longer has access to your app secrets.
 
 <section class="warning icon">
-**Warning:** `flyctl` and our API servers are designed to prevent user secrets from being extracted. However, secrets are available to your application code as environment variables. People with deploy access _can_ deploy code that reads secret values and prints them to logs, or writes them to unencrypted data stores.
+**Warning:** `flyctl` and our API servers are designed to prevent user secrets from being extracted. However, secrets are available to your application code as environment variables. People with deploy access **can** deploy code that reads secret values and prints them to logs, or writes them to unencrypted data stores.
 </section>
 
 ## Working with Secrets
@@ -40,7 +40,7 @@ fly secrets set DATABASE_URL=postgres://example.com/mydb --stage
 
 In the preceding example, the staged secret will be available only on Machines that are started or updated after the `fly secrets set` command was run.
 
-The `secrets` command can also take secrets from STDIN. For commands and options, see the [`fly secrets` docs](/docs/flyctl/secrets/) or run `fly secrets --help`.
+The `secrets` command can also take secrets from `stdin`. For commands and options, see the [`fly secrets` docs](/docs/flyctl/secrets/) or run `fly secrets --help`.
 
 <section class="note icon">
 **Note:** You can update a machine by triggering a new release with `fly deploy`. Alternatively, the `fly secrets deploy` command will redeploy the current release with the staged secrets. This is helpful if you want to skip rebuilding the image from source code.</section>
@@ -77,7 +77,13 @@ fly secrets unset MY_SECRET DATABASE_URL
 
 You can write a secret’s value directly to the machine's filesystem at startup using the `[[files]]` section in `fly.toml`. This is useful for things like private keys your app expects on disk.
 
-Secrets must be base64‑encoded before setting.
+Secrets must be base64‑encoded. 
+
+Example:
+
+```cmd
+fly secrets set SUPER_SECRET=$(cat filename.txt | base64)
+```
 
 `secret_name`: The name of an app secret that’s been set with `fly secrets set`. The value of the secret will be written to the file. The referenced secret’s value must be base64 encoded.
 

--- a/apps/secrets.html.markerb
+++ b/apps/secrets.html.markerb
@@ -5,7 +5,9 @@ nav: apps
 redirect_from: /docs/reference/secrets/
 ---
 
-Specify secrets for your Fly App using the `fly secrets` command. Secrets allow sensitive values, such as credentials, to be passed securely to your Fly App. The secret is encrypted and stored in a vault. An app's secrets are available as environment variables at runtime on every Machine belonging to that Fly App, whether the Machine is managed by Fly Launch or not. 
+## Overview
+
+You can specify secrets for your Fly App using the `fly secrets` command. Secrets allow sensitive values, such as credentials, to be passed securely to your Fly App. The secret is encrypted and stored in a vault. An app's secrets are available as environment variables at runtime on every Machine belonging to that Fly App, whether the Machine is managed by Fly Launch or not. 
 
 Data stored as secrets doesn't have to be sensitive; secrets are made available to the app as environment variables to use for whatever purpose you like.
 
@@ -13,7 +15,7 @@ If you need secrets to be available when building your Docker image, see [Build 
 
 ## Architecture
 
-Secrets are stored in an encrypted vault. When you set a secret through flyctl, it sends the secret value through our API, which writes to the vault for your specific Fly App. The API servers can only encrypt; they cannot decrypt secret values. Secret values are never logged.
+Secrets are stored in an encrypted vault. When you set a secret through `flyctl`, it sends the secret value through our API, which writes to the vault for your specific Fly App. The API servers can only encrypt; they cannot decrypt secret values. Secret values are never logged.
 
 When we launch a Machine for your app, we issue a temporary auth token to the host it runs on. The Fly.io agent on the host uses this token to decrypt your app secrets and inject them into your Machine as environment variables at boot time. When you destroy your Machines, the host environment no longer has access to your app secrets.
 
@@ -21,7 +23,8 @@ When we launch a Machine for your app, we issue a temporary auth token to the ho
 **Warning:** `flyctl` and our API servers are designed to prevent user secrets from being extracted. However, secrets are available to your application code as environment variables. People with deploy access _can_ deploy code that reads secret values and prints them to logs, or writes them to unencrypted data stores.
 </section>
 
-## Set secrets
+## Working with Secrets
+### Set secrets
 
 The `fly secrets set` command sets one or more app secrets, then updates each Machine belonging to that Fly App. This involves a restart of the Machine and a consequent reset of its ephemeral file system.
 
@@ -42,7 +45,7 @@ The `secrets` command can also take secrets from STDIN. For commands and options
 <section class="note icon">
 **Note:** You can update a machine by triggering a new release with `fly deploy`. Alternatively, the `fly secrets deploy` command will redeploy the current release with the staged secrets. This is helpful if you want to skip rebuilding the image from source code.</section>
 
-## List secrets
+### List secrets
 
 List secrets that are set for your app. The list shows only the secret name; the value is not shown as it is a secret.
 
@@ -60,7 +63,7 @@ fly secrets list
 
 For security reasons, we do not allow read access to the plain-text values of secrets.
 
-## Remove secrets
+### Remove secrets
 
 Remove one or more secret values from your app by name.
 
@@ -69,3 +72,23 @@ The following example removes two secrets from the app:
 ```cmd
 fly secrets unset MY_SECRET DATABASE_URL
 ```
+
+### Mounting Secrets as Files
+
+You can write a secret’s value directly to the machine's filesystem at startup using the `[[files]]` section in `fly.toml`. This is useful for things like private keys your app expects on disk.
+
+Secrets must be base64‑encoded before setting.
+
+`secret_name`: The name of an app secret that’s been set with `fly secrets set`. The value of the secret will be written to the file. The referenced secret’s value must be base64 encoded.
+
+`guest_path`: The full path inside the Machine where the file will be written at boot/
+
+```toml
+[[files]]
+  guest_path = "/path/to/secret.txt"
+  secret_name = "SUPER_SECRET"
+```
+
+You can use this with other `[[files]]` entries, check the `fly.toml` [reference](/docs/reference/configuration/#the-files-section) for more details.
+
+


### PR DESCRIPTION
### Summary of changes
Improving Secrets docs
- add new section: mounting secrets on the filesystem
- add headings and subheadings for easier navigation

### Preview
<img width="1327" height="664" alt="Screenshot 2025-08-29 at 11 38 26 AM" src="https://github.com/user-attachments/assets/097f5f8d-f09e-4878-b652-c35a1a0ce69e" />




requested by @lillianberryfly 
