### PR TITLE
Recommend app-scoped static egress IPs in Static Machine IPs section

### DIFF
--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -123,7 +123,11 @@ are; we've already done the heavy lifting.
 
 ### Static Machine IPs
 
-Static egress IPs can be attached to a machine. These IPs survive a [machine migration](/docs/reference/machine-migration/) and are not shared between machines.
+<div class="note icon">
+**App-scoped static egress IPs are recommended.** The machine-scoped static egress IPs described below are a legacy feature. For most use cases, you should allocate [app-scoped static egress IPs](/docs/networking/egress-ips/#static-egress-ips-app-scoped) instead. Unlike machine-scoped IPs, app-scoped IPs can be shared between multiple machines in a region and are not deleted when machines are recreated.
+</div>
+
+A machine-scoped static egress IP is attached to a single machine and isn't shared with other machines. It survives a [machine migration](/docs/reference/machine-migration/).
 
 Static egress IPs are useful when your machine needs to connect to a service that requires allowlisting a specific set of IPs.
 If supported, it is recommended to use [Wireguard](/docs/networking/private-networking/#private-network-vpn) to connect to external services.

--- a/machines/overview.html.markerb
+++ b/machines/overview.html.markerb
@@ -130,7 +130,7 @@ are; we've already done the heavy lifting.
 A machine-scoped static egress IP is attached to a single machine and isn't shared with other machines. It survives a [machine migration](/docs/reference/machine-migration/).
 
 Static egress IPs are useful when your machine needs to connect to a service that requires allowlisting a specific set of IPs.
-If supported, it is recommended to use [Wireguard](/docs/networking/private-networking/#private-network-vpn) to connect to external services.
+If supported, it is recommended to use [WireGuard](/docs/networking/private-networking/#private-network-vpn) to connect to external services.
 
 You can attach a static egress IP to your machine with `fly machine egress-ip allocate <machine_id>`
 


### PR DESCRIPTION
Adds a note to the **Static Machine IPs** section of the Machines overview steering readers toward [app-scoped static egress IPs](https://fly.io/docs/networking/egress-ips/#static-egress-ips-app-scoped), which are now recommended over the legacy machine-scoped IPs.

- Adds a note box flagging machine-scoped egress IPs as legacy and linking to the app-scoped section on the egress IPs page.
- Clarifies the existing sentence so it reads as describing the machine-scoped behavior rather than stating a drawback out of context.