### PR TITLE
docs: document Tigris public bucket access with dedicated content domains

### DIFF
--- a/deep-dive/tigris.html.markerb
+++ b/deep-dive/tigris.html.markerb
@@ -10,6 +10,6 @@ order: 6
 
 [Tigris](https://fly.io/docs/tigris/) is a globally distributed object storage service. It essentially requires no configuration, and seamlessly handles multi-regions. If you upload an audio file to a host in Virginia, you can access it from Amsterdam. Even better: subsequent accesses from regions other than the primary region are served locally. 
 
-Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`.
+Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. Existing accounts can also use `bucket-name.fly.storage.tigris.dev` for public access.
 
 And if you happen to have an existing S3 object store, check out [shadow buckets](/docs/tigris/#migrating-to-tigris-with-shadow-buckets), which enable you to incrementally migrate your data.

--- a/deep-dive/tigris.html.markerb
+++ b/deep-dive/tigris.html.markerb
@@ -10,6 +10,6 @@ order: 6
 
 [Tigris](https://fly.io/docs/tigris/) is a globally distributed object storage service. It essentially requires no configuration, and seamlessly handles multi-regions. If you upload an audio file to a host in Virginia, you can access it from Amsterdam. Even better: subsequent accesses from regions other than the primary region are served locally. 
 
-Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. Existing accounts can also use `bucket-name.fly.storage.tigris.dev` for public access.
+Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`.
 
 And if you happen to have an existing S3 object store, check out [shadow buckets](/docs/tigris/#migrating-to-tigris-with-shadow-buckets), which enable you to incrementally migrate your data.

--- a/deep-dive/tigris.html.markerb
+++ b/deep-dive/tigris.html.markerb
@@ -10,6 +10,6 @@ order: 6
 
 [Tigris](https://fly.io/docs/tigris/) is a globally distributed object storage service. It essentially requires no configuration, and seamlessly handles multi-regions. If you upload an audio file to a host in Virginia, you can access it from Amsterdam. Even better: subsequent accesses from regions other than the primary region are served locally. 
 
-Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.fly.storage.tigris.dev/key-name`.
+Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`.
 
 And if you happen to have an existing S3 object store, check out [shadow buckets](/docs/tigris/#migrating-to-tigris-with-shadow-buckets), which enable you to incrementally migrate your data.

--- a/deep-dive/tigris.html.markerb
+++ b/deep-dive/tigris.html.markerb
@@ -10,6 +10,6 @@ order: 6
 
 [Tigris](https://fly.io/docs/tigris/) is a globally distributed object storage service. It essentially requires no configuration, and seamlessly handles multi-regions. If you upload an audio file to a host in Virginia, you can access it from Amsterdam. Even better: subsequent accesses from regions other than the primary region are served locally. 
 
-Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want.
+Unlike relational databases, there may be reasons why you want to make your object store available via the internet. In this demo, the object store starts out private, but you can make it [public](/docs/tigris/#public-buckets) if you want. Public buckets serve objects without authentication at `https://bucket-name.fly.storage.tigris.dev/key-name`.
 
 And if you happen to have an existing S3 object store, check out [shadow buckets](/docs/tigris/#migrating-to-tigris-with-shadow-buckets), which enable you to incrementally migrate your data.

--- a/laravel/the-basics/laravel-tigris-file-storage.html.markerb
+++ b/laravel/the-basics/laravel-tigris-file-storage.html.markerb
@@ -106,4 +106,4 @@ Now that we have our Tigris Bucket, let's connect it with our Laravel app.
 
 If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed.
 
-See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains and custom domain setup.
+For production use, we recommend setting up a [custom domain](https://www.tigrisdata.com/docs/buckets/custom-domain/) so your public URLs stay stable. See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains.

--- a/laravel/the-basics/laravel-tigris-file-storage.html.markerb
+++ b/laravel/the-basics/laravel-tigris-file-storage.html.markerb
@@ -100,4 +100,10 @@ Now that we have our Tigris Bucket, let's connect it with our Laravel app.
         Storage::disk('s3')->put('example.txt', 'Contents');
     }
     ```
-    Calling the function above should upload a new file in your bucket. 
+    Calling the function above should upload a new file in your bucket.
+
+## Serving public files
+
+If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.fly.storage.tigris.dev/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed.
+
+See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains and custom domain setup.

--- a/laravel/the-basics/laravel-tigris-file-storage.html.markerb
+++ b/laravel/the-basics/laravel-tigris-file-storage.html.markerb
@@ -104,6 +104,6 @@ Now that we have our Tigris Bucket, let's connect it with our Laravel app.
 
 ## Serving public files
 
-If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed.
+If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed. Existing Fly.io accounts can also use `bucket-name.fly.storage.tigris.dev` for public access, but this is not available for new accounts.
 
 For production use, we recommend setting up a [custom domain](https://www.tigrisdata.com/docs/buckets/custom-domain/) so your public URLs stay stable. See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains.

--- a/laravel/the-basics/laravel-tigris-file-storage.html.markerb
+++ b/laravel/the-basics/laravel-tigris-file-storage.html.markerb
@@ -104,6 +104,6 @@ Now that we have our Tigris Bucket, let's connect it with our Laravel app.
 
 ## Serving public files
 
-If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.fly.storage.tigris.dev/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed.
+If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed.
 
 See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains and custom domain setup.

--- a/laravel/the-basics/laravel-tigris-file-storage.html.markerb
+++ b/laravel/the-basics/laravel-tigris-file-storage.html.markerb
@@ -104,6 +104,6 @@ Now that we have our Tigris Bucket, let's connect it with our Laravel app.
 
 ## Serving public files
 
-If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed. Existing Fly.io accounts can also use `bucket-name.fly.storage.tigris.dev` for public access, but this is not available for new accounts.
+If your bucket is [public](/docs/tigris/#public-buckets), uploaded objects are accessible without authentication at `https://bucket-name.t3.tigrisfiles.io/key-name`. You can use this URL directly in your Blade templates for images, CSS, JavaScript, and other assets. No credentials or pre-signed URLs are needed.
 
 For production use, we recommend setting up a [custom domain](https://www.tigrisdata.com/docs/buckets/custom-domain/) so your public URLs stay stable. See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains.

--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -34,6 +34,12 @@ Objects in a public bucket can be accessed by anyone without authentication. Pub
 * `https://mybucket.t3.tigrisbucket.io/key-name`
 * `https://mybucket.t3.tigrisblob.io/key-name`
 
-No credentials or pre-signed URLs are needed. For production use, we recommend setting up a [custom domain](https://www.tigrisdata.com/docs/buckets/custom-domain/). See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for full details.
+No credentials or pre-signed URLs are needed. For production use, we recommend setting up a custom domain so your public URLs stay stable:
+
+```cmd
+flyctl storage update mybucket --custom-domain assets.example.com
+```
+
+Then create a CNAME record for `assets.example.com` pointing to `mybucket.t3.tigrisbucket.io`. See the [Tigris Custom Domain docs](https://www.tigrisdata.com/docs/buckets/custom-domain/) for full setup instructions and the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains.
 
 Currently, buckets must be public or private. ACL settings will be ignored by the Tigris API.

--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -34,9 +34,7 @@ Objects in a public bucket can be accessed by anyone without authentication. Pub
 * `https://mybucket.t3.tigrisbucket.io/key-name`
 * `https://mybucket.t3.tigrisblob.io/key-name`
 
-No credentials or pre-signed URLs are needed. Existing Fly.io accounts can also access public content at `mybucket.fly.storage.tigris.dev`, but this is not available for new accounts.
-
-For production use, we recommend setting up a custom domain so your public URLs stay stable:
+No credentials or pre-signed URLs are needed. For production use, we recommend setting up a custom domain so your public URLs stay stable:
 
 ```cmd
 flyctl storage update mybucket --custom-domain assets.example.com

--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -28,4 +28,6 @@ You can also make a public bucket private.
 fly storage update mybucket --private
 ```
 
+Objects in a public bucket can be accessed by anyone without authentication at `https://mybucket.fly.storage.tigris.dev/key-name`. No credentials or pre-signed URLs are needed. Public buckets are also served at dedicated Tigris domains. See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available domains and custom domain setup.
+
 Currently, buckets must be public or private. ACL settings will be ignored by the Tigris API.

--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -28,6 +28,12 @@ You can also make a public bucket private.
 fly storage update mybucket --private
 ```
 
-Objects in a public bucket can be accessed by anyone without authentication at `https://mybucket.fly.storage.tigris.dev/key-name`. No credentials or pre-signed URLs are needed. Public buckets are also served at dedicated Tigris domains. See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available domains and custom domain setup.
+Objects in a public bucket can be accessed by anyone without authentication. Public content is served from dedicated domains using the bucket name as a subdomain:
+
+* `https://mybucket.t3.tigrisfiles.io/key-name` (primary)
+* `https://mybucket.t3.tigrisbucket.io/key-name`
+* `https://mybucket.t3.tigrisblob.io/key-name`
+
+No credentials or pre-signed URLs are needed. For production use, we recommend setting up a [custom domain](https://www.tigrisdata.com/docs/buckets/custom-domain/). See the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for full details.
 
 Currently, buckets must be public or private. ACL settings will be ignored by the Tigris API.

--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -34,7 +34,9 @@ Objects in a public bucket can be accessed by anyone without authentication. Pub
 * `https://mybucket.t3.tigrisbucket.io/key-name`
 * `https://mybucket.t3.tigrisblob.io/key-name`
 
-No credentials or pre-signed URLs are needed. For production use, we recommend setting up a custom domain so your public URLs stay stable:
+No credentials or pre-signed URLs are needed. Existing Fly.io accounts can also access public content at `mybucket.fly.storage.tigris.dev`, but this is not available for new accounts.
+
+For production use, we recommend setting up a custom domain so your public URLs stay stable:
 
 ```cmd
 flyctl storage update mybucket --custom-domain assets.example.com


### PR DESCRIPTION
### Summary of changes

AI tools are incorrectly telling users that Tigris public buckets require authentication. This happens because the docs explain how to *create* public buckets (`fly storage create --public`) but never explain how to *access* them without authentication.

This PR documents that public bucket objects are accessible without credentials via dedicated public content domains (`t3.tigrisfiles.io`, `t3.tigrisbucket.io`, `t3.tigrisblob.io`), and adds custom domain setup instructions using `flyctl`.

Changes across three files:

- **`partials/tigris/_tigris-storage-create.erb`** — the shared partial included in the main Tigris page. Lists all three public content domains, adds the `flyctl storage update --custom-domain` command with CNAME pointing to `BUCKET.t3.tigrisbucket.io`.
- **`deep-dive/tigris.html.markerb`** — added a sentence clarifying that public buckets serve objects without authentication at `t3.tigrisfiles.io`.
- **`laravel/the-basics/laravel-tigris-file-storage.html.markerb`** — added a "Serving public files" section with the public content URL and custom domain recommendation.

### Preview

No visual changes to site layout — text additions only.

### Related Fly.io community and GitHub links

User report: an AI coding assistant incorrectly told a user that anonymous access is not supported for Tigris public buckets. Companion PR to Tigris docs: https://github.com/tigrisdata/tigris-os-docs/pull/406

### Notes

The Vale linter CI check will report 3 pre-existing errors in `tigris/index.html.markerb` (the erb partial path `tigris-storage-create` triggers the `Vale.Terms` casing rule) and 1 pre-existing suggestion in the Laravel file. None are introduced by this PR.