### PR TITLE
Add log-page technical terms to Vale vocab

### DIFF
--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -14,6 +14,7 @@ autosav\w+
 (?i)autostop\b
 (?i)autosuspend\b
 backhaul
+backpressure
 bluegreen
 bool
 (?i)boolean
@@ -36,6 +37,7 @@ declaratively
 (?i)dbs?\b
 discoverability
 Debian
+dedupe
 dev
 devs
 (?i)Dockerfile
@@ -132,6 +134,8 @@ Prisma
 Prometheus
 proxying
 psql
+queryable
+reconnections
 repmgr
 repo
 Resque


### PR DESCRIPTION
Adds four legitimate technical terms to the Vale vocabulary so `Fly.Spelling` stops flagging them as typos:

- `backpressure`
- `dedupe`
- `queryable`
- `reconnections`

All four appear in `monitoring/logs-api-options.html.md` and recur elsewhere in the docs. Because the Vale workflow lints whole changed files, these pre-existing suggestions turn the check red on any PR that touches that page (currently #2329). Adding them clears the noise and keeps the terms usable going forward.
