### PR TITLE
Add missing MPG regions to documentation

### DIFF
--- a/mpg/index.html.md
+++ b/mpg/index.html.md
@@ -52,11 +52,13 @@ The current regions available for deploying Fly.io Managed Postgres are:
 - `gru` - São Paulo, Brazil
 - `iad` - Ashburn, Virginia, USA
 - `lax` - Los Angeles, California, USA
+- `lhr` - London, United Kingdom
 - `nrt` - Tokyo, Japan
 - `ord` - Chicago, Illinois, USA
 - `sin` - Singapore
 - `sjc` - San Jose, California, USA
 - `syd` - Sydney, Australia
+- `yyz` - Toronto, Canada
 
 We'll be rolling out more regions as soon as we can. Choose a region close to your application for optimal performance.
 

--- a/mpg/overview.html.md
+++ b/mpg/overview.html.md
@@ -106,12 +106,18 @@ This command is useful when you want to connect to your database from your local
 
 The current regions available for deploying Fly.io Managed Postgres are:
 
+- `ams` - Amsterdam, Netherlands
 - `fra` - Frankfurt, Germany
 - `gru` - São Paulo, Brazil
-- `iad` - Ashburn, USA
-- `lax` - Los Angeles, USA
-- `ord` - Chicago, USA
+- `iad` - Ashburn, Virginia, USA
+- `lax` - Los Angeles, California, USA
+- `lhr` - London, United Kingdom
+- `nrt` - Tokyo, Japan
+- `ord` - Chicago, Illinois, USA
+- `sin` - Singapore
+- `sjc` - San Jose, California, USA
 - `syd` - Sydney, Australia
+- `yyz` - Toronto, Canada
 
 We'll be rolling out more regions as soon as we can. Choose a region close to your application for optimal performance.
 


### PR DESCRIPTION
## Summary
- Added `lhr` (London, United Kingdom) region to MPG docs
- Added `yyz` (Toronto, Canada) region to MPG docs
- Standardized region formatting in `overview.html.md` to include full location details (state names for US regions)
- Updated both `index.html.md` and `overview.html.md` to maintain consistency

## Test plan
- [x] Verify all region codes match the available regions in the MPG dashboard
- [x] Ensure formatting is consistent across both documentation files

🤖 Generated with [Claude Code](https://claude.com/claude-code)