### PR TITLE
Update free trial messaging

### DIFF
--- a/about/free-trial.html.md
+++ b/about/free-trial.html.md
@@ -10,7 +10,7 @@ date: 2025-10-27
 
 ## Free Trial overview
 
-A free trial on Fly.io includes up to 2 hours of machine runtime or 7 days of access, whichever comes first. That’s just enough to get a real app up and running before you decide if it’s a fit for you.
+A free trial on Fly.io includes 2 hours of machine runtime or 7 days of access, whichever comes first. That’s just enough to get a real app up and running before you decide if it’s a fit for you.
 
 <div class="callout">If you hit any of the limits below before your 7 days are up, **your trial is considered exhausted**, and your apps will stop until you add a payment method.</div>
 


### PR DESCRIPTION
### Summary of changes
- reorganized text and callout warnings to better highlight that Free Trial can end before 7 days + other copy edits
- add new messaging re: Trial Machines defaulting to auto stop after 5 minutes
- changed Title to "Fly.io Free Trial"

### Preview
<img width="1371" height="920" alt="Screenshot 2025-10-27 at 12 10 51 PM" src="https://github.com/user-attachments/assets/f0da87d8-8e70-47fd-bef8-5d2c6a828085" />



