### PR TITLE
Rewrite Flycast blueprint to drop GPU/Ollama example

### DIFF
--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -6,10 +6,8 @@ nav: guides
 author: xe
 categories:
   - networking
-date: 2024-06-17
+date: 2026-04-29
 ---
-
-<center><iframe width="600" height="315" src="https://www.youtube-nocookie.com/embed/PR0rzkwKwFA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></center><br />
 
 ## Overview
 
@@ -17,7 +15,7 @@ A lot of the time your applications are made to be public and shared with the wo
 
 Sometimes you need a middle ground between fully public apps and fully private apps. [Flycast](/docs/networking/flycast/) addresses are private but global IPv6 addresses inside your private network that go through the Fly Proxy, so you get all of the load management and Machine waking powers that you get for free with public apps.
 
-This blueprint covers what Flycast is, when and why you’d want to use it, and shows you how to create an instance of Ollama that you can connect to over Flycast.
+This blueprint covers what Flycast is, when and why you’d want to use it, and shows you how to deploy a small private HTTP service that you can connect to over Flycast.
 
 ## What is Flycast?
 
@@ -37,17 +35,13 @@ When you want to connect to an app via Flycast, you connect to `appname.flycast`
 
 Just a heads-up. In general, it’s a bad idea to assume that network access barriers like Flycast or NAT are security layers. At best, this is an obfuscation layer that makes it more difficult for attackers to get into private applications. Flycast is not a replacement for authentication in your private applications. With Flycast, you don’t know _who_ a request is coming from, but you do know that it’s coming from _something_ or _someone_ in your private network.
 
-One of the biggest platform features that uses Flycast out of the box is Fly Postgres. Even though Flycast addresses are local to your private network, Fly Postgres still configures usernames and passwords for your database.
+One of the biggest platform features that uses Flycast out of the box is [Managed Postgres](/docs/mpg/). Even though Flycast addresses are local to your private network, Managed Postgres still configures usernames and passwords for your database.
 
 ## Goal
 
-We'll show Flycast off by setting up an instance of [Ollama](https://ollama.com+external).
+We'll show Flycast off by deploying a small HTTP service that's only reachable from inside your organization's private network. The classic example is an internal admin panel: a service you and your apps need to reach, but that should never be exposed to the public internet. Flycast also lets the platform turn the service off when nobody's using it, so you're not paying to keep an idle admin panel running.
 
-Ollama is a program that wraps large language models and gives you an interface like Docker so that you can run open-weights large language models privately on your own device. Large language models are computationally expensive to run, so being able to offload them to a GPU-powered Fly Machine means you can hack all you want without burning up your precious battery life.
-
-Ollama doesn’t ship with authentication by default. When you create an instance of Ollama, anyone can access it without entering in a username, password, or API key. This is fine for running your models on your own computer; but it means that if you expose it to the internet, anyone can use it and run models whenever they want. This could rack up your bill infinitely.
-
-This is where Flycast comes in. Flycast lets you run a copy of Ollama on your private network so that you and your apps can access it, but nobody else. Flycast also lets you have the platform turn off your Ollama server when you’re not using it, which will save you money. This fits into that middle ground case that Flycast covers perfectly.
+For this walkthrough we'll use the public [`nginxdemos/hello`](https://hub.docker.com/r/nginxdemos/hello+external) image as a stand-in for any private HTTP service. It's a tiny container that responds to HTTP requests with the server's hostname and address, which makes it easy to confirm that traffic is reaching the right Machine over Flycast.
 
 ## Prerequisites
 
@@ -56,41 +50,29 @@ To get started, you need to do the following:
 - [sign up or sign in](/docs/getting-started/sign-up-sign-in/) to Fly.io
 - [install flyctl](/docs/flyctl/install/) (the Fly CLI)
 
-If you want to interact with your Flycast apps&mdash;like an Ollama instance&mdash;from your computer, you’ll need to [jack into your private network with WireGuard](/docs/blueprints/connect-private-network-wireguard/).
+If you want to interact with your Flycast apps from your computer, you’ll need to [jack into your private network with WireGuard](/docs/blueprints/connect-private-network-wireguard/).
 
 ## Steps
 
