### PR TITLE
add docker compose section to multicontainer guide

### DIFF
--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -229,6 +229,10 @@ fly deploy
 
 The `web` container handles inbound traffic on port 80, and the `redis` container runs alongside it as a sidecar. Your application code can reach Redis at `localhost:6379` because both containers share the same network namespace inside the Machine.
 
+<div class="warning icon">
+**Warning:** Fly ignores `volumes:` declarations in your Compose file and prints `Warning: Could not read volume file...` at deploy time. The deploy still succeeds, but any data your containers write is stored on an ephemeral overlay that's wiped on restart or redeploy. For persistent storage, attach a [Fly Volume](/docs/volumes/) and mount it via `[mounts]` in `fly.toml`.
+</div>
+
 #### Limitations
 
 - **Exactly one buildable service.** `fly deploy` requires exactly one service in the Compose file to specify `build`. All other services must use pre-built images.

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -146,7 +146,7 @@ If you already have a Docker Compose setup, you can deploy it to Fly Machines wi
 
 #### Requirements
 
-You need flyctl v0.3.149 or later:
+You need flyctl v0.3.152 or later:
 
 ```bash
 fly version

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -235,10 +235,6 @@ The `web` container handles inbound traffic on port 80, and the `redis` containe
 - **Secrets are global.** Secrets set with `fly secrets` are available to every container in the Machine. You can't scope a secret to a single service.
 - **Environment variable conflicts.** Fly injects runtime environment variables (like `FLY_APP_NAME`, `PRIMARY_REGION`, etc.) into all containers. These can overwrite values you define in your Compose file's `environment` block.
 
-#### Planned improvements
-
-The team is working on support for mapping Compose volumes to Fly volumes, replacing database services in Compose files with Fly-managed equivalents (like Fly Postgres), and auto-detecting Compose files during `fly launch`.
-
 ### Using the Machines API
 
 You can create multi-container Machines by sending a POST request to the Machines API. For example, using `curl`:

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -140,6 +140,103 @@ Containers in a Machine share the same kernel and VM, but are isolated at the pr
 
 There are several ways to deploy multi-container machines on Fly.io. Choose the method that best fits your workflow:
 
+### Using Docker Compose
+
+If you already have a Docker Compose setup, you can deploy it to Fly Machines without rewriting your configuration. Fly builds and runs Compose services as containers within a single Machine.
+
+#### Requirements
+
+You need flyctl v0.3.149 or later:
+
+```bash
+fly version
+```
+
+If you're behind, update with `fly version update`.
+
+#### Configuration
+
+Add a `[build.compose]` section to your `fly.toml`:
+
+```toml
+[build.compose]
+```
+
+Fly auto-detects Compose files using the standard lookup order: `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`. If your file has a different name, specify it:
+
+```toml
+[build.compose]
+file = "docker-compose.prod.yml"
+```
+
+#### Routing traffic
+
+Set `internal_port` in your `fly.toml` `[[services]]` or `[http_service]` block to match the port exposed by the container that should receive traffic. Only one container handles inbound requests from the Fly proxy.
+
+```toml
+[http_service]
+  internal_port = 8080
+  force_https = true
+```
+
+#### Example
+
+A rate-limiting setup with nginx in front of a backend app.
+
+**compose.yml:**
+
+```yaml
+services:
+  nginx:
+    image: nginx:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - app
+
+  app:
+    build: .
+    expose:
+      - "3000"
+```
+
+**fly.toml:**
+
+```toml
+app = "my-rate-limited-app"
+primary_region = "ord"
+
+[build.compose]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+```
+
+Deploy with:
+
+```bash
+fly deploy
+```
+
+#### Limitations
+
+- **One buildable service.** Only one service in the Compose file can specify `build`. All other services must use pre-built images.
+- **Secrets are global.** Secrets set with `fly secrets` are available to every container in the Machine. You can't scope a secret to a single service.
+- **Environment variable conflicts.** Fly injects runtime environment variables (like `FLY_APP_NAME`, `PRIMARY_REGION`, etc.) into all containers. These can overwrite values you define in your Compose file's `environment` block.
+
+#### Planned improvements
+
+The team is working on support for mapping Compose volumes to Fly volumes, replacing database services in Compose files with Fly-managed equivalents (like Fly Postgres), and auto-detecting Compose files during `fly launch`.
+
 ### Using the Machines API
 
 You can create multi-container Machines by sending a POST request to the Machines API. For example, using `curl`:

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -181,14 +181,20 @@ Set `internal_port` in your `fly.toml` `[[services]]` or `[http_service]` block 
 
 #### Example
 
-A web service with a Redis sidecar, both running in the same Machine.
+A web service with a Redis sidecar, both running in the same Machine. `fly deploy` builds the `web` service from a `Dockerfile` in your project directory; `redis` runs as a pre-built sidecar.
+
+**Dockerfile:**
+
+```dockerfile
+FROM nginxdemos/hello:plain-text
+```
 
 **compose.yml:**
 
 ```yaml
 services:
   web:
