### PR TITLE
Update flycast guide header image link

### DIFF
--- a/blueprints/index.html.md
+++ b/blueprints/index.html.md
@@ -11,7 +11,7 @@ A growing library of guides for running, designing, and deploying all kinds of a
 
 Guides for the structure your app on Fly.io. Layouts, tradeoffs, moving parts.
 
-- [Deploy OpenClaw on Fly.io](/docs/blueprints/deploy-openclaw/) NEW!!
+- [Deploy OpenClaw on Fly.io](/docs/blueprints/deploy-openclaw/)
 - [Run Hermes Agent on Fly.io](/docs/blueprints/hermes-agent-on-fly-io/) NEW!!
 - [Deploying Remote MCP Servers](/docs/blueprints/remote-mcp-servers/)
 - [Resilient apps use multiple Machines](/docs/blueprints/resilient-apps-multiple-machines/)

--- a/blueprints/private-applications-flycast.html.md
+++ b/blueprints/private-applications-flycast.html.md
@@ -9,6 +9,10 @@ categories:
 date: 2026-05-19
 ---
 
+<figure>
+  <img src="/static/images/campfire_apps.png" alt="Illustration by Annie Ruygt of some apps sitting around a campfire" class="w-full max-w-lg mx-auto">
+</figure>
+
 ## Overview
 
 A lot of the time your applications are made to be public and shared with the world. Sometimes you need to be more careful. When you deploy your apps on Fly.io, you get a private network for your organization. This lets your applications in other continents contact each other like they were in the same room.


### PR DESCRIPTION
### Summary of changes
- new header image link for private apps with Flycast guide
- remove "new" label from OpenClaw guide

### Preview
<img width="1287" height="805" alt="Screenshot 2026-05-27 at 11 45 44 AM" src="https://github.com/user-attachments/assets/e1c4f016-6a69-4303-b8b7-bd9bb9852934" />