-Create a new folder on your computer called `ollama`. This is where we’ll put the Ollama configuration. Open a terminal in that folder and run the fly launch command:
+Create a new folder on your computer called `flycast-demo` and open a terminal in it. We don't need any source code for this walkthrough — we'll launch the app directly from a public Docker image with the `--flycast` flag, which tells Fly Launch to allocate a private IPv6 address instead of public ones:
 
 ```
-fly launch --from https://github.com/fly-apps/ollama-demo --no-deploy
+fly launch --image nginxdemos/hello --flycast
 ```
 
-This command creates a new fly app from the [`ollama-demo` template](https://github.com/fly-apps/ollama-demo+external) and tells the flyctl command to not deploy it after you create the app. If we don’t do this, then the platform will create public IPv4 and IPv6 addresses, which will make this a public app. The name you choose when you create your app will be used to connect to your app over Flycast.
+The name you choose for your app will be the hostname you use to reach it over Flycast (`<appname>.flycast`). When `fly launch` asks if you want to tweak the settings, you can accept the defaults.
 
-Next, allocate a Flycast address for your app with the `fly ips allocate-v6` command:
-
-```
-$ fly ips allocate-v6 --private
-```
-
-Now you can deploy the app with the `fly deploy` command:
-
-```
-$ fly deploy
-```
-
-After that finishes, you can see the list of IP addresses associated to an app with `fly ips list`:
+After deploy finishes, you can see the list of IP addresses associated to an app with `fly ips list`:
 
 ```
 $ fly ips list
 VERSION	IP                	TYPE   	REGION	CREATED AT
 v6     	fdaa:3:9018:0:1::7	private	global	23h12m ago
-
-Learn more about [Fly.io public, private, shared and dedicated IP addresses](/docs/reference/services/#ip-addresses).
 ```
 
-This app only has one IP address: a private Flycast IPv6 address. If had public IP addresses, it'd look like this:
+Learn more about [Fly.io public, private, shared and dedicated IP addresses](/docs/reference/services/#ip-addresses).
+
+This app only has one IP address: a private Flycast IPv6 address. If it had public IP addresses, it'd look like this:
 
 ```
 $ fly ips list -a recipeficator
@@ -112,51 +94,49 @@ The Ubuntu image we chose is very minimal, so we need to install a few tools suc
 # apt update && apt install -y curl iputils-ping dnsutils
 ```
 
-My app is named`xe-ollama`, so let’s look up its `.flycast` address with `nslookup xe-ollama.flycast`:
+Say my app is named `flycast-demo`. Let’s look up its `.flycast` address with `nslookup flycast-demo.flycast`:
 
 ```
-# nslookup xe-ollama.flycast
+# nslookup flycast-demo.flycast
 Server:		fdaa::3
 Address:	fdaa::3#53
 
-Name:	xe-ollama.flycast
+Name:	flycast-demo.flycast
 Address: fdaa:3:9018:0:1::7
 ```
 
 It matches that IP address from earlier. Now let’s see what happens when we ping it:
 
 ```
-# ping xe-ollama.flycast -c2
-PING xe-ollama.flycast (fdaa:3:9018:0:1::7) 56 data bytes
+# ping flycast-demo.flycast -c2
+PING flycast-demo.flycast (fdaa:3:9018:0:1::7) 56 data bytes
 64 bytes from fdaa:3:9018:0:1::7: icmp_seq=1 ttl=63 time=0.138 ms
 64 bytes from fdaa:3:9018:0:1::7: icmp_seq=2 ttl=63 time=0.223 ms
 
---- xe-ollama.flycast ping statistics ---
+--- flycast-demo.flycast ping statistics ---
 2 packets transmitted, 2 received, 0% packet loss, time 1009ms
 rtt min/avg/max/mdev = 0.138/0.180/0.223/0.042 ms
 ```
 
-Perfect, now let’s make a request to the Ollama app with curl:
+Now let’s make a request to the app with curl:
 
 ```
-# curl http://xe-ollama.flycast
+# curl http://flycast-demo.flycast
 ```
 
-It took a moment for Ollama to spin up, and now we get a happy “Ollama is running” message. Wait a few moments so your Ollama app goes to sleep and run the `time` command to see how long the first request takes:
+You should get back an HTML page with the server's hostname and address. Wait a few moments so your app goes to sleep, then run the `time` command to see how long the first request takes:
 
 ```
-# time curl http://xe-ollama.flycast
-Ollama is running
-real	0m9.144s
+# time curl -o /dev/null -s http://flycast-demo.flycast
+real	0m2.411s
 user	0m0.003s
 sys		0m0.003s
 ```
 
-It took a few seconds for the platform to wake up Ollama and make sure it was ready for your requests. The next request is a lot faster:
+It took a couple of seconds for the platform to wake the Machine up and make sure it was ready for your request. The next request is a lot faster:
 
 ```
-# time curl http://xe-ollama.flycast
-Ollama is running
+# time curl -o /dev/null -s http://flycast-demo.flycast
 real	0m0.043s
 user	0m0.003s
 sys		0m0.003s
@@ -164,36 +144,10 @@ sys		0m0.003s
 
 And if you wait a few moments, it’ll spin back down.
 
-### Running Llama 3
-
-Now that we’ve set up Ollama and demonstrated the platform turning it off and on for you, let’s run Llama 3. Exit out of that shell Machine with control-D so we can make a new one with the Ollama client installed.
-
-Create an Ollama shell using `fly machine run`:
-
-```
-$ fly machine run --shell ollama/ollama
-```
-
-Once that starts up, point the Ollama client to your Flycast app by setting the `OLLAMA_HOST` environment variable:
-
-```
-# export OLLAMA_HOST=http://xe-ollama.flycast
-```
-
-Then you can ask Llama 3 anything you want:
-
-```javascript
-# ollama run llama3 "Why is the sky blue?"
-```
-
-It took a moment for Ollama to get ready and download the image, then it downloaded it and answered your question. Once it’s been idle for a moment, the platform will turn Ollama back off.
-
-And there we go! We’ve covered what Flycast is, why you’d want to use it, and set up an instance of Ollama to show it off.
+And there we go! We’ve covered what Flycast is, why you’d want to use it, and walked through deploying a private HTTP service to show it off. The same pattern works for any internal app: admin panels, internal APIs, dashboards, or anything else you'd rather keep off the public internet.
 
 ## Related reading
 
-We've talked about Flycast in some past blog posts and blueprints:
-
 - [Autostart and autostop private apps](/docs/blueprints/autostart-internal-apps/)
-- [Deploy Your Own (Not) Midjourney Bot on Fly GPUs](https://fly.io/blog/not-midjourney-bot/)
-- [Scaling Large Language Models to zero with Ollama](https://fly.io/blog/scaling-llm-ollama/)
+- [Flycast — private Fly.io services](/docs/networking/flycast/)
+- [Private networking](/docs/networking/private-networking/)

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -70,7 +70,7 @@ VERSION	IP                	TYPE   	REGION	CREATED AT
 v6     	fdaa:3:9018:0:1::7	private	global	23h12m ago
 ```
 
-Learn more about [Fly.io public, private, shared and dedicated IP addresses](/docs/reference/services/#ip-addresses).
+Learn more about [Fly.io public, private, shared and dedicated IP addresses](/docs/networking/services/#anycast-ip-addresses).
 
 This app only has one IP address: a private Flycast IPv6 address. If it had public IP addresses, it'd look like this:
 

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -54,7 +54,7 @@ If you want to interact with your Flycast apps from your computer, you’ll need
 
 ## Steps
 
-Create a new folder on your computer called `flycast-demo` and open a terminal in it. We don't need any source code for this walkthrough — we'll launch the app directly from a public Docker image with the `--flycast` flag, which tells Fly Launch to allocate a private IPv6 address instead of public ones. We'll also pass `--no-deploy` so we can adjust one setting before the first deploy:
+Create a new folder on your computer called `flycast-demo` and open a terminal in it. We don't need any source code for this walkthrough. We'll launch the app directly from a public Docker image with the `--flycast` flag, which tells Fly Launch to allocate a private IPv6 address instead of public ones. We'll also pass `--no-deploy` so we can adjust one setting before the first deploy:
 
 ```
 fly launch --image nginxdemos/hello --flycast --internal-port 80 --no-deploy
@@ -167,5 +167,5 @@ And there we go! We’ve covered what Flycast is, why you’d want to use it, an
 ## Related reading
 
 - [Autostart and autostop private apps](/docs/blueprints/autostart-internal-apps/)
-- [Flycast — private Fly.io services](/docs/networking/flycast/)
+- [Flycast: private Fly.io services](/docs/networking/flycast/)
 - [Private networking](/docs/networking/private-networking/)

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -99,10 +99,10 @@ v6     	2a09:8280:1::37:7312:0	public (dedicated)	global	May 30 2024 13:51
 v4     	66.241.124.113        	public (shared)   	      	Jan 1 0001 00:00
 ```
 
-Now that we've proven it's private, let’s open an interactive shell Machine to play around with Flycast. Create the shell Machine with `fly machine run`:
+Now that we've proven it's private, let’s open an interactive shell Machine to play around with Flycast. Create the shell Machine with `fly machine run`, giving it enough memory to install a few packages with `apt`:
 
 ```
-$ fly machine run --shell ubuntu
+$ fly machine run --shell --vm-memory 1024 ubuntu
 root@e784127b51e083:/#
 ```
 

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -3,10 +3,10 @@ title: Run private apps with Flycast
 layout: docs
 sitemap: true
 nav: guides
-author: xe
+author: kcmartin
 categories:
   - networking
-date: 2026-04-29
+date: 2026-05-19
 ---
 
 ## Overview

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -62,7 +62,7 @@ fly launch --image nginxdemos/hello --flycast --internal-port 80 --no-deploy
 
 The name you choose for your app will be the hostname you use to reach it over Flycast (`<appname>.flycast`). When `fly launch` asks if you want to tweak the settings, you can accept the defaults.
 
-The `--internal-port 80` flag tells Fly Launch that our app listens on port 80 (the default for the `nginxdemos/hello` image). Fly Launch defaults to port 8080, so without this flag the Fly Proxy wouldn't be able to reach the app.
+The `--internal-port 80` flag tells Fly Launch that our app listens on port 80 (the default for the `nginxdemos/hello` image). Fly Launch defaults to port 8080, so without this flag the Fly Proxy wouldn't be able to reach the app. You could also set `internal_port = 80` in `fly.toml` directly in the next step; the flag is just a shortcut so you don't have to edit the file twice.
 
 Open the generated `fly.toml` in your editor, find the `[http_service]` block, and change `force_https` to `false`:
 

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -146,18 +146,18 @@ You should get back an HTML page with the server's hostname and address. Wait a 
 
 ```
 # time curl -o /dev/null -s http://flycast-demo.flycast
-real	0m2.411s
-user	0m0.003s
-sys		0m0.003s
+real	0m1.539s
+user	0m0.004s
+sys		0m0.012s
 ```
 
 It took a couple of seconds for the platform to wake the Machine up and make sure it was ready for your request. The next request is a lot faster:
 
 ```
 # time curl -o /dev/null -s http://flycast-demo.flycast
-real	0m0.043s
+real	0m0.018s
 user	0m0.003s
-sys		0m0.003s
+sys		0m0.008s
 ```
 
 And if you wait a few moments, it’ll spin back down.

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -57,10 +57,12 @@ If you want to interact with your Flycast apps from your computer, you’ll need
 Create a new folder on your computer called `flycast-demo` and open a terminal in it. We don't need any source code for this walkthrough — we'll launch the app directly from a public Docker image with the `--flycast` flag, which tells Fly Launch to allocate a private IPv6 address instead of public ones:
 
 ```
-fly launch --image nginxdemos/hello --flycast
+fly launch --image nginxdemos/hello --flycast --internal-port 80
 ```
 
 The name you choose for your app will be the hostname you use to reach it over Flycast (`<appname>.flycast`). When `fly launch` asks if you want to tweak the settings, you can accept the defaults.
+
+The `--internal-port 80` flag tells Fly Launch that our app listens on port 80 (the default for the `nginxdemos/hello` image). Fly Launch defaults to port 8080, so without this flag the Fly Proxy wouldn't be able to reach the app.
 
 After deploy finishes, you can see the list of IP addresses associated to an app with `fly ips list`:
 

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -54,15 +54,31 @@ If you want to interact with your Flycast apps from your computer, you’ll need
 
 ## Steps
 
-Create a new folder on your computer called `flycast-demo` and open a terminal in it. We don't need any source code for this walkthrough — we'll launch the app directly from a public Docker image with the `--flycast` flag, which tells Fly Launch to allocate a private IPv6 address instead of public ones:
+Create a new folder on your computer called `flycast-demo` and open a terminal in it. We don't need any source code for this walkthrough — we'll launch the app directly from a public Docker image with the `--flycast` flag, which tells Fly Launch to allocate a private IPv6 address instead of public ones. We'll also pass `--no-deploy` so we can adjust one setting before the first deploy:
 
 ```
-fly launch --image nginxdemos/hello --flycast --internal-port 80
+fly launch --image nginxdemos/hello --flycast --internal-port 80 --no-deploy
 ```
 
 The name you choose for your app will be the hostname you use to reach it over Flycast (`<appname>.flycast`). When `fly launch` asks if you want to tweak the settings, you can accept the defaults.
 
 The `--internal-port 80` flag tells Fly Launch that our app listens on port 80 (the default for the `nginxdemos/hello` image). Fly Launch defaults to port 8080, so without this flag the Fly Proxy wouldn't be able to reach the app.
+
+Open the generated `fly.toml` in your editor, find the `[http_service]` block, and change `force_https` to `false`:
+
+```toml
+[http_service]
+  internal_port = 80
+  force_https = false
+```
+
+Fly Launch enables `force_https` by default, which makes the proxy return a 301 redirect from HTTP to HTTPS. That's a good default for public apps, but Flycast addresses don't have public TLS certificates, so the redirect would just break plain HTTP requests from inside your private network.
+
+Now deploy the app:
+
+```
+fly deploy
+```
 
 After deploy finishes, you can see the list of IP addresses associated to an app with `fly ips list`:
 

--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -177,6 +177,7 @@ Vite
 VSCode
 Vue
 (?i)webpack
+walkthrough
 websockets?\b
 WireGuard
 


### PR DESCRIPTION
## Summary

GPU Machines are being deprecated on 2026-08-01, and the Flycast blueprint at `blueprints/private-applications-flycast.html.md` was built almost entirely around an Ollama-on-GPU walkthrough. The Flycast concepts themselves are GPU-independent, so this rewrites the guide rather than removing it.

- Replaces the Ollama example with a generic private HTTP service using the public `nginxdemos/hello` image, so no external example repo is needed
- Swaps the multi-step `fly launch --no-deploy` + `fly ips allocate-v6 --private` + `fly deploy` flow for the modern `fly launch --image ... --flycast`
- Removes the YouTube embed (GPU/Ollama walkthrough), the "Running Llama 3" subsection, and the GPU-related related-reading links
- Replaces "Fly Postgres" with "Managed Postgres" in the security note (the currently supported offering)
- Refreshes related reading to point at the autostart blueprint, the Flycast reference, and private networking
- Fixes a separately broken link (`/docs/reference/services/#ip-addresses` → `/docs/networking/services/#anycast-ip-addresses`); the old path no longer resolves
- Adds `walkthrough` to `styles/config/vocabularies/fly-terms/accept.txt` so Vale stops flagging it as a typo (it's already used elsewhere in the docs)

## Walkthrough gotchas baked into the recipe

- `--internal-port 80` on `fly launch`: `nginxdemos/hello` listens on 80, but Fly Launch defaults to 8080
- `force_https = false` in `fly.toml`: Flycast addresses don't have public TLS certs, so the default 301-to-HTTPS breaks the demo's plain HTTP requests
- `--vm-memory 1024` on the shell Machine: the 256MB default OOM-kills during `apt install -y curl iputils-ping dnsutils`