### PR TITLE
Finish the Sentry sunset cleanup

### DIFF
--- a/apps/going-to-production.html.markerb
+++ b/apps/going-to-production.html.markerb
@@ -97,7 +97,7 @@ Moving an app from staging to production can expose unexpected failure modes: se
   items: [
     
     { id: "metrics", title: "Monitor your app with fully-managed metrics", description: "Use managed Prometheus and managed Grafana dashboards to monitor your app. Read about [Metrics on Fly.io](/docs/monitoring/metrics/)."},
-    { id: "sentry", title: "Use Sentry for Error tracking", description: "Our extension partner Sentry provides an application monitoring platform that helps you identify and fix software problems before they impact your users. Fly.io organizations get a year's worth of [Sentry Team Plan](https://fly.io/docs/monitoring/sentry/#sentry-plan-details) credits. Read how to configure [Application Monitoring by Sentry](/docs/monitoring/sentry/)."},
+    { id: "sentry", title: "Use Sentry for error tracking", description: "Sentry is an application monitoring platform that helps you identify and fix software problems before they impact your users. [Sign up with Sentry](https://sentry.io/signup/), then set your `SENTRY_DSN` as an app secret. Read more about [Application Monitoring by Sentry](/docs/monitoring/sentry/)."},
     { id: "export-logs", title: "Export your logs", description: "Set up the Fly Log Shipper to aggregate your app’s logs to a service of your choice. Read more about [Exporting logs](/docs/monitoring/exporting-logs/)."}
   ],
   c: params[:c] || "",

--- a/blueprints/shared-nothing.html.markerb
+++ b/blueprints/shared-nothing.html.markerb
@@ -281,7 +281,7 @@ Two major additions since I wrote up that blog entry:
   * I have my log tracker query Sentry whenever I visit the web page to see if there are new events.  This
     serves as an additional reminder to go check for errors.
 
-I strongly encourage people to look into [Sentry](https://community.fly.io/t/integrated-sentry-error-tracking/15278).
+I strongly encourage people to look into [Sentry](https://sentry.io/).
 
 ## Applying updates
 

--- a/monitoring/index.html.markerb
+++ b/monitoring/index.html.markerb
@@ -20,11 +20,11 @@ _Fully-managed metrics solutions to help you monitor your apps._
 
 ---
 
-## Error monitoring by Sentry
+## Error monitoring
 
-_Error monitoring for your apps from our extension providers._
+_Error monitoring for your apps._
 
-- **[Sentry](/docs/monitoring/sentry/):** Use Sentry on Fly.io and get actionable insights to resolve the most important code-related issues. Fly.io organizations that use Sentry can claim a year’s worth of Team Plan credits.
+- **[Sentry](/docs/monitoring/sentry/):** Use Sentry to get actionable insights to resolve the most important code-related issues in your app.
 
 ---
 


### PR DESCRIPTION
Follow-up to #2447. That PR updated the Sentry page and four others, but three pages still described the partnership in present tense and sent new users toward a signup flow that no longer exists.

- **Going to production checklist:** the error tracking item told readers that "Fly.io organizations get a year's worth of Sentry Team Plan credits" and linked to the plan details anchor. This is the most likely path for a new user to hit the dead flow, since the checklist is what we point people at before launch. It now points at signing up with Sentry directly and setting `SENTRY_DSN` as an app secret.
- **Monitoring index:** dropped the "can claim a year's worth of Team Plan credits" sentence and the "from our extension providers" framing in the section heading. The linked Sentry page already carries the sunset banner.
- **Shared-nothing blueprint:** the closing recommendation linked to the community post announcing the integrated Sentry error tracking. Points to sentry.io instead. The other Sentry mentions in that blueprint are the author describing his own tooling, so they stay.

Two things outside this repo that are still open:

- `/docs/flyctl/extensions-sentry-create/` still reads "Provision a Sentry project for a Fly.io app" with no warning, and `fly extensions` still lists the subcommand. Those pages are generated from flyctl, so closing that path needs a change upstream.
- The `fly launch` output samples in the Next.js, Python, and Rust guides still show a `Sentry: false (not requested)` line. Accurate to what flyctl prints today, so left alone.