### PR TITLE
add 7 illustration links to blueprint guides

### DIFF
--- a/blueprints/infra-automation-without-terraform.html.md
+++ b/blueprints/infra-automation-without-terraform.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-08-05
 ---
 
+<figure>
+  <img src="/static/images/building-infrastructure-automation.png" alt="Illustration by Annie Ruygt of a Frankie the balloon working on automation at his computer" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Overview
 
 We don’t have a Terraform provider anymore, and that’s intentional. It’s not a great fit for how our platform works. This guide is about how to get a Terraform-like experience using the tools that do fit.

--- a/blueprints/n-tier-architecture.html.md
+++ b/blueprints/n-tier-architecture.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-08-29
 ---
 
+<figure>
+  <img src="/static/images/get-started-n-tier.png" alt="Illustration by Annie Ruygt of a bird slicing a loaf of bread-think app layers" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## What is n-tier architecture?
 
 When people talk about “**n-tier architecture**,” they’re describing a way of splitting an app into layers (or “tiers”) that each have a specific job. The “**n**” just means there could be two, three, or more tiers depending on how you slice things.

--- a/blueprints/rollback-guide.html.md
+++ b/blueprints/rollback-guide.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-08-22
 ---
 
+<figure>
+  <img src="/static/images/rollback-guide.png" alt="Illustration by Annie Ruygt of a Frankie the hot air balloon helping his developer friend roll back a bad deploy" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Why rollback?
 
 Fly.io runs your apps close to your users, in VMs you can spin up and tear down in seconds. But what if you spin up something broken? If a deploy goes wrong, it’s easy to roll back: just tell Fly to redeploy a previous image. There’s no special `rollback` command because you don’t need one. Rollbacks use the same deploy mechanism you already know.

--- a/blueprints/seamless-deployments.html.md
+++ b/blueprints/seamless-deployments.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-06-26
 ---
 
+<figure>
+  <img src="/static/images/seamless-deployments.png" alt="Illustration by Annie Ruygt of a balloon doing a health check" class="w-full max-w-lg mx-auto">
+</figure>
+
 <div class="callout">
 **Zero-downtime deploys aren’t magic. They’re just health checks that work. Fly.io apps run on individual VMs, and we won’t start routing traffic to a new one until it proves it’s alive. Here's how to get seamless deploys without breaking things or relying on hope as a strategy.**
 </div>

--- a/blueprints/setting-concurrency-limits.html.md
+++ b/blueprints/setting-concurrency-limits.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-05-15
 ---
 
+<figure>
+  <img src="/static/images/setting-limits.png" alt="Illustration by Annie Ruygt of Frankie the hot air balloon with two other balloon friends of different colors" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Introduction
 
 On Fly.io, machines aren’t created automatically based on traffic; you create them manually. But once a machine is created, it can be stopped when idle (meaning you’re not paying for it), and started again instantly when load picks up. Our “autostart/autostop” feature can drive this process for you — but it only works well if you’ve tuned `soft_limit` and `hard_limit` correctly. Those limits tell Fly when a machine is too busy and it's time to bring more machines online.

--- a/blueprints/task-scheduling.html.md
+++ b/blueprints/task-scheduling.html.md
@@ -8,6 +8,11 @@ categories:
 date: 2025-07-18
 ---
 
+<figure>
+  <img src="/static/images/task-scheuling.png" alt="Illustration by Annie Ruygt of Frankie the hot air balloon scheduling some tasks on his calendar" class="w-full max-w-lg mx-auto">
+</figure>
+
+
 Running on a schedule: it's not just for trains. If your app needs to rebuild a cache every night, prune old data, or email a weekly newsletter to your users, you’re probably looking for a way to run a cron job. Fly.io gives you a few ways to get that done.
 
 We’ll walk through options for task scheduling, starting with the most robust and ending with the “it works, okay?” tier.

--- a/blueprints/work-queues.html.md
+++ b/blueprints/work-queues.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-07-17
 ---
 
+<figure>
+  <img src="/static/images/work-queue.png" alt="Illustration by Annie Ruygt of a robot setting up a queue of boxes and tasks" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Overview
 
 Some things just take a while. Generating a PDF. Calling a slow third-party API. Running a machine learning model. Sending an email newsletter, and retrying if the mail server flakes out.


### PR DESCRIPTION
### Summary of changes
Add new illustration links to these docs:
[Setting concurrency limits](https://fly.io/docs/blueprints/setting-concurrency-limits/)
[Seamless deployments](https://fly.io/docs/blueprints/seamless-deployments/)
[Work queues guide](https://fly.io/docs/blueprints/work-queues/)
[Task scheduling guide](https://fly.io/docs/blueprints/task-scheduling/)
[Automation without Terraform](https://fly.io/docs/blueprints/infra-automation-without-terraform/)
[Rollback guide](https://fly.io/docs/blueprints/rollback-guide/)
[Getting started with n-tier architecture](https://fly.io/docs/blueprints/n-tier-architecture/)

All previewed in local env

