### PR TITLE
Add 7 illustration links jan 2026

### DIFF
--- a/about/cost-management.html.md
+++ b/about/cost-management.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-10-23
 ---
 
+<figure>
+<img src="/static/images/cost-management.png" alt="Illustration by Annie Ruygt of a Frankie the hot air balloon tallying up a total on a paper-tape calculator" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Predicting your Fly.io bill and avoiding surprises
 
 We’ve done our best to make billing on Fly.io something you can reason about. Machines don’t appear out of nowhere. If something is running, it’s because you launched it, or you configured something that did. In general, when we talk about **autoscaling**, we mean starting or stopping machines you’ve already defined. We don’t quietly spin up extras in the background that turn into mystery charges on your bill. The idea is that your bill should always be traceable to something you can see, name, and plausibly explain when someone asks. If it’s not, we’re happy to help you sort it out.

--- a/about/free-trial.html.md
+++ b/about/free-trial.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-10-27
 ---
 
+<figure>
+<img src="/static/images/free-trial.png" alt="Illustration by Annie Ruygt of a Frankie the hot air balloon showing a Free Trial banner to his developer friend who carries an app" class="w-full max-w-lg mx-auto">
+</figure>
+
 **Fly.io runs your apps close to your users. This page explains how our free trial works and what resources you can use before you need to add a payment method.**
 
 ## Free Trial overview

--- a/apps/app-handover-guide.html.md
+++ b/apps/app-handover-guide.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-07-03
 ---
 
+<figure>
+<img src="/static/images/app-handover-guide.png" alt="Illustration by Annie Ruygt of a house with a Welcome sign and hot air balloons in the backgroud" class="w-full max-w-lg mx-auto">
+</figure>
+
 <div class="callout">
 **If you're building an app for someone else and they’re going to run it themselves on Fly.io, you’ve got two good options. You can either start development inside their Fly.io organization, or build it in yours and move it over later. Here’s how both paths work, and what can get messy during the move.**
 </div>

--- a/blueprints/custom-deploy-workflows.html.md
+++ b/blueprints/custom-deploy-workflows.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-12-05
 ---
 
+<figure>
+<img src="/static/images/custom-deploy-workflows.png" alt="Illustration by Annie Ruygt of a Frankie the hot air balloon writing on a notepad about different modes of transport including a jet a car and a truck" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Overview
 
 <div class="callout">

--- a/blueprints/working-with-docker.html.md
+++ b/blueprints/working-with-docker.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-12-12
 ---
 
+<figure>
+<img src="/static/images/Docker-With-Fly.png" alt="Illustration by Annie Ruygt of a Frankie the hot air balloon giving flowers to the Docker whale" class="w-full max-w-lg mx-auto">
+</figure>
+
 <div class="callout">
 **Fly.io runs apps close to your users by turning Docker images into VMs running in our global network. This is a practical guide for using Docker effectively on Fly.io.**
 </div>

--- a/networking/custom-private-networks.html.markerb
+++ b/networking/custom-private-networks.html.markerb
@@ -4,6 +4,10 @@ layout: docs
 nav: firecracker
 ---
 
+<figure>
+<img src="/static/images/custom-private-networks.png" alt="Illustration by Annie Ruygt of two apps sitting on clouds and talking to each other on the telephone" class="w-full max-w-lg mx-auto">
+</figure>
+
 You can isolate users, data, or code using custom private networks. 
 
 Every organization gets a default [private network](https://fly.io/docs/networking/private-networking/) (6PN) and all the apps in that network can communicate privately using `.internal` domains. When you create a new app, you can choose to place it on a distinct custom 6PN within your organization. Apps on separate 6PNs can never communicate unless explicitly configured to do so.

--- a/networking/egress-ips.html.md
+++ b/networking/egress-ips.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2025-10-02
 ---
 
+<figure>
+<img src="/static/images/Egress-IP.png" alt="Illustration by Annie Ruygt of two happy Machines sitting on clouds" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Overview
 
 - By default, outbound (egress) IPs from Fly Machines are **unstable** and may change.


### PR DESCRIPTION
### Summary of changes
New illustrations for 7 pages:
https://fly.io/docs/blueprints/working-with-docker/
https://fly.io/docs/blueprints/custom-deploy-workflows/
https://fly.io/docs/networking/egress-ips/
https://fly.io/docs/networking/custom-private-networks/
https://fly.io/docs/about/free-trial/
https://fly.io/docs/about/cost-management/
https://fly.io/docs/apps/app-handover-guide/

