### PR TITLE
Clean up dead link to Shopify YouTube video

### DIFF
--- a/js/shopify.html.markerb
+++ b/js/shopify.html.markerb
@@ -7,9 +7,7 @@ order: 3
 
 Fly.io has built in support for [Shopify Remix applications](https://shopify.dev/docs/apps/build): simply [scaffold](https://shopify.dev/docs/apps/build/scaffold-app), [build](https://shopify.dev/docs/apps/build/build?framework=remix), and [launch](https://fly.io/shopify).
 
-<%= youtube "https://www.youtube.com/watch?v=F4qL3nCFg3E" %>
-
--- [https://x.com/i/status/1892986447788966011](https://x.com/i/status/1892986447788966011)
+Check out a video from Shopify running through the deploy process [here](https://x.com/i/status/1892986447788966011).
 
 To see this in action, [Scaffold an app](https://shopify.dev/docs/apps/build/scaffold-app) and immediately proceed to fly launch:
 


### PR DESCRIPTION
## Description:
- Removed the YouTube embed from Shopify since it seems like that video no longer exists on YouTube.
- Kept the X link and slightly reformatted it to be clearer.

## Notes:
- I managed to download the actual video and started trying to embed it, but it started feeling like it was too much trouble. If we want to go this route, we always can in the future.