### PR TITLE
Remove litefs cloud blueprint from side navigation and Blueprints index

### DIFF
--- a/blueprints/deno-kv-litefs.html.markerb
+++ b/blueprints/deno-kv-litefs.html.markerb
@@ -1,6 +1,7 @@
 ---
 title: Deno KV with LiteFS Cloud
 layout: docs
+published: false
 nav: firecracker
 author: jesse
 date: 2024-05-28


### PR DESCRIPTION
### Summary of changes
- This blueprint has deprecated content (LiteFS Cloud), so removing it from the blueprints side nav and index page, but keeping the page for seo purposes for now
- `published: false` in frontmatter removes from nav and index, while keeping the page still reachable via url.
- There's already a deprecation notice on the page
- verified change in local env


