### PR TITLE
docs(monitoring): add SigNoz to metrics and log export docs

### DIFF
--- a/monitoring/exporting-logs.html.md
+++ b/monitoring/exporting-logs.html.md
@@ -10,7 +10,7 @@ redirect_from:
 
 The Fly Log Shipper app enables you to aggregate your app's logs to a service of your choice.
 
-Your app's output to `stdout` become logs in Fly.io. Live log tail and log search are good enough for most things. But if you need to export your logs to an external service, such as Datadog or AWS S3, then you can use the Log Shipper.
+Your app's output to `stdout` become logs in Fly.io. Live log tail and log search are good enough for most things. But if you need to export your logs to an external service, such as Datadog, [SigNoz](https://signoz.io+external), or AWS S3, then you can use the Log Shipper.
 
 ## The Fly Log Shipper
 

--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -132,6 +132,12 @@ We publish our [Fly.io Dashboards](https://grafana.com/grafana/dashboards/14741)
 To install, just [import the dashboard](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) using the listed IDs.
 If you'd like to contribute changes to the dashboards, we have created a [repository](https://github.com/superfly/dashboards) for them.
 
+### SigNoz
+
+[SigNoz](https://signoz.io) is an open source observability platform that can scrape your Fly.io Prometheus endpoint to visualize built-in metrics.
+
+A pre-built [Fly.io dashboard](https://github.com/SigNoz/dashboards/blob/main/fly/fly-prometheus-v1.json) is available, along with [setup instructions](https://signoz.io/docs/integrations/outposts/flyio/?signal=metrics) for configuring the Prometheus data source.
+
 ## Built-in metrics
 
 Fly apps automatically publish a number of built-in metrics.


### PR DESCRIPTION
### Summary of changes

- Adds new SigNoz subsection under Dashboards. SigNoz scrapes the Fly.io Prometheus endpoint; links to the pre-built Fly.io Prometheus dashboard and SigNoz-side setup docs.
- Added SigNoz to the inline example list of log destinations.

