### PR TITLE
Fix secrets import command for Windows compatibility

### DIFF
--- a/js/the-basics/secrets.html.md
+++ b/js/the-basics/secrets.html.md
@@ -20,7 +20,7 @@ fly secrets set SECRET_KEY=YOURSECRETKEYGOESHERE
 Or you can import your dotenv file wholesale using [fly secrets import](https://fly.io/docs/flyctl/secrets-import/):
 
 ```
-fly secrets import < .dotenv
+cat .dotenv | fly secrets import
 ```
 
 Both commands will restart your application if it has previously been deployed.  Pass the `--stage` option if you would rather deploy these changes later.


### PR DESCRIPTION
## Summary
- Replace `fly secrets import < .dotenv` with `cat .dotenv | fly secrets import` in the JS secrets doc
- The `<` stdin redirection operator fails on Windows PowerShell ("reserved for future use")
- This matches the pattern already used in the Heroku migration guide

Closes #2350