### PR TITLE
Fix Extensions pricing: Tigris data transfer is billed

### DIFF
--- a/about/pricing.html.markerb
+++ b/about/pricing.html.markerb
@@ -225,9 +225,8 @@ You will not be billed separately for:
 
 * Machines running the services, which are hosted in the provider's account
 * IP addresses associated with the service
-* Bandwidth to Tigris Object Storage
 
-You **will** be billed separately for data transfer to these external third-party services. See our [data transfer pricing](#data-transfer-pricing) for details.
+You **will** be billed separately for data transfer to these external third-party services, including Tigris Object Storage. See our [data transfer pricing](#data-transfer-pricing) for details.
 
 ## Unsupported Products
 


### PR DESCRIPTION
PR #2196 removed the statements exempting Tigris Object Storage from data-transfer billing but left a "Bandwidth to Tigris Object Storage" bullet in the "not billed separately for" list, contradicting the billed sentence below it. Remove that leftover bullet and name Tigris explicitly in the billed sentence, so the page consistently states that data transfer to third-party services, including Tigris, is billed.

