### PR TITLE
Remove extra incorrect link from Guides section nav partial

### DIFF
--- a/partials/_guides_nav.html.erb
+++ b/partials/_guides_nav.html.erb
@@ -53,7 +53,6 @@
         { text: "Observability for User Apps", path: "/docs/blueprints/observability-for-user-apps/" },
         { text: "Autoscale Machines", path: "/docs/blueprints/autoscale-machines/" },
         { text: "Autostart and autostop private apps", path: "/docs/blueprints/autostart-internal-apps/" },
-        { text: "Backing up your cluster", path: "/docs/litefs/backup" },
         { text: "Setting Hard and Soft Concurrency Limits", path: "/docs/blueprints/setting-concurrency-limits/" },
         { text: "Using Fly Volume forks for faster startup times", path: "/docs/blueprints/volume-forking/" },
         { text: "Going to Production with Healthcare Apps", path: "/docs/blueprints/going-to-production-with-healthcare-apps/" }


### PR DESCRIPTION
### Summary of changes
- remove extra link from Guides nav (copy-paste error)

