### PR TITLE
Add 7 illustration links to guides-oct batch 1

### DIFF
--- a/blueprints/multi-region-fly-replay.html.md
+++ b/blueprints/multi-region-fly-replay.html.md
@@ -4,6 +4,10 @@ layout: docs
 nav: guides
 ---
 
+<figure>
+  <img src="/static/images/multi-region.png" alt="Illustration by Annie Ruygt of Frankie looking out over the solar system" class="w-full max-w-lg mx-auto">
+</figure>
+
 You want to run your app and database in multiple [regions](/docs/reference/regions/) close to your users, and deploying database read replicas will give you better performance on read requests. This is a good solution for apps with read-heavy database workloads. But you also want writes to be efficient, despite needing to write to a primary database on the other side of the world.
 
 This blueprint will help you understand the concepts to implement an app, with a primary database and read replicas in multiple regions, that uses the `fly-replay` response header to re-route write requests to the primary region. Consider using this blueprint when:

--- a/blueprints/per-user-dev-environments.html.md
+++ b/blueprints/per-user-dev-environments.html.md
@@ -5,6 +5,10 @@ nav: guides
 date: 2025-04-02
 ---
 
+<figure>
+  <img src="/static/images/per-user-dev.png" alt="Illustration by Annie Ruygt of different envrionments under glass domes" class="w-full max-w-lg mx-auto">
+</figure>
+
 Fly Machines are fast-launching VMs behind [a simple API](https://fly.io/docs/machines/api), enabling you to launch tightly isolated app instances in milliseconds [all over the world](https://fly.io/docs/reference/regions/).
 
 One interesting use case: running isolated dev environments for your users (or robots). Fly Machines are a safe execution sandbox for even the sketchiest user-generated (or LLM-generated) code.

--- a/blueprints/remote-mcp-servers.html.md
+++ b/blueprints/remote-mcp-servers.html.md
@@ -4,6 +4,11 @@ layout: docs
 nav: guides
 date: 2025-04-15
 ---
+
+<figure>
+  <img src="/static/images/remote-mpc.png" alt="Illustration by Annie Ruygt of bird working at their computer while drinking coffee" class="w-full max-w-lg mx-auto">
+</figure>
+
 The Model Context Protocol (MCP) is a fun new way to give LLMs new powers. Originally developed by Anthropic, the protocol has since been adopted by OpenAI (with Google Gemini support in the works at the time of writing).
 
 The protocol defines a standardized way of connecting tools and providing additional context to LLMs, not dissimilar to the way USB provides a standardized way to connect computers to peripherals and devices. Fly Machines are tightly isolated VMs that are perfect for running MCP servers.

--- a/blueprints/resilient-apps-multiple-machines.html.md
+++ b/blueprints/resilient-apps-multiple-machines.html.md
@@ -5,6 +5,10 @@ nav: guides
 date: 2025-09-12
 ---
 
+<figure>
+  <img src="/static/images/resilient-apps.png" alt="Illustration by Annie Ruygt of an armoured truck with a Fly balloon logo" class="w-full max-w-lg mx-auto">
+</figure>
+
 <div class="callout">
 **Fly Machines are fast-launching VMs, the basic compute unit of the Fly.io platform. Each Machine runs on a single physical host. If that host fails, the Machine goes down and does not automatically start again on another host.**
 </div>

--- a/blueprints/review-apps-guide.html.md
+++ b/blueprints/review-apps-guide.html.md
@@ -11,6 +11,10 @@ categories:
 redirect_from: /docs/app-guides/review-apps-guide/
 ---
 
+<figure>
+  <img src="/static/images/review-apps-github.png" alt="Illustration by Annie Ruygt of Github Octocat and Frankie with some apps" class="w-full max-w-lg mx-auto">
+</figure>
+
 Review apps are a great way to preview new features, changes, and bug fixes. This guide will teach you how to automatically generate ephemeral "review apps" on Fly.io for each pull request (PR) using GitHub Actions. This approach can be applied to other Git services and source code versioning software that supports branching and hooks.
 
 ## Quick Start

--- a/blueprints/sticky-sessions.html.md
+++ b/blueprints/sticky-sessions.html.md
@@ -6,9 +6,11 @@ author: rubys
 date: 2024-07-17
 ---
 
-In a number of scenarios, it is important to ensure that certain requests are
-routed to a specific Machine.  This frequently is expressed in the form of
-wanting an entire user's session to be processed by the same Machine.
+<figure>
+  <img src="/static/images/session-affinity.png" alt="Illustration by Annie Ruygt of a machine sticking envelopes together" class="w-full max-w-lg mx-auto">
+</figure>
+
+In a number of scenarios, it is important to ensure that certain requests are routed to a specific Machine.  This frequently is expressed in the form of wanting an entire user's session to be processed by the same Machine.
 
 There are two basic approaches to addressing this with Fly.io:
   * [fly-force-instance-id](https://fly.io/docs/networking/dynamic-request-routing#the-fly-force-instance-id-request-header) request header

--- a/blueprints/using-base-images-for-faster-deployments.html.md
+++ b/blueprints/using-base-images-for-faster-deployments.html.md
@@ -4,6 +4,10 @@ layout: docs
 nav: guides
 ---
 
+<figure>
+  <img src="/static/images/using-base-images.png" alt="Illustration by Annie Ruygt of the Docker whale carrying some containers" class="w-full max-w-lg mx-auto">
+</figure>
+
 This blueprint explains how to use base images for faster deployments.  A base image is any image that is intended to be used as the `FROM` line in a Dockerfile.  Each app that is deployed on Fly.io can add an image to the Fly registry.
 
 Every app in the same organization can access the image for any other app and use it as the `FROM` line in their Dockerfile.  This means that it is very easy to make a base image by making a second app to use as the base image.


### PR DESCRIPTION
### Summary of changes
Add illustrations links to these guides:
https://fly.io/docs/blueprints/resilient-apps-multiple-machines/
https://fly.io/docs/blueprints/sticky-sessions/
https://fly.io/docs/blueprints/multi-region-fly-replay/
https://fly.io/docs/blueprints/remote-mcp-servers/
https://fly.io/docs/blueprints/review-apps-guide/
https://fly.io/docs/blueprints/per-user-dev-environments/
https://fly.io/docs/blueprints/using-base-images-for-faster-deployments/



### Preview
Previewed all in local env

