### PR TITLE
Add warning to Pricing page about checking for mpg dbs after deleting an app

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -128,6 +128,10 @@ The price of running Fly.io Managed Postgres depends on your selected Managed Po
 
 Current pricing for Managed Postgres plans and storage is available [here](/docs/mpg#pricing).
 
+<div class="warning icon">
+<b>Important:</b> Managed Postgres lives outside your apps. Deleting an app won’t delete its database. Have a look in your Dashboard when you're cleaning up. A quick check can save you a surprise charge later.
+</div>
+
 ## Persistent Storage Volumes
 
 ### Volumes


### PR DESCRIPTION
### Summary of changes
Some customers are surprised by MPG charges after deleting apps, this is an additional warning to check for DBs after they delete an app.

### Preview
<img width="1337" height="341" alt="Screenshot 2025-12-02 at 10 43 32 AM" src="https://github.com/user-attachments/assets/31969dd8-95e5-4037-871c-fe125cc1e3ab" />



