### PR TITLE
Remove deprecated regions from  reference/regions

### DIFF
--- a/reference/regions.html.markerb
+++ b/reference/regions.html.markerb
@@ -20,38 +20,21 @@ You can host your apps in any of the following regions.
 |-----------|-------------------------------|-------------|
 | ams       | Amsterdam, Netherlands        | ✓           |
 | arn       | Stockholm, Sweden             | ✓           |
-| atl       | Atlanta, Georgia (US)         |             |
-| bog       | Bogotá, Colombia              |             |
 | bom       | Mumbai, India                 | ✓           |
-| bos       | Boston, Massachusetts (US)    |             |
 | cdg       | Paris, France                 | ✓           |
-| den       | Denver, Colorado (US)         |             |
 | dfw       | Dallas, Texas (US)            | ✓           |
 | ewr       | Secaucus, NJ (US)             | ✓           |
-| eze       | Ezeiza, Argentina             |             |
 | fra       | Frankfurt, Germany            | ✓           |
-| gdl       | Guadalajara, Mexico           | ✓           |
-| gig       | Rio de Janeiro, Brazil        |             |
 | gru       | Sao Paulo, Brazil             |             |
-| hkg       | Hong Kong, Hong Kong          | ✓           |
 | iad       | Ashburn, Virginia (US)        | ✓           |
 | jnb       | Johannesburg, South Africa    |             |
 | lax       | Los Angeles, California (US)  | ✓           |
 | lhr       | London, United Kingdom        | ✓           |
-| mad       | Madrid, Spain                 |             |
-| mia       | Miami, Florida (US)           |             |
 | nrt       | Tokyo, Japan                  | ✓           |
 | ord       | Chicago, Illinois (US)        | ✓           |
-| otp       | Bucharest, Romania            |             |
-| phx       | Phoenix, Arizona (US)         |             |
-| qro       | Querétaro, Mexico             | ✓           |
-| scl       | Santiago, Chile               | ✓           |
-| sea       | Seattle, Washington (US)      | ✓           |
 | sin       | Singapore, Singapore          | ✓           |
 | sjc       | San Jose, California (US)     | ✓           |
 | syd       | Sydney, Australia             | ✓           |
-| waw       | Warsaw, Poland                |             |
-| yul       | Montreal, Canada              |             |
 | yyz       | Toronto, Canada               | ✓           |
 
 - **Gateway regions:** "Gateway" regions also have WireGuard gateways, through which you connect to your organization's private network.


### PR DESCRIPTION
Removed all to-be-depreciated regions from the general region list.

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

