### PR TITLE
Update docs for the Sentry partnership sunset

### DIFF
--- a/apps/app-handover-guide.html.md
+++ b/apps/app-handover-guide.html.md
@@ -51,7 +51,7 @@ or go to the App Settings page in your Dashboard, click Move app, pick the new o
     - **Postgres** **(unmanaged and managed):** Moving Postgres databases across orgs is not supported. You’ll need to spin up a new Fly Postgres app in the target org and restore from a volume snapshot. Or you can use `pgloader` to migrate the data. 
     - **Upstash Redis:** This is tied to an org’s private network. You’ll need to provision a new DB in the new org. 
     - **Tigris buckets:** You’ll have to delete the old Tigris bucket, recreate it in the new org, and copy the data over (try `s3sync`). Don’t forget to reset your app’s secrets. 
-    - **Sentry and other extensions**: Be sure to create fresh ones in the new org and reconfigure the app to use them.
+    - **Sentry and other extensions**: Extensions don’t move between orgs, and sorting them out is on you. For Sentry, new Fly.io-provisioned projects are no longer available—handle the handover in the Sentry dashboard directly (transfer the project or invite the new owners) and keep the app’s `SENTRY_DSN` secret pointing at it. For other extensions, create fresh ones in the new org and reconfigure the app to use them.
 
 ### Summary
 

--- a/apps/app-handover-guide.html.md
+++ b/apps/app-handover-guide.html.md
@@ -51,7 +51,6 @@ or go to the App Settings page in your Dashboard, click Move app, pick the new o
     - **Postgres** **(unmanaged and managed):** Moving Postgres databases across orgs is not supported. You’ll need to spin up a new Fly Postgres app in the target org and restore from a volume snapshot. Or you can use `pgloader` to migrate the data. 
     - **Upstash Redis:** This is tied to an org’s private network. You’ll need to provision a new DB in the new org. 
     - **Tigris buckets:** You’ll have to delete the old Tigris bucket, recreate it in the new org, and copy the data over (try `s3sync`). Don’t forget to reset your app’s secrets. 
-    - **Sentry and other extensions**: Extensions don’t move between orgs, and sorting them out is on you. For Sentry, new Fly.io-provisioned projects are no longer available—handle the handover in the Sentry dashboard directly (transfer the project or invite the new owners) and keep the app’s `SENTRY_DSN` secret pointing at it. For other extensions, create fresh ones in the new org and reconfigure the app to use them.
 
 ### Summary
 

--- a/blueprints/cell-based.html.md
+++ b/blueprints/cell-based.html.md
@@ -220,8 +220,7 @@ likely make use of one or more of the following:
    addresses many problems, it doesn't help deal with logs that are missing due
    to application or network problems.  Consider having applications emit a
    heartbeat, and write monitoring software that looks for missing heartbeats
