### PR TITLE
Remove stray backslash in Hermes Agent blueprint fly.toml

### DIFF
--- a/blueprints/hermes-agent-on-fly-io.html.md
+++ b/blueprints/hermes-agent-on-fly-io.html.md
@@ -40,7 +40,7 @@ primary_region = "<region>"
 machine_config = "machine_config.json"
 
 [build]
-  image = "nousresearch/hermes-agent:latest"\
+  image = "nousresearch/hermes-agent:latest"
 
 [[mounts]]
   source = "data"


### PR DESCRIPTION
The fly.toml example in the Hermes Agent blueprint had a stray trailing backslash on the `image` line, which would break the TOML if copied as-is.

Closes #2445