-    image: nginxdemos/hello:plain-text
+    build: .
     ports:
       - "8080:80"
 
@@ -225,7 +231,7 @@ The `web` container handles inbound traffic on port 8080, and the `redis` contai
 
 #### Limitations
 
-- **One buildable service.** Only one service in the Compose file can specify `build`. All other services must use pre-built images.
+- **Exactly one buildable service.** `fly deploy` requires exactly one service in the Compose file to specify `build`. All other services must use pre-built images.
 - **Secrets are global.** Secrets set with `fly secrets` are available to every container in the Machine. You can't scope a secret to a single service.
 - **Environment variable conflicts.** Fly injects runtime environment variables (like `FLY_APP_NAME`, `PRIMARY_REGION`, etc.) into all containers. These can overwrite values you define in your Compose file's `environment` block.
 

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -181,31 +181,25 @@ Set `internal_port` in your `fly.toml` `[[services]]` or `[http_service]` block 
 
 #### Example
 
-A rate-limiting setup with nginx in front of a backend app.
+A web service with a Redis sidecar, both running in the same Machine.
 
 **compose.yml:**
 
 ```yaml
 services:
-  nginx:
-    image: nginx:latest
+  web:
+    image: nginxdemos/hello:plain-text
     ports:
-      - "8080:8080"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    depends_on:
-      - app
+      - "8080:80"
 
-  app:
-    build: .
-    expose:
-      - "3000"
+  redis:
+    image: redis:latest
 ```
 
 **fly.toml:**
 
 ```toml
-app = "my-rate-limited-app"
+app = "my-compose-app"
 primary_region = "ord"
 
 [build.compose]
@@ -226,6 +220,8 @@ Deploy with:
 ```bash
 fly deploy
 ```
+
+The `web` container handles inbound traffic on port 8080, and the `redis` container runs alongside it as a sidecar. Your application code can reach Redis at `localhost:6379` because both containers share the same network namespace inside the Machine.
 
 #### Limitations
 

--- a/machines/guides-examples/multi-container-machines.html.markerb
+++ b/machines/guides-examples/multi-container-machines.html.markerb
@@ -196,7 +196,7 @@ services:
   web:
     build: .
     ports:
-      - "8080:80"
+      - "80:80"
 
   redis:
     image: redis:latest
@@ -211,7 +211,7 @@ primary_region = "ord"
 [build.compose]
 
 [http_service]
-  internal_port = 8080
+  internal_port = 80
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
@@ -227,7 +227,7 @@ Deploy with:
 fly deploy
 ```
 
-The `web` container handles inbound traffic on port 8080, and the `redis` container runs alongside it as a sidecar. Your application code can reach Redis at `localhost:6379` because both containers share the same network namespace inside the Machine.
+The `web` container handles inbound traffic on port 80, and the `redis` container runs alongside it as a sidecar. Your application code can reach Redis at `localhost:6379` because both containers share the same network namespace inside the Machine.
 
 #### Limitations
 


### PR DESCRIPTION
### Summary of changes
Add a self-contained section to add to the multi-container Machines guide. Covers config, routing, a practical nginx + Redis example, three clear limitations.

### Preview
<img width="1205" height="781" alt="Screenshot 2026-04-10 at 4 16 53 PM" src="https://github.com/user-attachments/assets/2b49df4a-9ba9-4c45-92d2-3e65d09fbd94" />


