### PR TITLE
Update automatic build secrets using ephemeral machine Dockerfile secret casing

### DIFF
--- a/apps/build-secrets.html.md
+++ b/apps/build-secrets.html.md
@@ -96,7 +96,7 @@ RUN --mount=type=secret,id=ALL_SECRETS \
     some_command
 ```
 
-Assuming your builder Dockerfile is named `Dockerfile.builder`, you can launch the emphemeral machine using the following command:
+Assuming your builder Dockerfile is named `Dockerfile.builder`, you can launch the ephemeral machine using the following command:
 
 ```cmd
 flyctl console --dockerfile Dockerfile.builder -C "/srv/deploy.sh" --env=FLY_API_TOKEN=$(fly auth token)


### PR DESCRIPTION
### Summary of changes

Changed the casing of the property read by the `jq` command in the example given on using ephemeral machines to automatically inject build secrets from `Name` to `name`

The current example doesn't work since the output of the `flyctl secrets list --json` command outputs `name` for every environment variable, not `Name`, causing the `jq` command to simply return `null`.

Fixes #2215 