### PR TITLE
Add MPG guide on how to create databases via dashboard and flyctl, and users via flyctl

### DIFF
--- a/mpg/configuration.html.md
+++ b/mpg/configuration.html.md
@@ -144,7 +144,8 @@ Your Managed Postgres cluster is created with the default `fly-db` database. You
 
 These databases can be accessed by existing users in your cluster, based on their role.
 
-#### Creating additional Databases
+### Creating additional Databases
+
 To create additional databases via the dashboard:
 1. Navigate to your MPG cluster's "Databases" tab in the dashboard
 2. Enter a name for your new database in the input field under the "Databases" section.


### PR DESCRIPTION
### Summary of changes

Updated the `mpg/configuration.html.md`  file to add a last section called "Databases".
This section provides two uses:
1. Describe steps on how to create additional databases in an MPG cluster
2. Let's user know that yes, it's possible to add new databases aside from the default fly-db database

Updated the same file to add another guide on how to create users via flyctl

### Preview

### Related Fly.io community and GitHub links
User asked how to create a new database for their MPG cluster. ( See row #59 in my [ticket list](https://docs.google.com/spreadsheets/d/1FSOBYSB-ZFoEPoCeSGkYkzSiSnf1dkHtTOLf2DKueX0/edit?gid=869828631#gid=869828631) )

### Notes