-   and reports them as issues.  [Sentry](https://fly.io/docs/monitoring/sentry/)
-   can help here.
+   and reports them as issues.
  * While applying updates when all of the services for a single Machine are
    self contained is an easier problem then upgrading potentially
    interdependent services running live in production, it does come at a cost:

--- a/getting-started/migrate-from-heroku.html.md
+++ b/getting-started/migrate-from-heroku.html.md
@@ -307,7 +307,7 @@ Once DNS propagates, Fly automatically provisions an SSL certificate.
 | Heroku Scheduler | Use cron in your app, or a separate "cron" process |
 | Papertrail | `fly logs` built-in, or add a log drain |
 | SendGrid | Keep using SendGrid (just use API key) |
-| New Relic | `fly extensions sentry` or keep using New Relic |
+| New Relic | Keep using New Relic (just use license key) |
 | S3 / Bucketeer | `fly storage create` (Tigris) or keep using S3 |
 | Elasticsearch | Deploy Elasticsearch as a Fly app, or use a hosted service |
 | Memcached | Use Redis instead (`fly redis create`) |

--- a/monitoring/sentry.html.md
+++ b/monitoring/sentry.html.md
@@ -10,23 +10,11 @@ date: 2025-07-21
 **Heads up**: Provisioning new Sentry projects through Fly.io (`fly ext sentry create`) is no longer available. Existing projects keep working, and this page sticks around for the people using them. Need error tracking on a new app? [Sign up with Sentry directly](https://sentry.io/signup/) and set your `SENTRY_DSN` as an app secret — same result, one extra step.
 </div>
 
-[Sentry](https://sentry.io/) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our partnership with Sentry, each of your Fly organizations can claim a year’s worth of [Team Plan](https://sentry.io/pricing) credits.
+[Sentry](https://sentry.io/) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our former partnership with Sentry, organizations that provisioned Sentry through Fly.io received a year’s worth of [Team Plan](https://sentry.io/pricing) credits.
 
-## Set up Sentry for your Fly.io app
+## Access your Sentry project
 
-In your project source directory, run the following command:
-
-```
-fly ext sentry create
-```
-
-This command will:
-
-- Create a Sentry account using your Fly.io user email
-- Create a Sentry organization linked to your Fly.io organization
-- Set the `SENTRY_DSN` secret in your app
-
-Once this is complete, your app will have the `SENTRY_DSN` environment variable available at runtime. Most Sentry SDKs will automatically pick this up and begin sending events.
+Apps provisioned through Fly.io have the `SENTRY_DSN` secret set, so the environment variable is available at runtime. Most Sentry SDKs will automatically pick this up and begin sending events.
 
 You can open the Sentry dashboard for your app by running:
 
@@ -40,7 +28,7 @@ To start sending events to Sentry, you’ll need to instrument your app with the
 
 ## Sentry Plan details
 
-Your organization receives one year of Sentry’s Team plan, which includes monthly:
+Your organization received one year of Sentry’s Team plan, which includes monthly:
 
 - 50k errors
 - 100k [performance units](https://sentry.io/changelog/2023-5-9-introducing-performance-units/)

--- a/monitoring/sentry.html.md
+++ b/monitoring/sentry.html.md
@@ -6,6 +6,10 @@ redirect_from: /docs/reference/sentry/
 date: 2025-07-21
 ---
 
+<div class="warning icon">
+**Heads up**: Provisioning new Sentry projects through Fly.io (`fly ext sentry create`) is no longer available. Existing projects keep working, and this page sticks around for the people using them. Need error tracking on a new app? [Sign up with Sentry directly](https://sentry.io/signup/) and set your `SENTRY_DSN` as an app secret — same result, one extra step.
+</div>
+
 [Sentry](https://sentry.io/) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our partnership with Sentry, each of your Fly organizations can claim a year’s worth of [Team Plan](https://sentry.io/pricing) credits.
 
 ## Set up Sentry for your Fly.io app

--- a/monitoring/sentry.html.md
+++ b/monitoring/sentry.html.md
@@ -7,7 +7,7 @@ date: 2025-07-21
 ---
 
 <div class="warning icon">
-**Heads up**: Provisioning new Sentry projects through Fly.io (`fly ext sentry create`) is no longer available. Existing projects keep working, and this page sticks around for the people using them. Need error tracking on a new app? [Sign up with Sentry directly](https://sentry.io/signup/) and set your `SENTRY_DSN` as an app secret — same result, one extra step.
+**Heads up**: Provisioning new Sentry projects through Fly.io (`fly ext sentry create`) is no longer available. Existing projects keep working, and this page sticks around for the people using them. Need error tracking on a new app? [Sign up with Sentry directly](https://sentry.io/signup/) and set your `SENTRY_DSN` as an app secret.
 </div>
 
 [Sentry](https://sentry.io/) is a developer-first application monitoring platform that helps you identify and fix software problems before they impact your users. Through our former partnership with Sentry, organizations that provisioned Sentry through Fly.io received a year’s worth of [Team Plan](https://sentry.io/pricing) credits.

--- a/security/org-roles-permissions.html.md
+++ b/security/org-roles-permissions.html.md
@@ -32,7 +32,7 @@ Admins have all the permissions of Members, plus a few critical ones:
 
 Use the admin role sparingly. Admins can burn the place down—on purpose or by accident.
 
-**Note**: For billing and user permission details for our extension partners (e.g. Tigris, Sentry, etc.) please check with the vendor directly.
+**Note**: For billing and user permission details for our extension partners (e.g. Tigris) please check with the vendor directly.
 
 ### Quick Comparison
 


### PR DESCRIPTION
New Sentry provisioning is now blocked platform-wide (superfly/web#4239) and removed from the dashboard/launch UIs (superfly/ui-ex#4992, #4993, #4996, #5005). This updates the docs to match:

- **`/docs/monitoring/sentry/`**: sunset warning banner up top — existing projects keep working, the page stays as reference for them, and new users are pointed at signing up with Sentry directly (same link as the API error message). Rest of the page untouched.
- **App handover guide**: Sentry handover now happens in the Sentry dashboard directly; new Fly-provisioned projects are gone.
- **Heroku migration**: New Relic row mirrors the SendGrid "keep using it" advice instead of suggesting `fly extensions sentry`.
- **Cell-based blueprint**: dropped the Sentry recommendation sentence.
- **Org roles**: trimmed Sentry from the extension-partner examples.

Deliberately untouched: the sidebar "Sentry Error Tracking" nav link (the page still serves existing customers) and the python/rust speedrun `fly launch` sample outputs (flyctl's own output, will self-correct when flyctl drops the field).

## Screenshots

<img width="888" height="456" alt="deprecation-banner" src="https://github.com/user-attachments/assets/b2bed1ab-5772-4e14-9fad-64fcbabadb67" />
