### PR TITLE
Fix metrics scrape limit: 16 KiB -> 16 MB

### DIFF
--- a/monitoring/metrics.html.md
+++ b/monitoring/metrics.html.md
@@ -100,7 +100,7 @@ There's currently no additional charge for the managed Prometheus and Grafana. P
 
 A couple of practical limits to be aware of:
 
-- We cap your app's metrics endpoint response at 16 KiB and drop anything larger.
+- We cap your app's metrics endpoint response at 16 MB and drop anything larger.
 - We may drop very high-cardinality custom metrics.
 
 ## Dashboards


### PR DESCRIPTION
The endpoint response cap was incorrectly documented as 16 KiB. The actual VictoriaMetrics maxScrapeSize default is 16 MB (16777216 bytes).
