### PR TITLE
Fix review apps guide to use fly-pr-review-apps@1.2.1

### DIFF
--- a/blueprints/review-apps-guide.html.md
+++ b/blueprints/review-apps-guide.html.md
@@ -120,7 +120,7 @@ These inputs can be added to the `deploy` step in your workflow using the `with`
       # ...
       - name: Deploy PR app to Fly.io
         id: deploy
-        uses: superfly/fly-pr-review-apps@1.2.0
+        uses: superfly/fly-pr-review-apps@1.2.1
         with:
           name: my-app-name-pr-${{ github.event.number }}
           config: fly.review.toml
@@ -139,7 +139,7 @@ You probably won't need the same specifications for the Fly Machines used by rev
       # ...
       - name: Deploy PR app to Fly.io
         id: deploy
-        uses: superfly/fly-pr-review-apps@1.2.0
+        uses: superfly/fly-pr-review-apps@1.2.1
         with:
           config: fly.review.toml
 ```
@@ -165,7 +165,7 @@ Once you have your secrets and environment variables set in GitHub, add each of 
       # ...
       - name: Deploy PR app to Fly.io
         id: deploy
-        uses: superfly/fly-pr-review-apps@1.2.0
+        uses: superfly/fly-pr-review-apps@1.2.1
         with:
           secrets: FOOBAR=${{ secrets.FOOBAR }} SOME_API_KEY=${{ secrets.SOME_API_KEY}}
 ```


### PR DESCRIPTION
The "Customize your workflow" examples in the review apps guide still pinned `superfly/fly-pr-review-apps@1.2.0`, which fails with `Error: unknown flag: --region`. The main workflow example already uses `@1.2.1`; this updates the three remaining examples to match so every snippet works.

Closes #1894