### PR TITLE
Documentation for session-based replay caching

### DIFF
--- a/blueprints/sticky-sessions.html.md
+++ b/blueprints/sticky-sessions.html.md
@@ -12,14 +12,13 @@ date: 2024-07-17
 
 In a number of scenarios, it is important to ensure that certain requests are routed to a specific Machine.  This frequently is expressed in the form of wanting an entire user's session to be processed by the same Machine.
 
-There are two basic approaches to addressing this with Fly.io:
-  * [fly-force-instance-id](https://fly.io/docs/networking/dynamic-request-routing#the-fly-force-instance-id-request-header) request header
-  * [fly-replay](https://fly.io/docs/networking/dynamic-request-routing#the-fly-replay-response-header) response header.
+There are two approaches to addressing this with Fly.io:
+  * [fly-force-instance-id](#fly-force-instance-id) - Client-side request header
+  * [fly-replay](#fly-replay) - Server-side response header
 
-## Fly-Force-Instance_Id
+## Fly-Force-Instance-Id
 
-This is the preferred approach, but it does require you to have control over the client, typically a browser.  The example below uses Rails' Hotwire [Turbo](https://turbo.hotwired.dev/) with [Stimulus](https://stimulus.hotwired.dev/) to
-send the required header.
+This approach requires you to have control over the client, typically a browser, but allows for immediate routing without an additional hop. The example below uses Rails' Hotwire [Turbo](https://turbo.hotwired.dev/) with [Stimulus](https://stimulus.hotwired.dev/) to send the required header.
 
 For this to work, the client needs some way of knowing what Machine to route requests to.  This can be accomplished by adding attributes to the `<body>` tag in HTML responses.  With Rails, those tags would be found in
 `app/views/layouts/application.html.erb`.
@@ -66,12 +65,11 @@ This code will subscribe and unsubscribe from
 
 ## Fly-Replay
 
-This approach can be implemented entirely on the server.  This will require an additional "hop" to route requests and [is limited to payloads of 1 megabyte](https://fly.io/docs/networking/dynamic-request-routing/#limitations).
+This approach is implemented entirely on the server. Your application examines each request, determines which Machine should handle it, and returns a `fly-replay` response header to route the request accordingly. Initial requests will require an additional "hop" to route, and [requests are limited to payloads of 1 megabyte](https://fly.io/docs/networking/dynamic-request-routing/#limitations).
 
-The example below creates [Express Middleware](https://expressjs.com/en/guide/using-middleware.html) that creates cookies containing the desired Machine id, and then replays requests that arrive at the wrong destination:
+The example below creates [Express Middleware](https://expressjs.com/en/guide/using-middleware.html) that routes requests based on a session cookie:
 
 ```js
-
 // Import required modules
 import express from "express";
 import cookieParser from "cookie-parser";
@@ -82,26 +80,34 @@ const app = express();
 // Middleware to parse cookies
 app.use(cookieParser());
 
-// Make sessions sticky
 app.use((request, response, next) => {
-  if (!process.env.FLY_MACHINE_ID) {
-    next();
-  } else if (!request.cookies["fly-machine-id"]) {
-    const maxAge = 6 * 24 * 60 * 60 * 1000; // six days
-    response.cookie("fly-machine-id", process.env.FLY_MACHINE_ID, { maxAge });
-    next();
-  } else if (request.cookies["fly-machine-id"] !== process.env.FLY_MACHINE_ID) {
-    response.set('Fly-Replay', `instance=${request.cookies["fly-machine-id"]}`)
-    response.status(307)
-    response.send()
-  } else {
-    next();
-  }
-});
+  // This assumes your application has already established a session using a session_id cookie via your session middleware.
+  const sessionId = request.cookies["session_id"];
 
-// For demonstration purposes: show the Machine id that produced the response
-app.get("/", (_request, response) => {
-  response.send(`FLY_MACHINE_ID: ${JSON.stringify(process.env.FLY_MACHINE_ID)}`);
+  if (!sessionId) {
+    // No session - let any machine handle it
+    next();
+    return;
+  }
+
+  // Determine which machine should handle this session
+  // This could be based on:
+  // - Database lookup (session -> machine mapping)
+  // - Consistent hashing of session ID
+  // - Regional routing logic
+  // - Load balancing algorithm
+  // You'll need to implement determineTargetMachine() based on your routing strategy
+  const targetMachineId = determineTargetMachine(sessionId);
+
+  if (targetMachineId === process.env.FLY_MACHINE_ID) {
+    // This is the correct machine - handle the request
+    next();
+  } else {
+    // Route to the correct machine
+    response.set('Fly-Replay', `instance=${targetMachineId}`);
+    response.status(307);
+    response.send();
+  }
 });
 
 // Start the Express server
@@ -111,13 +117,32 @@ app.listen(port, () => {
 });
 ```
 
-The key code here appears directly after the `// Make sessions sticky` comment.
+### Optimizing with Replay Caching
 
-If the `FLY_MACHINE_ID` environment variable is not set, this code is not running on a Fly.io Machine, and this middleware immediately exits.
+For production workloads, having your application replay every request can create unnecessary load and latency. You can configure Fly Proxy to cache replay decisions, so only the first request in a session needs to consult your application.
 
-If the `fly-machine-id` cookie is not set, then this presumably is the first request of a session, and the cookie is
-set to ensure that future requests are routed to the same destination.
+Add replay cache rules to your `fly.toml`:
 
-If the cookie does not match the environment variable, then a response containing a `Fly-Replay` header is created, which triggers the Fly Proxy to replay the request to the desired Machine.
+```toml
+[http_service]
+  internal_port = 8080
+  force_https = true
 
-If none of these conditions is satisfied, the middleware passes on the request to the next handler.
+  [[http_service.http_options.replay_cache]]
+    path_prefix = "/"
+    ttl_seconds = 300
+    type = "cookie"
+    name = "session_id"
+```
+
+With this configuration:
+1. The first request with a given `session_id` hits your app
+2. Your app returns a `fly-replay` response
+3. Fly Proxy caches this decision for that specific `session_id` value
+4. For the next 5 minutes, requests with the same `session_id` are automatically routed without consulting your app
+
+Caching is an optimization, not a guarantee, so your origin app still needs to handle replaying requests that aren't routed by a cached replay.
+
+Replays can be cached on any existing cookie or request header. For sticky sessions with an API, for example, you might choose to cache based on the `Authorization` header.
+
+For complete details on replay caching configuration, see [Session-based Replay Caching](/docs/networking/dynamic-request-routing/#session-based-replay-caching).

--- a/networking/dynamic-request-routing.html.markerb
+++ b/networking/dynamic-request-routing.html.markerb
@@ -128,20 +128,30 @@ Route to another app, and modify the request:
 
 ## Replay Caching
 
-In cases where the replay target does not change often, you can use the `fly-replay-cache` mechanism to relieve the original app of some load. Here's how it works:
+Replay caching allows Fly Proxy to remember and reuse replay decisions, reducing both load on your application and the latency of replayed requests. There are two types of replay caching:
+
+- **Path-based**: Cache replays for specific URL paths
+- **Session-based**: Cache replays for specific cookie or header values
+
+<div class="note icon">
+**Note**: Replay caching is an optimization, not a guarantee. Your app should _not_ depend on this mechanism to function.
+The app issuing `fly-replay` still serves as the ultimate source of truth, and we may decide to consult that app at any moment even if a replay cache has previously been set.
+To ensure reliable operation, the app issuing `fly-replay` should still have multiple instances deployed in multiple regions.
+</div>
+
+### Path-based Replay Caching
+
+Replay caching for paths is configured per-request during a replay. To cache a replay for a path:
+
 - Issue a `fly-replay` header as usual
 - Set `fly-replay-cache: /some/path/*`
-  - This needs to be a path-matching pattern ending with a wildcard `/*`. This is where the cached replay is applied.
+  - This needs to be a path-matching pattern, and implicitly ends with a wildcard `/*`. This is where the cached replay is applied.
   - The cached replay is unique to the request domain. The domain may also be set explicitly: `example.com/some/path/*`
   - The domain part should not include ports; use `example.com`, not `example.com:80`.
   - The pattern must also match the current request.
 - Set `fly-replay-cache-ttl-secs: number_of_seconds`
 
-If the replay target does eventually change, the replay target may proactively invalidate the cache by
-- Issuing a `fly-replay` back to the origin
-- Setting `fly-replay-cache: invalidate`
-
-For apps using the JSON format, specify a `cache` object:
+For apps using the JSON format, specify a `cache` object as part of the replay:
 
 ```json
 {
@@ -153,6 +163,58 @@ For apps using the JSON format, specify a `cache` object:
 }
 ```
 
+### Session-based Replay Caching
+
+If your app's sessions are identified by a cookie or authorization header, and should consistently route to the same target, Fly Proxy can cache that replay.
+
+Unlike path-based caching (which requires your app to return `fly-replay-cache` headers), session-based caching is configured in your `fly.toml`. When your app issues a `fly-replay` response for a request with a matching cookie or header, Fly Proxy will cache that replay decision and automatically apply it to subsequent requests with the same session identifier.
+
+#### Configuration
+
+Configure session-based replay caching in your `fly.toml`. This can be set under `http_service.http_options` or `services.ports.http_options`:
+
+```toml
+[http_service]
+  internal_port = 8080
+  force_https = true
+
+  [[http_service.http_options.replay_cache]]
+    path_prefix = "/"
+    ttl_seconds = 300
+    type = "cookie"
+    name = "session_id"
+
+  [[http_service.http_options.replay_cache]]
+    path_prefix = "/api"
+    ttl_seconds = 600
+    type = "header"
+    name = "Authorization"
+```
+
+In this example:
+- Replays for requests to `/` (and its subpaths) are cached for 5 minutes based on the `session_id` cookie value
+- Replays for requests to `/api` (and its subpaths) are cached for 10 minutes based on the `Authorization` header value
+- When multiple rules match, the longest matching path takes precedence
+
+If your app accepts requests for multiple hostnames, you can narrow the configuration by specifying a hostname in `path_prefix`:
+
+```toml
+  [[http_service.http_options.replay_cache]]
+    path_prefix = "api.example.com/api"
+```
+
+Caches are not shared between hostnames, even when `path_prefix` doesn't specify a hostname. Each hostname maintains its own cache.
+
+For more details on configuration options, see the [fly.toml configuration reference](/docs/reference/configuration/#http_service-http_options-replay_cache).
+
+### Invalidating the Replay Cache
+
+If the replay target does eventually change, the replay target may proactively invalidate the cache by:
+- Issuing a `fly-replay` back to the origin
+- Setting `fly-replay-cache: invalidate`
+
+Or, using the JSON format:
+
 ```json
 {
   "app": "origin-app",
@@ -162,25 +224,27 @@ For apps using the JSON format, specify a `cache` object:
 }
 ```
 
-<div class="note icon">
-**Note**: Replay caching is an optimization, not a guarantee. Your app should _not_ depend on this mechanism to function.
-The app issuing `fly-replay` still serves as the ultimate source of truth, and we may decide to consult that app at any moment even if a replay cache has previously been set.
-To ensure reliable operation, the app issuing `fly-replay` should still have multiple instances deployed in multiple regions.
-</div>
+This works for invalidating both the path-based cache, and the session-based cache.
 
-### Bypassing the replay cache
+### Bypassing Replay Cache
 
 Sometimes, you might want a client to bypass a cached replay without actually invalidating the cache.
 For example, you might have an API endpoint that _mostly_ needs to be replayed to a "leader" instance. But depending on application logic, it could sometimes be handled by any instance.
 
 The recommended approach is to clearly separate endpoints that require replay from those that don't.
-However, when that is not possible, the replaying app can additionally set the header
+However, when that is not possible, the replaying app can be configured to allow bypass.
+
+For path-based replay caching, additionally set the header:
 
 ```
 fly-replay-cache-allow-bypass: yes
 ```
 
-or set the JSON field `"allow_bypass": true`. Then, when your client makes a request, it can set the header:
+or set the JSON field `"allow_bypass": true`.
+
+For session-based replay caching, set [allow_bypass](/docs/reference/configuration/#http_service-http_options-replay_cache-allow_bypass) to `true` in your `fly.toml` configuration for your `replay_cache` rule.
+
+Then, when your client makes a request, it can set the header:
 
 ```
 fly-replay-cache-control: skip
@@ -189,7 +253,7 @@ fly-replay-cache-control: skip
 to skip any cached replay that might be present.
 
 <div class="note icon">
-**Note**: This behavior is opt-in because enabling it by default could make your app vulnerable to malicious clients creating unexpected load on the replaying machine. All it takes is setting a boolean HTTP header.
+**Note**: This behavior is opt-in because enabling it by default could make your app vulnerable to malicious clients creating unexpected load on the replaying machine.
 </div>
 
 ### Was my request served by the cache?

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -410,6 +410,49 @@ In the following example, `h2_backend` is set to `true`, which allows the app to
     h2_backend = true
 ```
 
+### `http_service.http_options.replay_cache`
+
+Configures session-based replay caching. When your app issues a `fly-replay` response, Fly Proxy can cache that replay decision based on cookie or header values, automatically applying it to subsequent requests with the same identifier.
+
+Each `http_options.replay_cache` entry configures a caching rule:
+
+```toml
+[[http_service.http_options.replay_cache]]
+  path_prefix = "/"
+  ttl_seconds = 300
+  type = "cookie"
+  name = "session_id"
+  allow_bypass = false
+```
+
+For documentation on replays, and further explanation on caching, see [Session-based Replay Caching](/docs/networking/dynamic-request-routing/#session-based-replay-caching).
+
+#### `http_service.http_options.replay_cache.path_prefix`
+
+Path pattern where this caching rule applies. 
+
+This can be a path like `/api` (applies to any hostname) or include a hostname like `example.com/api`. When multiple rules match a request, the longest matching path takes precedence. 
+
+If including a hostname, do not include the protocol or the port. If no hostname is provided, the cache rule applies to all hostnames, but each hostname retains a separate cache.
+
+Implicitly ends with `/*`, meaning that `example.com/api`, `example.com/api/`, and `example.com/api/*` are all equivalent.
+
+#### `http_service.http_options.replay_cache.ttl_seconds`
+
+How many seconds to cache the replay decision. Minimum value is 10 seconds.
+
+#### `http_service.http_options.replay_cache.type`
+
+Either `"cookie"` or `"header"`. Specifies whether to key the cache on a cookie or request header.
+
+#### `http_service.http_options.replay_cache.name`
+
+Name of the cookie or header to use as the cache key.
+
+#### `http_service.http_options.replay_cache.allow_bypass`
+
+Optional boolean. When `true`, allows clients to bypass the cache by setting the `fly-replay-cache-control: skip` request header. Default is `false`.
+
 ### `http_service.tls_options`
 
 Configure the TLS versions and ALPN protocols that Fly's edge will use to terminate TLS for your application with:
@@ -601,6 +644,49 @@ In the following example, `h2_backend` is set to `true`, which allows the app to
   [services.ports.http_options]
     h2_backend = true
 ```
+
+### `services.ports.http_options.replay_cache`
+
+Configures session-based replay caching. When your app issues a `fly-replay` response, Fly Proxy can cache that replay decision based on cookie or header values, automatically applying it to subsequent requests with the same identifier.
+
+Each `http_options.replay_cache` entry configures a caching rule:
+
+```toml
+  [[services.ports.http_options.replay_cache]]
+    path_prefix = "/"
+    ttl_seconds = 300
+    type = "cookie"
+    name = "session_id"
+    allow_bypass = false
+```
+
+For documentation on replays, and further explanation on caching, see [Session-based Replay Caching](/docs/networking/dynamic-request-routing/#session-based-replay-caching).
+
+#### `services.ports.http_options.replay_cache.path_prefix`
+
+Path pattern where this caching rule applies. 
+
+This can be a path like `/api` (applies to any hostname) or include a hostname like `example.com/api`. When multiple rules match a request, the longest matching path takes precedence. 
+
+If including a hostname, do not include the protocol or the port. If no hostname is provided, the cache rule applies to all hostnames, but each hostname retains a separate cache.
+
+Implicitly ends with `/*`, meaning that `example.com/api`, `example.com/api/`, and `example.com/api/*` are all equivalent.
+
+#### `services.ports.http_options.replay_cache.ttl_seconds`
+
+How many seconds to cache the replay decision. Minimum value is 10 seconds.
+
+#### `services.ports.http_options.replay_cache.type`
+
+Either `"cookie"` or `"header"`. Specifies whether to key the cache on a cookie or request header.
+
+#### `services.ports.http_options.replay_cache.name`
+
+Name of the cookie or header to use as the cache key.
+
+#### `services.ports.http_options.replay_cache.allow_bypass`
+
+Optional boolean. When `true`, allows clients to bypass the cache by setting the `fly-replay-cache-control: skip` request header. Default is `false`.
 
 #### `services.ports.proxy_proto_options`
 


### PR DESCRIPTION
Updates the sticky session blueprint, dynamic routing documentation, and configuration reference to describe the new "session-based" replay caching.