### PR TITLE
Add new autoscaling illustration to reference page

### DIFF
--- a/reference/autoscaling.html.md
+++ b/reference/autoscaling.html.md
@@ -4,6 +4,10 @@ layout: docs
 nav: firecracker
 ---
 
+<figure class="flex justify-center">
+  <img src="/static/images/autoscaling.png" alt="Illustration by Annie Ruygt of several machines running" class="w-full max-w-lg mx-auto">
+</figure>
+
 Autoscaling adjusts the number of running or created Fly Machines dynamically. We support two forms of autoscaling:
 
 - Autostop/autostart Machines


### PR DESCRIPTION
### Summary of changes
Adding new illustration to [Autoscaling Reference page](https://fly.io/docs/reference/autoscaling/)

### Preview
<img width="1105" height="545" alt="Screenshot 2025-09-22 at 12 29 40 PM" src="https://github.com/user-attachments/assets/a46dfb29-b129-47ab-bf0b-18c84f29ea33" />



