### PR TITLE
Add object level ACL details to Tigris docs

### DIFF
--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -42,4 +42,6 @@ flyctl storage update mybucket --custom-domain assets.example.com
 
 Then create a CNAME record for `assets.example.com` pointing to `mybucket.t3.tigrisbucket.io`. See the [Tigris Custom Domain docs](https://www.tigrisdata.com/docs/buckets/custom-domain/) for full setup instructions and the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains.
 
-Currently, buckets must be public or private. ACL settings will be ignored by the Tigris API.
+### Object Level Access Control 
+By default, all objects inherit the access control settings of the bucket they are in. If a bucket is private, all objects in it are also private and vice versa. However, you can make individual objects in a bucket public-read (or private) by setting an object level ACL on them. 
+This lets you serve a public object from an otherwise private bucket, or a private object from an otherwise public bucket. For details on how to set this up see the [Tigris Object ACL docs](https://www.tigrisdata.com/docs/objects/acl/) 

--- a/partials/tigris/_tigris-storage-create.erb
+++ b/partials/tigris/_tigris-storage-create.erb
@@ -43,5 +43,6 @@ flyctl storage update mybucket --custom-domain assets.example.com
 Then create a CNAME record for `assets.example.com` pointing to `mybucket.t3.tigrisbucket.io`. See the [Tigris Custom Domain docs](https://www.tigrisdata.com/docs/buckets/custom-domain/) for full setup instructions and the [Tigris Public Bucket docs](https://www.tigrisdata.com/docs/buckets/public-bucket/) for details on all available public domains.
 
 ### Object Level Access Control 
-By default, all objects inherit the access control settings of the bucket they are in. If a bucket is private, all objects in it are also private and vice versa. However, you can make individual objects in a bucket public-read (or private) by setting an object level ACL on them. 
-This lets you serve a public object from an otherwise private bucket, or a private object from an otherwise public bucket. For details on how to set this up see the [Tigris Object ACL docs](https://www.tigrisdata.com/docs/objects/acl/) 
+By default, all objects inherit the access control settings of the bucket they are in. If a bucket is private, all objects in it are also private and vice versa. 
+However, you can make individual objects in a bucket public-read (or private) by setting an object level ACL on them. This lets you serve a public object from an otherwise private bucket, or a private object from an otherwise public bucket. 
+For details on how to set this up see the [Tigris Object ACL docs](https://www.tigrisdata.com/docs/objects/acl/) 


### PR DESCRIPTION
Added information about object level access control and its implications for bucket settings. Requested by Tigris as docs were outdated

### Summary of changes

### Preview

### Related Fly.io community and GitHub links

### Notes

