### PR TITLE
Fix mismatch between builder and runtime images

### DIFF
--- a/rust/the-basics/cargo-chef.html.md
+++ b/rust/the-basics/cargo-chef.html.md
@@ -26,7 +26,7 @@ COPY . .
 RUN cargo build --release --bin [rust-app]
 
 # We do not need the Rust toolchain to run the binary!
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/[rust-app] /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/[rust-app]"] 


### PR DESCRIPTION
### Summary of changes

The `cargo-chef:latest-rust-1` has been updated since this doc was originally written and now compiles the Rust program with a later version of libc, than is used in the runtime images. Without a fix like this, programs will fail to build with an error like:

```/usr/local/bin/myapp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/myapp)```


