### PR TITLE
Add hero images to 6 docs pages

### DIFF
--- a/blueprints/deploy-openclaw.html.md
+++ b/blueprints/deploy-openclaw.html.md
@@ -5,6 +5,10 @@ nav: guides
 date: 2026-03-25
 ---
 
+<figure>
+  <img src="/static/images/open-claw.png" alt="Illustration by Annie Ruygt of some little characters walking along" class="w-full max-w-lg mx-auto">
+</figure>
+
 To deploy [OpenClaw](https://github.com/openclaw/openclaw) to Fly.io, download the deploy package and run the script. It handles everything — app creation, volumes, secrets, and deployment.
 
 <a href="https://github.com/superfly/Openclaw-Fly-Deploy/archive/refs/heads/main.zip" class="inline-flex items-center px-6 py-3 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-lg transition-colors no-underline" download>Download Deploy Package</a>

--- a/gpus/getting-started-gpus.html.md
+++ b/gpus/getting-started-gpus.html.md
@@ -4,6 +4,10 @@ layout: docs
 nav: firecracker
 ---
 
+<figure>
+  <img src="/static/images/gpus.png" alt="Illustration by Annie Ruygt of a developer sitting on a boombox" class="w-full max-w-lg mx-auto">
+</figure>
+
 <div class="warning icon">
 **GPUs are deprecated and will be unavailable after August 1.**
 </div>

--- a/machines/guides-examples/managing-machines-with-the-api.html.md
+++ b/machines/guides-examples/managing-machines-with-the-api.html.md
@@ -6,6 +6,10 @@ author: kcmartin
 date: 2026-04-06
 ---
 
+<figure>
+  <img src="/static/images/managing-machines-api.png" alt="Illustration by Annie Ruygt of a big book about the Machines API" class="w-full max-w-lg mx-auto">
+</figure>
+
 <div class="callout">
 **The [Machines resource API](/docs/machines/api/machines-resource/) documents every endpoint. This guide covers the patterns you'll actually need when building on it: cloning machines, keeping them in sync with `flyctl`, configuring services, managing auto-stop/start behavior, and updating config.**
 </div>

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -5,6 +5,10 @@ nav: machines
 redirect_from: /docs/reference/machines/
 ---
 
+<figure>
+  <img src="/static/images/fly-machines-intro.png" alt="Illustration by Annie Ruygt of some birds launching a Fly rocket" class="w-full max-w-lg mx-auto">
+</figure>
+
 Fly Machines are fast-launching VMs with a simple [REST API](/docs/machines/api/). They're [the compute](https://fly.io/blog/fly-machines/) behind the Fly.io platform. If you've launched an app on Fly.io, you're already using Fly Machines.
 
 We use the [Machines API](/docs/machines/api/) to build the orchestration for [Fly Launch](/docs/apps). You can use it however you'd like.

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -8,6 +8,10 @@ redirect_from:
   - /docs/metrics-and-logs/metrics
 ---
 
+<figure>
+  <img src="/static/images/monitor-machines.png" alt="Illustration by Annie Ruygt of some Machines strutting along" class="w-full max-w-lg mx-auto">
+</figure>
+
 The Fly.io platform includes a fully-managed metrics solution to help you easily monitor your Fly apps.
 It includes the following components:
 

--- a/mpg/guides-examples/phoenix-guide.html.md
+++ b/mpg/guides-examples/phoenix-guide.html.md
@@ -6,6 +6,10 @@ date: 2025-09-16
 author: Kaelyn
 ---
 
+<figure>
+  <img src="/static/images/phoenix.png" alt="Illustration by Annie Ruygt of a Phoenix bird resting with Frankie the balloon looking on" class="w-full max-w-lg mx-auto">
+</figure>
+
 This guide explains the key **Managed Postgres (MPG)-specific adjustments** you need when connecting a Phoenix app. We'll focus on:
 
 1. Connection Pooling Settings


### PR DESCRIPTION
## Summary
- Add hero illustration images to 6 docs pages, linking to images from superfly/landing PR #1096
- Pages updated: GPU getting started, Phoenix MPG guide, Metrics, Machines overview, Machines API guide, Deploy OpenClaw
- Each image includes alt text crediting illustrator Annie Ruygt

## Depends on
- superfly/landing#1096 (adds the image files)

## Test plan
- [x] Verify images render correctly after landing PR #1096 is merged
- [x] Check alt text is accurate and accessible