### PR TITLE
Correct fly platform regions description on machine placement page

### DIFF
--- a/machines/guides-examples/machine-placement.html.md
+++ b/machines/guides-examples/machine-placement.html.md
@@ -14,9 +14,9 @@ Let’s say you run `fly scale count` and tell it to drop 10 machines into `dfw`
 
 Most of the time this just works—`dfw` and `iad` are solid bets for region choices. But some regions, like `sjc`, `gru`, and `bom`, tend to be in high demand. If you hardcode your placement into one of those and cross your fingers, you might find yourself scaling to zero.
 
-### How to check available capacity
+### Where can you deploy?
 
-Run `fly platform regions`. You’ll get a list of regions and their available CPU cores. These aren’t guarantees, but they’re a decent snapshot of where you’re most likely to succeed.
+Run `fly platform regions` to see the regions where Fly.io has datacenters, along with their region codes. Use those codes to set region preferences for your Machines.
 
 ### Let the scheduler help
 


### PR DESCRIPTION
The [Machine Placement and Regional Capacity](https://fly.io/docs/machines/guides-examples/machine-placement/#how-to-check-available-capacity) guide said `fly platform regions` returns "a list of regions and their available CPU cores." It doesn't.

`fly platform regions` briefly had a capacity column, which was removed. The command now renders `Name` and `Code` only. Our own generated reference at `flyctl/cmd/fly_platform_regions.md` already reflects this.

This rewrites the section to describe what the command does today.