### PR TITLE
Remove GPU mentions due to impending deprecation

### DIFF
--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -46,14 +46,6 @@ For example, a Machine described in your dashboard as having 1GB of rootfs stopp
 
 ---
 
-## GPU billing
-
-GPUs are billed per second that the attached Fly Machine is running (the time they spend in the `started` state), based on the per hour cost of the GPU card. Learn more about [pricing for GPUs](/docs/about/pricing/#gpus-and-fly-machines).
-
-You're also billed for the Fly Machine separately from the GPU.
-
----
-
 ## Volume billing
 
 Volume billing is pro-rated to the hour and we subtract the free allowances first for the  Launch, Scale, and Enterprise plans (all of which are now discontinued for new customers). For details, see [Volume pricing](/docs/about/pricing/#persistent-storage-volumes).

--- a/about/free-trial.html.md
+++ b/about/free-trial.html.md
@@ -30,7 +30,7 @@ These are **not included** in the free trial:
 
 - Dedicated IPv4 addresses
 - Access to performance-optimized vCPUs
-- GPU machines
+- GPU machines (To be deprecated as of 08/01/26)
 
 <div class="callout">You can add a credit card from the dashboard at any time during the trial. This lifts the resource limits and keeps your apps running without interruption. **Note: adding a card ends the free trial** and your usage starts counting toward your bill from that point on.</div>
 

--- a/about/support.html.md
+++ b/about/support.html.md
@@ -93,7 +93,8 @@ Here are some things to include in your ticket:
         <h3 class="font-bold mb-4">Supported Products</h3>
         <ul class="space-y-2">
           <li>**Networking**</li>
-          <li>**Machines** (including GPUs)</li>
+          <li>**Machines**</li>
+          <li>**GPU Machines**-GPU support to end 08/01/26</li>
           <li>**Managed Postgres** (MPG)</li>
           <li>**Apps**</li>
           <li>**Launch/Deploy** (UI & CLI)</li>

--- a/apps/overview.html.markerb
+++ b/apps/overview.html.markerb
@@ -19,7 +19,7 @@ From a developer point of view, a Fly App might be:
 * a fullstack application (or just part of one)
 * a database
 * a few Machines running tasks, or a bunch of Machines, all with different configs, doing things you want them to do
-* anything you can think of doing with fast-launching Machines, including [GPU Machines](/docs/gpus/) for AI/ML workloads
+* anything you can think of doing with fast-launching Machines
 
 All the apps in your organization can communicate over a [private network](/docs/networking/private-networking/), so it’s also possible to have multiple apps working together as one system.
 

--- a/blueprints/autostart-internal-apps.html.md
+++ b/blueprints/autostart-internal-apps.html.md
@@ -115,9 +115,3 @@ Run `fly deploy` for the configuration changes to take effect.
 
 Other apps in your organization can now reach your private app using the [Flycast](/docs/networking/flycast/) IP address or the `<appname>.flycast` domain.
 
-## Related reading
-
-We've talked about Flycast in some past blog posts:
-
-- [Deploy Your Own (Not) Midjourney Bot on Fly GPUs](https://fly.io/blog/not-midjourney-bot/)
-- [Scaling Large Language Models to zero with Ollama](https://fly.io/blog/scaling-llm-ollama/)

--- a/blueprints/going-to-production-with-healthcare-apps.html.md
+++ b/blueprints/going-to-production-with-healthcare-apps.html.md
@@ -74,16 +74,16 @@ If the default region is not where you want to host your application, run `fly p
 
 ```bash
 fly platform regions
-NAME                        	CODE	GATEWAY	GPUS	CAPACITY	LAUNCH PLAN+
+NAME                        	CODE	GATEWAY	CAPACITY	LAUNCH PLAN+
 
 North America
-Ashburn, Virginia (US)      	iad 	✓      	✓   	164
-Chicago, Illinois (US)      	ord 	✓      	      385
-Dallas, Texas (US)          	dfw 	✓      	      426
-Los Angeles, California (US)	lax 	✓      	      635
-San Jose, California (US)   	sjc 	✓      	✓     2399
-Secaucus, NJ (US)           	ewr                     233
-Toronto, Canada             	yyz 	✓      	      70
+Ashburn, Virginia (US)      	iad 	✓      	164
+Chicago, Illinois (US)      	ord 	✓      	385
+Dallas, Texas (US)          	dfw 	✓      	426
+Los Angeles, California (US)	lax 	✓      	635
+San Jose, California (US)   	sjc 	✓      	2399
+Secaucus, NJ (US)           	ewr            233
+Toronto, Canada             	yyz 	✓      	 70
 # ... Lots more regions...
 ```
 

--- a/deep-dive/launch-deep-dive.html.markerb
+++ b/deep-dive/launch-deep-dive.html.markerb
@@ -63,4 +63,3 @@ Optional, but if you haven't yet dived in, details are provided for each runtime
 
 --- 
 
-**Next:** Add [OpenAI Whisper](../whisper/) speech recognition as a bonus.

--- a/deep-dive/whisper.html.markerb
+++ b/deep-dive/whisper.html.markerb
@@ -2,6 +2,7 @@
 title: Whisper
 layout: docs
 nav: demo
+published: false
 order: 8
 ---
 

--- a/getting-started/essentials.html.md
+++ b/getting-started/essentials.html.md
@@ -51,8 +51,6 @@ Learn more about [Fly Apps](/docs/apps/overview/).
 
 **[Fly Apps](/docs/apps/):** The way Machines are grouped for admin and management on the Fly.io platform.
 
-**[Fly GPUs](/docs/gpus/):** Machines, but with GPUs. They boot up with GPU drivers installed and you can run `nvidia-smi` right away.
-
 **[Fly Launch](/docs/launch/):** Our orchestrator that includes some good stuff for app hosting, like the `fly launch` command to get started, `fly.toml` for configuration, the `fly deploy` command to deploy all your app's Machines into new versions/releases, and the `fly scale` command to scale Machines.
 
 **[Fly Machines](/docs/machines/):** [Firecracker microVMs](https://firecracker-microvm.github.io/) that launch quickly in any [region supported by Fly.io](/docs/reference/regions/). A VM, or virtual machine, functions like a physical computer, but is software-based. Multiple VMs can run, completely isolated, on one physical host. If you've deployed an app on Fly.io, then it's running on Fly Machines. There’s a fast [REST API](/docs/machines/api/) to manage Machines, but you can also use flyctl&mdash;the Fly CLI&mdash;to manage everything from the command line. And then there’s Fly Launch, which combines flyctl commands with a shared config to manage your app’s Machines as a group.

--- a/getting-started/index.html.md
+++ b/getting-started/index.html.md
@@ -15,7 +15,7 @@ Get up and running on Fly.io:
 
 - **[Launch hellofly demo app](/docs/getting-started/launch-demo):** Walk through installing the flyctl command-line tool and creating an account, then launch a simple "hellofly" demo app.
 
-- **[Deep dive demo](/docs/deep-dive/):** get a fully-functioning app running in the first few minutes, explore how the pieces fit together, and even integrate AI functionality that makes use of GPUs
+- **[Deep dive demo](/docs/deep-dive/):** get a fully-functioning app running in the first few minutes and explore how the pieces fit together.
 
 - **[Choose your language or framework](/docs/getting-started/get-started-by-framework/):** Get started on Fly.io with the tech _you_ love.
 

--- a/getting-started/launch.html.markerb
+++ b/getting-started/launch.html.markerb
@@ -38,7 +38,6 @@ Check out some of the ways you can increase availability, capacity, and performa
 * [Autoscale Machines based on load or custom metrics](/docs/reference/autoscaling/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/)
 * [Scale Machine count](/docs/apps/scale-count/)
-* Try out [Fly GPUs](/docs/gpus/)
 
 
 If you have questions, need help, or want to talk about what you're building, visit our [community forum](https://community.fly.io).

--- a/index.html.md
+++ b/index.html.md
@@ -33,7 +33,6 @@ brew install flyctl
     <li><a href="/docs/machines/">Fly Machines</a></li>
     <li><a href="/docs/volumes/">Fly Volumes</a></li>
     <li><a href="/docs/security/">Security</a></li>
-    <li><a href="/docs/gpus/">Fly GPUs</a></li>
     <li><a href="/docs/networking/">Networking</a></li>
     <li><a href="/docs/mpg/">Managed Postgres</a></li>
     <li><a href="/docs/kubernetes/">Fly Kubernetes</a></li>

--- a/kubernetes/index.html.markerb
+++ b/kubernetes/index.html.markerb
@@ -21,6 +21,4 @@ Fly Kubernetes (FKS) is a fully managed Kubernetes service built on the Fly.io p
 
 - **[Configure FKS Services](/docs/kubernetes/services):** Configure ClusterIP and LoadBalancer services.
 
-- **[Use GPUs with FKS](/docs/kubernetes/using-gpus/):** Use Fly GPU Machines in your FKS cluster.
-
 - **[Use volumes with FKS](/docs/kubernetes/using-volumes/):** Use Fly Volumes for PersistentVolumes in FKS.

--- a/languages-and-frameworks/dockerfile.html.markerb
+++ b/languages-and-frameworks/dockerfile.html.markerb
@@ -139,7 +139,6 @@ Check out some of the ways you can increase availability, capacity, and performa
 * [Autoscale Machines based on load or custom metrics](/docs/reference/autoscaling/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine count](/docs/apps/scale-count/)
-* Try out [Fly GPUs](/docs/gpus/)
 
 
 If you have questions, need help, or want to talk about what you're building, visit our [community forum](https://community.fly.io).

--- a/launch/create.html.markerb
+++ b/launch/create.html.markerb
@@ -102,4 +102,3 @@ Check out some of the ways you can increase availability, capacity, and performa
 * [Autoscale Machines based on load or custom metrics](/docs/reference/autoscaling/)
 * [Scale Machine CPU and RAM](/docs/apps/scale-machine/) 
 * [Scale Machine count](/docs/apps/scale-count/)
-* Try out [Fly GPUs](/docs/gpus/)

--- a/python/do-more/add-ollama.html.markerb
+++ b/python/do-more/add-ollama.html.markerb
@@ -1,6 +1,7 @@
 ---
 title: "Add Ollama"
 layout: framework_docs
+published: false
 objective: How to setup ollama and interact with its API.
 order: 1
 ---

--- a/reference/configuration.html.markerb
+++ b/reference/configuration.html.markerb
@@ -938,8 +938,6 @@ All keys are optional and `size` has lower precedence than all other keys.
   memory = "1gb"
   cpus = 2
   cpu_kind = "shared"
-  gpus = 1
-  gpu_kind = "a100-pcie-40gb"
   kernel_args = "no-hlt=true"
   host_dedication_id = "customer-id"
   persist_rootfs = "never"
@@ -963,18 +961,6 @@ The number of vCPUs to request. Valid values are `1`, `2`, `4`, `8`, or `16`, bu
 ### `cpu_kind`
 
 The kind of CPU to request. Valid values are `shared` and `performance`.
-
-### `gpus`
-
-The number of GPUs to request. Valid values are `1`, `2`, `4`, `8`, but depends on `gpu_kind`. 
-
-Setting this value requires also setting `gpu_kind`.
-
-### `gpu_kind`
-
-The kind of GPU to request. Valid values are `a10`, `l40s`, `a100-pcie-40gb` and `a100-sxm4-80gb`.
-
-Setting this value assumes `gpus = 1` if not present.
 
 ### `kernel_args`
 

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -86,7 +86,7 @@ A machine can use suspend if it has:
 - **≤ 2 GB** memory (For larger memory sizes, suspend is discouraged due to increased suspend times)
 - **No** [**swap**](https://fly.io/docs/reference/configuration/#swap_size_mb-option) **configured**
 - **No** [**schedule**](https://fly.io/docs/machines/flyctl/fly-machine-run/#start-a-machine-on-a-schedule) **configured** 
-- **No GPU configured**
+- **No GPU configured** (GPUs will be deprecated as of 08/01/26)
 - Been updated since **June 20, 2024 20:00 UTC**
 
 If you have an older machine, or you’re not sure when it was last updated, you can bring it up to date with:


### PR DESCRIPTION
### Summary of changes

- Remove mentions of GPU machines in several docs pages, due to impending GPU deprecation (08/01/26)
- In some cases, we retain the mention and add the deprecation date information


