### PR TITLE
blueprints/hermes-agent: pass --insecure to `hermes dashboard`

### DIFF
--- a/blueprints/hermes-agent-on-fly-io.html.md
+++ b/blueprints/hermes-agent-on-fly-io.html.md
@@ -112,8 +112,10 @@ In one terminal, start the dashboard inside the machine:
 
 ```bash
 fly ssh console -a <your-hermes-app> -C \
-  "hermes dashboard --host 0.0.0.0 --no-open"
+  "hermes dashboard --host 0.0.0.0 --no-open --insecure"
 ```
+
+`--insecure` is required because `hermes dashboard` refuses to bind to a non-loopback interface without explicit acknowledgement. In this setup the dashboard isn't actually unprotected — Fly's authenticated WireGuard tunnel is the auth layer, not the dashboard's own check — but `hermes dashboard` can't see that, so it needs the flag to bind `0.0.0.0`.
 
 In a second terminal, open a Fly proxy from your laptop:
 


### PR DESCRIPTION
## Summary

`hermes dashboard` refuses to bind to a non-loopback interface without `--insecure`, so the dashboard command in the Hermes Agent blueprint currently exits with the following on a fresh deploy:

```
Refusing to bind to 0.0.0.0 — the dashboard exposes API keys and config without robust authentication.
Use --insecure to override (NOT recommended on untrusted networks).
Error: ssh shell: Process exited with status 1
```

This PR:

1. Adds `--insecure` to the `hermes dashboard` invocation so the command works as-is on a fresh deploy.
2. Adds one sentence explaining why `--insecure` is safe in this context: the dashboard is reached over Fly's authenticated WireGuard tunnel via `fly proxy`, not the public internet, so the flag just acknowledges that an external network layer (Fly) is doing the auth that the dashboard's own check would otherwise demand.

This matches the behavior the upstream Hermes Docker docs already describe — they note that when `HERMES_DASHBOARD=1` is used inside the container, the image's entrypoint auto-passes `--insecure` to `hermes dashboard` when `HERMES_DASHBOARD_HOST=0.0.0.0` (the default). The blueprint runs the dashboard manually via `fly ssh console`, so the same flag needs to be passed explicitly.

## Test plan

- [x] Reproduced the failure on a deploy following the blueprint verbatim.
- [x] Confirmed the patched command works end-to-end: dashboard reachable at `http://localhost:9119` via `fly proxy 9119:9119`, no public exposure.

## References

- [Hermes Agent Docker docs — Running the dashboard](https://hermes-agent.nousresearch.com/docs/user-guide/docker#running-the-dashboard) (notes the auto-`--insecure` behavior inside the entrypoint)

Made with [Cursor](https://cursor.com)