### PR TITLE
remove new label for custom deploys guide

### DIFF
--- a/blueprints/index.html.md
+++ b/blueprints/index.html.md
@@ -24,7 +24,7 @@ Guides for the structure your app on Fly.io. Layouts, tradeoffs, moving parts.
 Stuff you set up once and adjust when you ship code. Includes previews, base images, staging, and Docker wrangling.
 
 - [Working with Docker on Fly.io](/docs/blueprints/working-with-docker/) **NEW!**
-- [Custom Deploy Workflows](/docs/blueprints/custom-deploy-workflows/) **NEW!**
+- [Custom Deploy Workflows](/docs/blueprints/custom-deploy-workflows/)
 - [Seamless Deployments on Fly.io](/docs/blueprints/seamless-deployments/)
 - [Rollback Guide](/docs/blueprints/rollback-guide/)
 - [Git Branch Preview Environments on Github](/docs/blueprints/review-apps-guide/)


### PR DESCRIPTION
### Summary of changes
- remove "new" label on index page for Custom Deploy guide (it's over 30 days since initial publishing)

