### PR TITLE
Note dockerfile-rails gem requirement in Rails Dockerfiles guide

### DIFF
--- a/rails/getting-started/dockerfiles.html.md
+++ b/rails/getting-started/dockerfiles.html.md
@@ -27,6 +27,10 @@ to do is rerun the generator:
 bin/rails generate dockerfile
 ```
 
+<div class="note icon">
+If you get a `Could not find generator 'dockerfile'.` error, your app predates the `dockerfile-rails` gem. Add [dockerfile-rails](https://github.com/rubys/dockerfile-rails) to your Gemfile and run `bundle install` first.
+</div>
+
 The generator will remember the options you selected before (these are
 stored in `config/dockerfile.yml`).  If you need to change a boolean
 option, add or remove a `no-` prefix before the option name.


### PR DESCRIPTION
Running `bin/rails generate dockerfile` on an older Rails app that predates the `dockerfile-rails` gem fails with `Could not find generator 'dockerfile'.`, with no guidance in the docs. This adds a callout in the **Updates** section pointing users to add the gem first.

Supersedes #1184 (same idea; this version fixes a typo, links the canonical `rubys/dockerfile-rails` repo to match the rest of the page, and uses the standard callout markup).
