### PR TITLE
Disable Vale.Terms to stop false-positive casing errors

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -75,7 +75,7 @@ write-good.Weasel = NO # too arbitrary
 # Vale.Avoid = NO
 Vale.Repetition = NO # replaced by good-write.Illusions which has an adjustable error level
 Vale.Spelling = NO # replaced by Fly.Spelling
-# Vale.Terms = NO
+Vale.Terms = NO # noisy false positives: enforces vocab-term casing even inside code, and prints raw regex vocab entries as suggested fixes
 
 [formats]
 markerb = md # maps our markerb file extension to md for linting


### PR DESCRIPTION
`Vale.Terms` auto-derives from our `accept.txt` vocab and enforces the canonical casing of every term. Vale 3.15.1 (the version CI installs via `errata-ai/vale-action`) runs it aggressively:

- It flags terms inside code spans and code blocks (e.g. `` `fly scale vm` ``, `[[vm]]`), where the lowercase form is required and can't be changed.
- For regex vocab entries like `VM('s)?\b` or `configs?\b`, it prints the raw regex as the suggested replacement ("Use 'VM('s)?\b' instead of 'vm'").

Across the docs this is 450 findings in 216 files, nearly all false positives. Because the Vale workflow lints whole changed files (`filter_mode: file`) and reviewdog exits non-zero on any finding, this turns the Vale check red on unrelated PRs the moment they touch an affected file (most recently #2192).

This disables `Vale.Terms`, consistent with `Vale.Spelling` and `Vale.Repetition`, which are already off. The vocab still does its main job of spelling acceptance through `Fly.Spelling`, so no terms become misspellings.
