### PR TITLE
update app handover guide and move app doc with new UI option

### DIFF
--- a/apps/app-handover-guide.html.md
+++ b/apps/app-handover-guide.html.md
@@ -32,15 +32,18 @@ Here’s how that works:
 
 1. **Build as usual in your organization.**
 1. **Have the customer invite one of your devs to their org.** This person needs to be in _both_ orgs to do the move.
-1. **Transfer the app** 
-1. Use `fly apps move <app-name> --org <target-org-name>` 
-1. Heads up: the move causes a couple minutes of downtime. It’s a good idea to schedule this when traffic is low, and inform your users of a maintenance window. 
-1. What moves automatically: 
+1. **Transfer the app:** Use the CLI command `fly apps move <app-name> --org <target-organization-name>`,
+or go to the App Settings page in your Dashboard, click Move app, pick the new organization, and wait for the deployment to finish.
+<figure>
+  <img src="/static/images/move-app-ui-sm.png" alt="App settings page with Move app option" class="w-full max-w-lg mx-auto">
+</figure>
+1. **Be aware:** the move causes a couple minutes of downtime. It’s a good idea to schedule this when traffic is low, and inform your users of a maintenance window. 
+1. **What moves automatically:** 
     - Machines and volumes (data included) 
     - Secrets and environment variables 
     - Certificates and domain names 
     - LiteFS databases (as long as you’re using `$FLY_APP_NAME` for the Consul key) 
-1. What doesn’t move automatically: 
+1. **What doesn’t move automatically:** 
     - **Postgres** **(unmanaged and managed):** Moving Postgres databases across orgs is not supported. You’ll need to spin up a new Fly Postgres app in the target org and restore from a volume snapshot. Or you can use `pgloader` to migrate the data. 
     - **Upstash Redis:** This is tied to an org’s private network. You’ll need to provision a new DB in the new org. 
     - **Tigris buckets:** You’ll have to delete the old Tigris bucket, recreate it in the new org, and copy the data over (try `s3sync`). Don’t forget to reset your app’s secrets. 
@@ -54,6 +57,6 @@ If you know up front that your customer will own the app long-term, starting in 
 
 ### Related reading
 
-[Fly.io billing](/docs/about/billing)
+- [Move an app between orgs](/docs/apps/move-app-org)
 
-[Move an app between orgs](/docs/apps/move-app-org)
+- [Fly.io billing](/docs/about/billing)

--- a/apps/move-app-org.html.markerb
+++ b/apps/move-app-org.html.markerb
@@ -10,9 +10,9 @@ nav: apps
 
 You might want to move an app to a new org to hand off your completed work to a client, to take advantage of a new pricing model, or to move a production app out of your personal organization.
 
-You can move an entire app with its resources to another organization with the `fly apps move` command. You'll need to be a member of both organizations to move an app.
+You can move an entire app with its resources to another organization with the `fly apps move` command in `flyctl`, or using the App Settings page of the Dashboard. You'll need to be a member of both organizations to move an app.
 
-To move an app from one organization to another:
+**Move an app from one organization to another via the CLI:**
 
 ```cmd
 fly apps move <app name> --org <target organization name>
@@ -21,6 +21,14 @@ fly apps move <app name> --org <target organization name>
 <div class="important">
 **Fly Postgres:** You can't use the `fly apps move` command for Fly Postgres apps. To move a Postgres app to another organization, create a new Postgres app under the target organization, and then [restore the data from your current Postgres app volume snapshot](/docs/postgres/managing/backup-and-restore/#restoring-from-a-snapshot).
 </div>
+
+**Move an app from one organization to another via the App Settings page:**
+
+Go to the App Settings page in your Dashboard, click Move app, pick the new organization, and wait for the deployment to finish. Your app will be up and running once the transfer is complete.
+
+<figure>
+  <img src="/static/images/move-app-ui-sm.png" alt="App settings page with Move app option" class="w-full">
+</figure>
 
 ## App downtime
 
@@ -45,4 +53,4 @@ The following extension services need to be reconfigured for the app after the m
 
 ## Read more
 
-[App handover considerations and approaches](/docs/apps/app-handover-guide/)
+[App handover guide: considerations and approaches](/docs/apps/app-handover-guide/)


### PR DESCRIPTION
### Summary of changes

Updates to [App Handover Guide](https://fly.io/docs/apps/app-handover-guide/) and [Moving an App between orgs](https://fly.io/docs/apps/move-app-org/) pages

- add explanation of new UI option for moving an app between orgs
- add screenshot of the UI
- some additional copy and formatting edits to both docs

### Related Fly.io community and GitHub links

New UI option announced here: https://community.fly.io/t/transfer-app-to-another-organization/26496



