### PR TITLE
Clarify max amount and hold time for preauthorization charges

### DIFF
--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -119,7 +119,7 @@ We require an active, valid credit card on file for most Fly.io accounts to do t
 
 We may send a pre-authorization request to the issuing bank to verify a bank will authorize charges. Some credit card companies present these as real charges, which may surprise you.
 
-A pre-auth is really just a hold on a credit card; it is not a real charge. We’ll typically pre-authorize a small amount (usually less than US $10) after signup, then cancel the authorization immediately. Banks may show the pre-auth for up to 10 working days, even though we have not collected any money.
+A pre-auth is really just a hold on a credit card; it is not a real charge. We’ll typically pre-authorize a small amount (usually less than US $10) after signup, then cancel the authorization immediately. Banks may show the pre-auth for up to 10 business days, even though we have not collected any money.
 
 ### If you don't have a credit card
 

--- a/about/billing.html.markerb
+++ b/about/billing.html.markerb
@@ -10,7 +10,7 @@ redirect_from: /docs/about/credit-cards/
 
 Billing for Fly.io is monthly per organization. Organizations are administrative entities that enable you to add members, share app development environments, and manage billing.
 
-New customers and all new organizations (including those created by previously existing customers) are billed monthly for resource usage. Refer to our resource [Pricing page](/docs/about/pricing/) for details. 
+New customers and all new organizations (including those created by previously existing customers) are billed monthly for resource usage. Refer to our resource [Pricing page](/docs/about/pricing/) for details.
 
 ---
 
@@ -119,7 +119,7 @@ We require an active, valid credit card on file for most Fly.io accounts to do t
 
 We may send a pre-authorization request to the issuing bank to verify a bank will authorize charges. Some credit card companies present these as real charges, which may surprise you.
 
-A pre-auth is really just a hold on a credit card; it is not a real charge. We’ll typically pre-authorize a small amount (usually less than $5) after signup, then cancel the authorization immediately. Banks may show the pre-auth for up to 7 days, even though we have not collected any money.
+A pre-auth is really just a hold on a credit card; it is not a real charge. We’ll typically pre-authorize a small amount (usually less than US $10) after signup, then cancel the authorization immediately. Banks may show the pre-auth for up to 10 working days, even though we have not collected any money.
 
 ### If you don't have a credit card
 


### PR DESCRIPTION
A user pointed out the documentation shows amounts and hold times that don't match what the UX says (ui-ex) nor what happens in reality. This updates the documentation so it matches actual behavior and/or other information we give users.

