### PR TITLE
Mention uv in Python dependency management options

### DIFF
--- a/python/the-basics/initial-setup.html.md
+++ b/python/the-basics/initial-setup.html.md
@@ -20,6 +20,7 @@ We recommend the latest [supported versions](https://devguide.python.org/version
 For project and dependency management we use [Poetry](https://python-poetry.org/). Like most package managers, Poetry combines multiple tools in one.
 
 You have other options:
+- [uv](https://docs.astral.sh/uv/)
 - [venv](https://docs.python.org/3/library/venv.html) and [pip](https://pip.pypa.io/)
 - [Pipenv](https://github.com/pypa/pipenv)
 - [pyenv](https://github.com/pyenv/pyenv)


### PR DESCRIPTION
The Python environment setup guide lists Poetry alternatives (venv/pip, Pipenv, pyenv, pip-tools) but omits uv, now a widely used Python packaging tool. This adds uv to that list.

Closes #1844