### PR TITLE
Fix About nav accordion always starting expanded

### DIFF
--- a/partials/_accordion_nav.html.erb
+++ b/partials/_accordion_nav.html.erb
@@ -2,7 +2,7 @@
   def section_open?(section)
     (!section[:path].nil? && current_page?(section[:path])) ||
     (!section[:open].nil? && section[:open]) ||
-    (section[:links] && section[:links].any? { |page| current_page?(page[:path]) || (page[:links] && section_open?(page)) })
+    (section[:links] && section[:links].any? { |page| (!page[:path].nil? && current_page?(page[:path])) || (page[:links] && section_open?(page)) })
   end
 
   nav.each { |nav| nav[:open] = section_open?(nav) unless nav[:title].nil? }


### PR DESCRIPTION
## Problem

On every docs page (e.g. https://fly.io/docs), the left-nav **About** accordion starts expanded. It should only auto-expand when you're actually on an `/docs/about/...` page.

## Root cause

#2431 added a nav entry with **no `:path`** to the About list:

```ruby
{ text: "Cookie preferences", cookie_prefs: true }
```

In `partials/_accordion_nav.html.erb`, `section_open?` decides whether an accordion starts open. Its link-scan clause called `current_page?(page[:path])` without a nil guard:

```ruby
(section[:links] && section[:links].any? { |page| current_page?(page[:path]) || ... })
```

For the Cookie preferences entry `page[:path]` is `nil`, and Padrino's `current_page?` treats a nil/blank argument as matching the current request — so About evaluated as "open" on every page.

The method's first clause already guards this exact case for `section[:path]` (`!section[:path].nil? && current_page?(...)`); the `.any?` clause simply lacked the same guard.

## Fix

Add the matching nil guard so pathless entries no longer count as the current page:

```ruby
(section[:links] && section[:links].any? { |page| (!page[:path].nil? && current_page?(page[:path])) || (page[:links] && section_open?(page)) })
```

About still auto-expands when you're on a real `/docs/about/...` page; it just no longer forces itself open everywhere. Also protects any future pathless nav entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)