### PR TITLE
Add "Cookie preferences" to the docs About nav (PostHog consent)

### DIFF
--- a/partials/_accordion_nav.html.erb
+++ b/partials/_accordion_nav.html.erb
@@ -72,6 +72,13 @@
                   </dd>
                 </dl>
               </li>
+            <% elsif page[:cookie_prefs] %>
+              <%# Reopens the PostHog consent banner (posthog-consent.js wires
+                  #footer-cookie-prefs). Rendered only when PostHog is built in;
+                  hidden until the JS un-hides it for in-scope visitors. %>
+              <% if ENV["POSTHOG_API_KEY"].to_s.strip != "" %>
+                <li><a id="footer-cookie-prefs" href="#" hidden><span class="truncate pointer-events-none"><%= page[:text] %></span></a></li>
+              <% end %>
             <% else %>
               <li>
                 <% if page[:type] == "flyctl" %>

--- a/partials/_firecracker_nav.html.erb
+++ b/partials/_firecracker_nav.html.erb
@@ -222,7 +222,8 @@
         { text: "Open Source", path: "/docs/about/open-source/" },
         { text: "Using Our Brand", path: "/docs/about/brand/" },
         { text: "Privacy Policy", path: "/legal/privacy-policy/" },
-        { text: "Terms of Service", path: "/legal/terms-of-service/" }
+        { text: "Terms of Service", path: "/legal/terms-of-service/" },
+        { text: "Cookie preferences", cookie_prefs: true }
       ]
     }
   ]


### PR DESCRIPTION
Adds a **"Cookie preferences"** control to the docs left-nav **About** section (next to Privacy Policy / Terms of Service), so EEA/UK visitors can reopen the PostHog consent banner and withdraw consent from docs pages.

## Why this is the only docs-repo change needed
Docs pages are **rendered by the `landing` app** — landing's CI clones this repo into `pages/docs/`, and `landing`'s `docs.html.erb` wraps the shared `html` shell layout. That shell already loads PostHog (bundled consent script + banner) via **superfly/landing#1165**. So docs pages **already track + show the banner**; the one thing missing was the withdraw control, because docs has no footer (where ui-ex/landing put it).

## What it does
- Adds `{ text: "Cookie preferences", cookie_prefs: true }` to the firecracker nav's About list.
- `_accordion_nav.html.erb` special-cases it → renders a hidden `<a id="footer-cookie-prefs" href="#">` (matching the sibling nav links' styling), **only when `POSTHOG_API_KEY` is set at build time**.
- `landing`'s `posthog-consent.js` already un-hides `#footer-cookie-prefs` and wires it to reopen the banner for in-scope visitors — no new JS here. (A one-line `preventDefault` companion is in the landing PR so the `<a href="#">` doesn't jump.)

Dormant until `POSTHOG_API_KEY` is set at build. Copy/consent behavior identical to the other surfaces.

**Companion:** superfly/landing#1165 (the actual PostHog integration; this just adds the docs withdraw link).