### PR TITLE
Clarify suspend volumes and capacity

### DIFF
--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -179,10 +179,8 @@ Suspended machines cost the same as stopped machines: storage only. There are no
 
 If a suspended machine has a volume, you keep paying for that volume the whole time it exists. [Volume storage](/docs/about/pricing/#persistent-storage-volumes) is billed whether the machine is running, stopped, or suspended.
 
----
-
 <div class="note icon">
-Suspending a machine lowers your cost (you're billed for storage only, with no CPU/RAM charges; see [Billing](#billing)), but it doesn't free up room in a region. A suspended machine still counts toward your regional capacity, so suspending isn't a way to fit more machines into a capacity-constrained region.
+Suspending lowers your cost, but it doesn't free up room in a region. A suspended machine still takes up capacity in the region, so it isn't a way to fit more machines into a capacity-constrained one.
 </div>
 
 ---

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -128,7 +128,7 @@ Snapshots are tied to the exact code and state of the machine they were taken fr
 
 ---
 
-## Suspend and volumes
+## Volume behavior with suspend
 
 Suspend automatically saves a machine's memory state to persistent storage. You don't need to attach a [volume](/docs/volumes/) for suspend to work, and the snapshot isn't stored on a volume.
 
@@ -138,10 +138,6 @@ If your machine does have a volume attached, the volume and its data aren't affe
 - Your **volume** is your own persistent storage. Its data survives suspend, resume, and cold starts, just as it does across a normal stop and start.
 
 Even if a snapshot is discarded and the machine cold starts, the data on your volume is still there.
-
-<div class="note icon">
-A suspended machine releases the CPU and memory it was using, just like a stopped machine, so it frees up compute capacity in the region. It still exists and uses storage, though, so suspending isn't the same as deleting.
-</div>
 
 ---
 
@@ -182,6 +178,12 @@ Tips:
 Suspended machines cost the same as stopped machines: storage only. There are no CPU/RAM charges.
 
 If a suspended machine has a volume, you keep paying for that volume the whole time it exists. [Volume storage](/docs/about/pricing/#persistent-storage-volumes) is billed whether the machine is running, stopped, or suspended.
+
+---
+
+<div class="note icon">
+Suspending a machine lowers your cost (you're billed for storage only, with no CPU/RAM charges; see [Billing](#billing)), but it doesn't free up room in a region. A suspended machine still counts toward your regional capacity, so suspending isn't a way to fit more machines into a capacity-constrained region.
+</div>
 
 ---
 

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -128,6 +128,23 @@ Snapshots are tied to the exact code and state of the machine they were taken fr
 
 ---
 
+## Suspend and volumes
+
+Suspend automatically saves a machine's memory state to persistent storage. You don't need to attach a [volume](/docs/volumes/) for suspend to work, and the snapshot isn't stored on a volume.
+
+If your machine does have a volume attached, the volume and its data aren't affected by suspend and resume. It helps to keep two things separate:
+
+- The **snapshot** is the saved CPU and memory state, managed by Fly. It can be discarded (for example, when you deploy new code), which forces a [cold start](#snapshot-behavior-with-suspend).
+- Your **volume** is your own persistent storage. Its data survives suspend, resume, and cold starts, just as it does across a normal stop and start.
+
+Even if a snapshot is discarded and the machine cold starts, the data on your volume is still there.
+
+<div class="note icon">
+A suspended machine releases the CPU and memory it was using, just like a stopped machine, so it frees up compute capacity in the region. It still exists and uses storage, though, so suspending isn't the same as deleting.
+</div>
+
+---
+
 ## Handling Network Connections After Resume
 
 On resume, the machine thinks its network connections are still live. External systems (databases, APIs) may disagree.
@@ -163,6 +180,8 @@ Tips:
 ## Billing
 
 Suspended machines cost the same as stopped machines: storage only. There are no CPU/RAM charges.
+
+If a suspended machine has a volume, you keep paying for that volume the whole time it exists. [Volume storage](/docs/about/pricing/#persistent-storage-volumes) is billed whether the machine is running, stopped, or suspended.
 
 ---
 

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -135,7 +135,7 @@ Suspend automatically saves a machine's memory state to persistent storage. You 
 If your machine does have a volume attached, the volume and its data aren't affected by suspend and resume. It helps to keep two things separate:
 
 - The **snapshot** is the saved CPU and memory state, managed by Fly. It can be discarded (for example, when you deploy new code), which forces a [cold start](#snapshot-behavior-with-suspend).
-- Your **volume** is your own persistent storage. Its data survives suspend, resume, and cold starts, just as it does across a normal stop and start.
+- The **volume** is your persistent storage. Its data survives suspend, resume, and cold starts, just as it does across a normal stop and start.
 
 Even if a snapshot is discarded and the machine cold starts, the data on your volume is still there.
 

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -177,7 +177,7 @@ Tips:
 
 Suspended machines cost the same as stopped machines: storage only. There are no CPU/RAM charges.
 
-If a suspended machine has a volume, you keep paying for that volume the whole time it exists. [Volume storage](/docs/about/pricing/#persistent-storage-volumes) is billed whether the machine is running, stopped, or suspended.
+If a suspended machine has a volume, you continue paying for the volume for as long as it exists [Volume storage](/docs/about/pricing/#persistent-storage-volumes) is billed whether the machine is running, stopped, or suspended.
 
 <div class="note icon">
 Suspending a machine lowers your costs, but it does not free capacity in a region. Suspended machines still reserve their resources, so suspension is not a way to fit more machines into a capacity-constrained region

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -134,7 +134,7 @@ Suspend automatically saves a machine's memory state to persistent storage. You 
 
 If your machine does have an attached volume, the volume and its data aren't affected by suspend and resume. It helps to think of the machine snapshot and the volume as separate things:
 
-- The **snapshot** is the saved CPU and memory state, managed by Fly. It can be discarded (for example, when you deploy new code), which forces a [cold start](#snapshot-behavior-with-suspend).
+- The **snapshot** is the saved CPU and memory state, managed by Fly. It can be discarded, for example, during a deploy, which forces a [cold start](#snapshot-behavior-with-suspend).
 - The **volume** is your persistent storage. Its data survives suspend, resume, and cold starts, just as it does across a normal stop and start.
 
 Even if a snapshot is discarded and the machine cold starts, the data on your volume is still there.

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -180,7 +180,7 @@ Suspended machines cost the same as stopped machines: storage only. There are no
 If a suspended machine has a volume, you keep paying for that volume the whole time it exists. [Volume storage](/docs/about/pricing/#persistent-storage-volumes) is billed whether the machine is running, stopped, or suspended.
 
 <div class="note icon">
-Suspending lowers your cost, but it doesn't free up room in a region. A suspended machine still takes up capacity in the region, so it isn't a way to fit more machines into a capacity-constrained one.
+Suspending a machine lowers your costs, but it does not free capacity in a region. Suspended machines still reserve their resources, so suspension is not a way to fit more machines into a capacity-constrained region
 </div>
 
 ---

--- a/reference/suspend-resume.html.md
+++ b/reference/suspend-resume.html.md
@@ -132,7 +132,7 @@ Snapshots are tied to the exact code and state of the machine they were taken fr
 
 Suspend automatically saves a machine's memory state to persistent storage. You don't need to attach a [volume](/docs/volumes/) for suspend to work, and the snapshot isn't stored on a volume.
 
-If your machine does have a volume attached, the volume and its data aren't affected by suspend and resume. It helps to keep two things separate:
+If your machine does have an attached volume, the volume and its data aren't affected by suspend and resume. It helps to think of the machine snapshot and the volume as separate things:
 
 - The **snapshot** is the saved CPU and memory state, managed by Fly. It can be discarded (for example, when you deploy new code), which forces a [cold start](#snapshot-behavior-with-suspend).
 - The **volume** is your persistent storage. Its data survives suspend, resume, and cold starts, just as it does across a normal stop and start.


### PR DESCRIPTION
Documents two things the Machine suspend/resume page didn't cover, that also came from customer queries:

Volumes: A volume isn't required for suspend (memory state is saved to Fly-managed storage, not your volume), and volume data is unaffected by suspend, resume, and cold starts.

Regional capacity: Suspending lowers cost (storage only, no CPU/RAM) but doesn't free up room in a region; a suspended machine still counts toward regional capacity, so it can't be used to pack more machines into a constrained region.