### PR TITLE
Amend multi-container Machines docs

### DIFF
--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -166,7 +166,7 @@ The `config` object can also include other Machine fields like `guest` and `serv
 
 Refer to the [Machines API documentation](https://docs.machines.dev/#tag/machines) for complete configuration options.
 
-### Using flyctl
+### Using `fly machine run`
 
 Create a multi-container Machine by passing a JSON configuration file (e.g., `cli-config.json`) to `fly machine run`:
 
@@ -196,7 +196,7 @@ fly machine run --machine-config cli-config.json \
 Note: When using `--machine-config`, your JSON file must include a `containers` array with at least one container that specifies an `image`.
 </div>
 
-### Using fly launch & fly deploy
+### Using `fly launch` & `fly deploy`
 
 Starting with `flyctl v0.3.147`, you can run multiple containers using `fly deploy`. This example demonstrates using a nginx container as a rate limiter and a custom app container.
 


### PR DESCRIPTION
### Summary of changes

Fixed some inconsistencies with the Machines API spec and updated "Deploying Multi-container Machines" section to clarify workflows

#### API spec corrections
Per [fly.ContainerConfig](https://docs.machines.dev/#model/flycontainerconfig):
- Fixed health check field name: `health_checks` -> `healthchecks` 
- Fixed so health check `grace_period`, `interval`, and `timeout` are integers e.g `"10s"` -> `10`
- Removed unsupported `services` field from container config

#### Other corrections
- Removed top-level `config` wrapper from `cli-config.json` examples
  - `machine-config` doesn't work unless `containers[]` is at the top level i.e `{ "containers": [...] }`
- Removed non-working `fly machine create` command example
  - the command shown in the docs returns `Error: requires at least 1 arg(s), only received 0` because it expects an `image` argument

#### Improvements
- Added "Using the Machines API" section
- Documented correct JSON config structure for API and CLI workflows