### PR TITLE
Secure log shipper docs: no public services or IPs

### DIFF
--- a/monitoring/exporting-logs.html.md
+++ b/monitoring/exporting-logs.html.md
@@ -46,7 +46,7 @@ fly secrets set LOGTAIL_TOKEN=<token provided by logtail source>
 
 You can configure as many providers as you'd like by adding more secrets. The secrets needed are determined by [which provider(s)](https://github.com/superfly/fly-log-shipper#provider-configuration+external) you want to use.
 
-The Log Shipper pulls logs from Fly.io's internal log stream and doesn't need to accept inbound connections, so it shouldn't have any public services or IP addresses. Before deploying, edit the generated `fly.toml` file and delete the entire `[[http_service]]` (or `[[services]]`) section.
+The Log Shipper pulls logs from Fly.io's internal log stream and doesn't need to accept inbound connections, so it shouldn't have any public services or IP addresses. Before deploying, edit the generated `fly.toml` file and delete the entire `[http_service]` (or `[[services]]`) section.
 
 Then deploy without allocating a public IP address:
 

--- a/monitoring/exporting-logs.html.md
+++ b/monitoring/exporting-logs.html.md
@@ -46,19 +46,15 @@ fly secrets set LOGTAIL_TOKEN=<token provided by logtail source>
 
 You can configure as many providers as you'd like by adding more secrets. The secrets needed are determined by [which provider(s)](https://github.com/superfly/fly-log-shipper#provider-configuration+external) you want to use.
 
-Before launching your application, you should edit the generated `fly.toml` file and delete the entire `[[services]]` section. Replace it with this:
+The Log Shipper pulls logs from Fly.io's internal log stream and doesn't need to accept inbound connections, so it shouldn't have any public services or IP addresses. Before deploying, edit the generated `fly.toml` file and delete the entire `[[http_service]]` (or `[[services]]`) section.
 
-```toml
-[[services]]
-  http_checks = []
-  internal_port = 8686
-```
-
-Then you can deploy it:
+Then deploy without allocating a public IP address:
 
 ```cmd
-fly deploy
+fly deploy --no-public-ips
 ```
+
+If you already deployed a Log Shipper with a public IP address, list its addresses with `fly ips list` and remove them with `fly ips release <address>`.
 
 ## Shipping specific logs
 

--- a/monitoring/exporting-logs.html.md
+++ b/monitoring/exporting-logs.html.md
@@ -56,6 +56,24 @@ fly deploy --no-public-ips
 
 If you already deployed a Log Shipper with a public IP address, list its addresses with `fly ips list` and remove them with `fly ips release <address>`.
 
+## Add a health check
+
+The Log Shipper can occasionally stop shipping logs without exiting, so it's a good idea to add a health check. Vector serves a `/health` endpoint on port 8686. Since the app has no services, use a top-level [`[checks]` section](/docs/reference/configuration/#the-checks-section) in `fly.toml`, which doesn't require a public service or IP address:
+
+```toml
+[checks]
+  [checks.vector]
+    port = 8686
+    type = "http"
+    method = "get"
+    path = "/health"
+    grace_period = "10s"
+    interval = "30s"
+    timeout = "5s"
+```
+
+Check the health status with `fly checks list`.
+
 ## Shipping specific logs
 
 By default, the log shipper gets logs from every app running within your organization (organization is set by the `ORG` secret/environment variable).

--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -28,6 +28,7 @@ containerd
 [Cc]ron(jobs?|job)?\b
 [Cc]rontabs?\b
 datacenters?\b
+Datadog
 datasource
 datatypes?\b
 declaratively


### PR DESCRIPTION
The Log Shipper guide told users to edit `fly.toml` and keep a `[[services]]` section on `internal_port = 8686`. That port serves Vector's GraphQL API (including an unauthenticated `/playground`), so following the docs exposed it publicly. This was [reported on the community forum](https://community.fly.io/t/fly-log-shipper-publishes-graphql-publicly/14836), where Fly staff recommended deploying with `--no-public-ips`.

Vector pulls logs from Fly.io's internal log stream and doesn't need to accept inbound connections, so this:

- Removes the `[[services]]` / port 8686 block from the setup steps
- Deploys with `fly deploy --no-public-ips`
- Notes how to release IPs on already-exposed deployments (`fly ips list` / `fly ips release`)
- Adds a health check section using a top-level `[checks]` block against Vector's `/health` on 8686, which works without a public service or IP (the shipper can stop shipping logs without exiting, see #1828)

All of the above was verified on a live deploy; see the testing comments below.

Supersedes #930 (same fix, but that PR targeted a since-moved file and had gone stale) and #1828 (same health check goal, but via a public `[http_service]`, which this PR removes).