### PR TITLE
Fix typo and remove duplicate Open Source entry in About section overview

### DIFF
--- a/about/index.html.markerb
+++ b/about/index.html.markerb
@@ -24,7 +24,7 @@ More details about using and working with the Fly.io platform.
 
 * **[Healthcare](/docs/about/healthcare/):** Controls relevant to running healthcare apps on Fly.io.
 
-* **[Engineering Jobs and Hiring](/docs/about/extensions/):** Learm more about our hiring process.
+* **[Engineering Jobs and Hiring](/docs/about/extensions/):** Learn more about our hiring process.
 
 * **[Open Source](/docs/about/open-source/):** How we help those OSS projects that help us.
 


### PR DESCRIPTION
### Summary of changes
Removed duplicate Open Source section from the About page.

### Preview

### Related Fly.io community and GitHub links
Location: https://fly.io/docs/about/
Source: https://github.com/superfly/docs/blob/main/about/index.html.markerb

### Notes
Resolves issue #2322
