### PR TITLE
Minor updates to Guides navigation for Open Claw guide

### DIFF
--- a/blueprints/index.html.md
+++ b/blueprints/index.html.md
@@ -11,13 +11,13 @@ A growing library of guides for running, designing, and deploying all kinds of a
 
 Guides for the structure your app on Fly.io. Layouts, tradeoffs, moving parts.
 
+- [Deploy OpenClaw on Fly.io](/docs/blueprints/deploy-openclaw/) NEW!!
+- [Deploying Remote MCP Servers](/docs/blueprints/remote-mcp-servers/)
 - [Resilient apps use multiple Machines](/docs/blueprints/resilient-apps-multiple-machines/)
 - [Getting Started with N-Tier Architecture](/docs/blueprints/n-tier-architecture/)
 - [Shared Nothing Architecture](/docs/blueprints/shared-nothing/)
 - [Session Affinity (a.k.a. Sticky Sessions)](/docs/blueprints/sticky-sessions/)
 - [Multi-region databases and fly-replay](/docs/blueprints/multi-region-fly-replay/)
-- [Deploying Remote MCP Servers](/docs/blueprints/remote-mcp-servers/)
-- [Deploy OpenClaw on Fly.io](/docs/blueprints/deploy-openclaw/)
 
 
 ## Deployment & Developer Workflow

--- a/partials/_guides_nav.html.erb
+++ b/partials/_guides_nav.html.erb
@@ -14,13 +14,13 @@
       title: "Architecture Patterns",
       open: true,
       links: [
+        { text: "Deploy OpenClaw on Fly.io", path: "/docs/blueprints/deploy-openclaw/" },
+        { text: "Deploying Remote MCP Servers", path: "/docs/blueprints/remote-mcp-servers/" },
         { text: "Resilient apps use multiple Machines", path: "/docs/blueprints/resilient-apps-multiple-machines/" },
         { text: "Getting Started with N-Tier Architecture", path: "/docs/blueprints/n-tier-architecture/" },
         { text: "Shared Nothing Architecture", path: "/docs/blueprints/shared-nothing/" },
         { text: "Session Affinity (a.k.a. Sticky Sessions)", path: "/docs/blueprints/sticky-sessions/" },
-        { text: "Multi-region databases and fly-replay", path: "/docs/blueprints/multi-region-fly-replay/" },
-        { text: "Deploying Remote MCP Servers", path: "/docs/blueprints/remote-mcp-servers/" },
-        { text: "Deploy OpenClaw on Fly.io", path: "/docs/blueprints/deploy-openclaw/" }
+        { text: "Multi-region databases and fly-replay", path: "/docs/blueprints/multi-region-fly-replay/" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Move OpenClaw guide to first position in Architecture Patterns section
- Move MCP Servers guide to second position
- Add "NEW!!" annotation to the OpenClaw entry on the index page
- Updates both the blueprints index page and the `_guides_nav.html.erb` sidebar partial

