### PR TITLE
Revised edits for the new egress-ip (app scoped) feature

### DIFF
--- a/networking/egress-ips.html.md
+++ b/networking/egress-ips.html.md
@@ -62,9 +62,14 @@ Each app-scoped IPv4 static egress address costs $3.60/mo, billed hourly. IPv6 a
 
 - Each static egress IP can support up to 64 Machines. If you need more than 64 Machines in one region, you will need to allocate multiple static egress IPs.
 - When using app-scoped static egress IPs, a Machine can make up to 1024 concurrent connections to _each_ destination IP address. There is no limit on the _total_ number of concurrent connections.
-- We do not expect this to be a concern for most apps. However, feel free to talk to us if this limits your use case!
+
+<div class="note icon">
+We do not expect this to be a concern for most apps. However, feel free to talk to us if this limits your use case!
+</div>
 - When you have multiple static egress IPs assigned in one region, there is currently no way to specify exactly which IP each machine will use.
-- There may be a short delay between allocating an egress IP (or creating a Machine) and the egress IP becoming usable. This is inherent to how the system applies IPs to new Machines. This delay may be more noticeable with more Machines or during bluegreen deployments. Allocating multiple pairs of static egress IPs alleviates the issue.
+- There may be delays when egress IPs are applied to Machines:
+- Right after allocating a new egress IP, it will be applied to all existing Machines in the region after a short delay. Allocating multiple pairs of static egress IPs will not help in this case.
+- When creating a new Machine in an app that already has an egress IP assigned, there may be a delay before the Machine can use the egress IP. This delay may be more noticeable with more Machines or during bluegreen deployments. Allocating multiple pairs of static egress IPs can help alleviate this issue.
 - `flyctl` surfaces warnings when these limits are approached during Machine creation, deployments, and IP management.
 
 ### Interaction with Machine-Scoped Egress IPs
@@ -72,10 +77,6 @@ Each app-scoped IPv4 static egress address costs $3.60/mo, billed hourly. IPv6 a
 App-scoped and machine-scoped egress IPs are not intended to be used together.
 
 If a Machine has a machine-scoped egress IP, it takes precedence over any app-scoped egress IP in the same region. This behavior may change in the future.
-
-<div class="warning icon">
-When migrating from machine-scoped to app-scoped egress IPs, release machine-scoped IPs first to make sure that Machines use the app-scoped IPs.
-</div>
 
 ---
 


### PR DESCRIPTION
### Summary of changes

1. Fixed typo
- "availble" → "available" in Overview section

2. Added beta status
- Section title updated to include "(Beta)" 

Why- The live doc treated app-scoped egress IPs as GA, but they're in beta. This should help set the proper expectations about stability and potential behavior changes that customers might experience.

3. Clarified release behavior
- Added explicit statement that app-scoped egress IPs are only released when you run `fly ips release-egress` and persist across Machine destruction.

Why- The live doc implied persistence but didn't state release behavior, which can cause billing confusion and leaked IPs.

4. Updated billing section
- Added beta pricing information- free during beta, expected to bill at $3.60/mo after beta.

Why: The live doc showed final pricing, but the feature is in beta and currently free. This prevents billing any surprises.

5. Standardized and improved Caveats section
- Connection limit standardized to 1024 concurrent connections (was 1000). This was written here as well originally- https://community.fly.io/t/beta-feature-try-out-app-scoped-egress-ips/26536.
- Changed "external IP address" to "destination IP address" for accuracy
- Fixed indentation of connection limit note
- Improved delay explanation, so now there is context about why delays occur
- Added a note about flyctl warnings when limits are approached, so users are aware

6. Added new section: "Interaction with Machine-Scoped Egress IPs"
- Explains that app-scoped and machine-scoped IPs shouldn't be used together
- States that machine-scoped IPs take precedence over app-scoped IPs
- Includes migration guidance with a warning callout

Why: During migration, machines can silently use machine-scoped IPs instead of app-scoped ones, causing unexpected routing. Want to make sure users are aware of this.