### PR TITLE
Correct confusing reference to database pricing - should be cluster

### DIFF
--- a/mpg/index.html.md
+++ b/mpg/index.html.md
@@ -89,4 +89,4 @@ The current monthly plan pricing is:
 
 Database storage is priced at **$0.28 per provisioned GB for a 30-day month**. For example, if you have 10GB of storage provisioned for your cluster, your monthly storage cost will be $2.80.
 
-Databases created or deleted mid-month will have their pricing prorated accordingly.
+Clusters created or deleted mid-month will have their pricing prorated accordingly.


### PR DESCRIPTION
### Summary of changes
Says "Databases created or deleted mid-month will have their pricing prorated accordingly.", should say "Clusters created or deleted mid-month will have their pricing prorated accordingly."
### Related Fly.io community and GitHub links
https://community.fly.io/t/pricing-clarification-for-mpg/26066/2

### Notes

